### PR TITLE
feat(lastfm): Redesign settings UI with bottom sheet dialogs and enhanced auth debugging

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Internet permission for Last.fm scrobbling and online features -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- USB Host (optional): for UAC 2.0 DAC/AMP detection on Android -->
     <uses-feature android:name="android.hardware.usb.host" android:required="false" />
     <!-- Storage permissions for music library access -->

--- a/lib/features/settings/widgets/lastfm_settings_tile.dart
+++ b/lib/features/settings/widgets/lastfm_settings_tile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -34,18 +35,25 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    debugPrint('[LastFm] App lifecycle changed: $state, _awaitingCallback=$_awaitingCallback');
     if (state == AppLifecycleState.resumed && _awaitingCallback) {
+      debugPrint('[LastFm] App resumed after auth, completing authentication');
       _awaitingCallback = false;
       _completeAuth();
     }
   }
 
   Future<void> _startAuth() async {
+    debugPrint('[LastFm] _startAuth: Starting authentication flow');
     final auth = ref.read(lastFmAuthServiceProvider);
 
     // Check if API credentials are configured
+    debugPrint('[LastFm] _startAuth: Checking API credentials');
     final hasCredentials = await auth.hasValidApiCredentials();
+    debugPrint('[LastFm] _startAuth: Has valid credentials: $hasCredentials');
+    
     if (!hasCredentials) {
+      debugPrint('[LastFm] _startAuth: Missing credentials, showing error');
       _showError(
         'Please configure your Last.fm API key and shared secret first.',
       );
@@ -53,24 +61,43 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
     }
 
     try {
+      debugPrint('[LastFm] _startAuth: Calling getTokenAndLaunchAuth');
       await auth.getTokenAndLaunchAuth();
+      debugPrint('[LastFm] _startAuth: Successfully launched auth, mounted=$mounted');
+      
       if (mounted) {
         setState(() => _awaitingCallback = true);
+        debugPrint('[LastFm] _startAuth: Set _awaitingCallback=true');
       }
-    } catch (e) {
-      _showError(
-        'Could not open Last.fm. Check your API credentials and internet connection.',
-      );
+    } catch (e, stackTrace) {
+      debugPrint('[LastFm] _startAuth: ERROR - $e');
+      debugPrint('[LastFm] _startAuth: Stack trace: $stackTrace');
+      
+      if (mounted) {
+        // Provide more specific error message for network issues
+        final errorMessage = e.toString().contains('SocketException') ||
+                e.toString().contains('Failed host lookup')
+            ? 'No internet connection. Please check your network and try again.'
+            : 'Could not connect to Last.fm. Check your API credentials and try again.';
+        
+        _showError(errorMessage);
+      } else {
+        debugPrint('[LastFm] _startAuth: Widget not mounted, skipping error display');
+      }
     }
   }
 
   Future<void> _completeAuth() async {
+    debugPrint('[LastFm] _completeAuth: Starting token exchange');
     final auth = ref.read(lastFmAuthServiceProvider);
     try {
       await auth.exchangeTokenForSession();
+      debugPrint('[LastFm] _completeAuth: Token exchange successful');
       ref.invalidate(lastFmSessionProvider);
       _showSuccess('Last.fm connected!');
-    } catch (_) {
+    } catch (e, stackTrace) {
+      debugPrint('[LastFm] _completeAuth: ERROR - $e');
+      debugPrint('[LastFm] _completeAuth: Stack trace: $stackTrace');
       _showError(
         'Authorization failed. Make sure you approved access on Last.fm.',
       );
@@ -567,24 +594,46 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
                             flex: 2,
                             child: ElevatedButton(
                               onPressed: () async {
+                                debugPrint('[LastFm] Save & Connect button pressed');
+                                
                                 if (apiKeyController.text.isEmpty ||
                                     sharedSecretController.text.isEmpty) {
+                                  debugPrint('[LastFm] Empty credentials provided');
                                   _showError(
                                     'Please enter both API key and shared secret',
                                   );
                                   return;
                                 }
+                                
+                                debugPrint('[LastFm] Saving credentials...');
                                 await auth.setApiCredentials(
                                   apiKeyController.text,
                                   sharedSecretController.text,
                                 );
+                                debugPrint('[LastFm] Credentials saved, mounted=$mounted');
+                                
                                 if (mounted) {
                                   Navigator.pop(ctx);
+                                  debugPrint('[LastFm] Dialog closed');
+                                  
                                   _showSuccess(
                                     'Credentials saved successfully!',
                                   );
+                                  
                                   if (autoConnectAfterSave && mounted) {
-                                    await _startAuth();
+                                    debugPrint('[LastFm] Auto-connect enabled, waiting 300ms...');
+                                    // Small delay to ensure dialog is fully closed
+                                    await Future.delayed(
+                                      const Duration(milliseconds: 300),
+                                    );
+                                    debugPrint('[LastFm] Delay complete, mounted=$mounted');
+                                    
+                                    if (mounted) {
+                                      debugPrint('[LastFm] Calling _startAuth()');
+                                      await _startAuth();
+                                    } else {
+                                      debugPrint('[LastFm] Widget unmounted, skipping auth');
+                                    }
                                   }
                                 }
                               },

--- a/lib/services/lastfm/lastfm_auth_service.dart
+++ b/lib/services/lastfm/lastfm_auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:flick/services/lastfm/lastfm_api_client.dart';
@@ -16,48 +17,86 @@ class LastFmAuthService {
   /// Step 1: Request a token and open the Last.fm authorization page.
   /// Requires API key and shared secret to be set first.
   Future<void> getTokenAndLaunchAuth() async {
+    debugPrint('[LastFm] getTokenAndLaunchAuth: Starting');
+    
     final apiKey = await _credentials.getApiKey();
     final sharedSecret = await _credentials.getSharedSecret();
+    
+    debugPrint('[LastFm] getTokenAndLaunchAuth: API key length: ${apiKey?.length ?? 0}');
+    debugPrint('[LastFm] getTokenAndLaunchAuth: Shared secret length: ${sharedSecret?.length ?? 0}');
 
     if (apiKey == null || apiKey.isEmpty) {
+      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - API key not configured');
       throw Exception(
         'Last.fm API key not configured. Please set your API key in settings.',
       );
     }
     if (sharedSecret == null || sharedSecret.isEmpty) {
+      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - Shared secret not configured');
       throw Exception(
         'Last.fm shared secret not configured. Please set your shared secret in settings.',
       );
     }
 
-    final data = await _client.post({'method': 'auth.getToken'});
-    final token = data['token'] as String;
+    debugPrint('[LastFm] getTokenAndLaunchAuth: Requesting token from Last.fm API');
+    try {
+      final data = await _client.post({'method': 'auth.getToken'});
+      final token = data['token'] as String;
+      debugPrint('[LastFm] getTokenAndLaunchAuth: Token received: ${token.substring(0, 8)}...');
 
-    await _credentials.setPendingToken(token);
+      await _credentials.setPendingToken(token);
+      debugPrint('[LastFm] getTokenAndLaunchAuth: Pending token saved');
 
-    final authUri = Uri.parse(
-      'https://www.last.fm/api/auth/'
-      '?api_key=$apiKey&token=$token',
-    );
+      final authUri = Uri.parse(
+        'https://www.last.fm/api/auth/'
+        '?api_key=$apiKey&token=$token',
+      );
+      debugPrint('[LastFm] getTokenAndLaunchAuth: Auth URL: ${authUri.toString()}');
 
-    final launched = await launchUrl(
-      authUri,
-      mode: LaunchMode.externalApplication,
-    );
+      try {
+        debugPrint('[LastFm] getTokenAndLaunchAuth: Attempting to launch URL');
+        final launched = await launchUrl(
+          authUri,
+          mode: LaunchMode.externalApplication,
+        );
+        debugPrint('[LastFm] getTokenAndLaunchAuth: Launch result: $launched');
 
-    if (!launched) {
-      throw Exception('Could not launch Last.fm authorization page.');
+        if (!launched) {
+          debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - launchUrl returned false');
+          // Clean up pending token if launch failed
+          await _credentials.deletePendingToken();
+          throw Exception('Could not launch Last.fm authorization page.');
+        }
+        
+        debugPrint('[LastFm] getTokenAndLaunchAuth: Successfully launched browser');
+      } catch (e, stackTrace) {
+        debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR during launch - $e');
+        debugPrint('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
+        // Clean up pending token on any launch error
+        await _credentials.deletePendingToken();
+        rethrow;
+      }
+    } catch (e, stackTrace) {
+      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR during token request - $e');
+      debugPrint('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
+      rethrow;
     }
   }
 
   /// Step 2: Exchange pending token for a permanent session key.
   Future<LastFmSession> exchangeTokenForSession() async {
+    debugPrint('[LastFm] exchangeTokenForSession: Starting');
+    
     final token = await _credentials.getPendingToken();
+    debugPrint('[LastFm] exchangeTokenForSession: Pending token exists: ${token != null}');
+    
     if (token == null) {
+      debugPrint('[LastFm] exchangeTokenForSession: ERROR - No pending token');
       throw Exception('No pending Last.fm token found. Start auth again.');
     }
 
     try {
+      debugPrint('[LastFm] exchangeTokenForSession: Requesting session from Last.fm API');
       final data = await _client.post({
         'method': 'auth.getSession',
         'token': token,
@@ -68,13 +107,19 @@ class LastFmAuthService {
         sessionKey: raw['key'] as String,
         username: raw['name'] as String,
       );
+      
+      debugPrint('[LastFm] exchangeTokenForSession: Session received for user: ${session.username}');
 
       await _credentials.setSessionKey(session.sessionKey);
       await _credentials.setUsername(session.username);
       await _credentials.deletePendingToken();
+      
+      debugPrint('[LastFm] exchangeTokenForSession: Session saved successfully');
 
       return session;
-    } catch (_) {
+    } catch (e, stackTrace) {
+      debugPrint('[LastFm] exchangeTokenForSession: ERROR - $e');
+      debugPrint('[LastFm] exchangeTokenForSession: Stack trace: $stackTrace');
       // Clean up stale pending token on failure so it doesn't linger
       await _credentials.deletePendingToken();
       rethrow;
@@ -103,8 +148,10 @@ class LastFmAuthService {
 
   /// Sets the API key and shared secret for the current user.
   Future<void> setApiCredentials(String apiKey, String sharedSecret) async {
+    debugPrint('[LastFm] setApiCredentials: Saving credentials (key length: ${apiKey.length}, secret length: ${sharedSecret.length})');
     await _credentials.setApiKey(apiKey);
     await _credentials.setSharedSecret(sharedSecret);
+    debugPrint('[LastFm] setApiCredentials: Credentials saved successfully');
   }
 
   /// Gets both API key and shared secret.


### PR DESCRIPTION
```markdown
# Summary

- Redesign Last.fm disconnect and credential dialogs with modern bottom sheet UI
- Add show/hide toggle for secret API key field
- Enhance authentication flow with comprehensive debug logging
- Add INTERNET permission for Android Last.fm connectivity

# Changes

- Replace `AlertDialog` with `showModalBottomSheet` for disconnect confirmation
- Add visual warning icon and improved header layout to disconnect dialog
- Implement show/hide toggle button for secret code field
- Add comprehensive debug logging throughout authentication lifecycle
- Enhance error handling with network-specific error messages
- Add mounted state checks before UI operations
- Implement 300ms delay after credential save before auto-connect
- Update button styling to match new bottom sheet design patterns

# Files Changed

- `lib/features/settings/widgets/lastfm_settings_tile.dart` — Bottom sheet UI redesign
- `lib/services/lastfm/lastfm_auth_service.dart` — Debug logging and error handling
- `android/app/src/main/AndroidManifest.xml` — INTERNET permission added
```

<img width="1080" height="2400" alt="Screenshot_20260323-165451" src="https://github.com/user-attachments/assets/55848b9c-0dc3-403d-a60a-e3a405e72dd2" />
<img width="1080" height="2400" alt="Screenshot_20260323-165448~2" src="https://github.com/user-attachments/assets/ec62004e-3b9c-43b4-a5f0-ae3d5a0253ec" />
