### PR TITLE
chore(release): bump version to 0.10.0-beta.1

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -393,7 +393,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.9.1-beta.3',
+            'Version 0.10.0-beta.1',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -686,7 +686,7 @@ SOFTWARE.
                             context,
                             icon: LucideIcons.info,
                             title: 'About Flick Player',
-                            subtitle: 'Version 0.9.1-beta.3',
+                            subtitle: 'Version 0.10.0-beta.1',
                             onTap: _showAboutBottomSheet,
                           ),
                           _buildDivider(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.9.1-beta.3+3
+version: 0.10.0-beta.1+4
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
- Update app version from 0.9.1-beta.3 to 0.10.0-beta.1 in pubspec.yaml
- Update version display in settings screen UI
- Increment build number from 3 to 4
- Prepare for next beta release cycle