### PR TITLE
Add fast-start logic for single tracks and playlist sync improvements

### DIFF
--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -357,7 +357,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
 
   /// Toggle loop mode.
   void toggleLoopMode() {
-    _service.toggleLoopMode();
+    unawaited(_service.toggleLoopMode());
   }
 
   /// Set playback speed.

--- a/lib/services/android_audio_engine.dart
+++ b/lib/services/android_audio_engine.dart
@@ -32,6 +32,14 @@ bool shouldUseFastStartCurrentTrackOnly({
       playlistLength > AndroidAudioEngine.fastStartPlaylistThreshold;
 }
 
+@visibleForTesting
+bool shouldExitSingleTrackMode({
+  required bool loadedSingleTrackOnly,
+  required int playerSequenceLength,
+}) {
+  return loadedSingleTrackOnly && playerSequenceLength > 1;
+}
+
 class AndroidAudioEngine implements AudioEngine {
   AndroidAudioEngine({
     required AndroidPlayerProvider playerProvider,
@@ -143,6 +151,7 @@ class AndroidAudioEngine implements AudioEngine {
   }
 
   void _syncTrackFromIndex(int? index) {
+    _syncPlaylistStateFromPlayer();
     if (_shouldSuppressTrackSync()) return;
     if (_awaitingInitialSeek) return;
     final nextTrack = _resolveTrack(index);
@@ -159,6 +168,23 @@ class AndroidAudioEngine implements AudioEngine {
         duration: nextTrack?.duration ?? Duration.zero,
       ),
     );
+  }
+
+  void _syncPlaylistStateFromPlayer() {
+    final player = _player;
+    if (player == null) return;
+
+    if (shouldExitSingleTrackMode(
+      loadedSingleTrackOnly: _loadedSingleTrackOnly,
+      playerSequenceLength: player.sequence.length,
+    )) {
+      _loadedSingleTrackOnly = false;
+      _playlistSignature = _playlistProvider()
+          .map((song) => song.id)
+          .toList(growable: false);
+    } else if (player.sequence.isEmpty) {
+      _playlistSignature = const <String>[];
+    }
   }
 
   Song? _resolveTrack(int? index) {

--- a/lib/services/android_audio_engine.dart
+++ b/lib/services/android_audio_engine.dart
@@ -18,6 +18,19 @@ typedef AndroidPlayerConfigurator =
 typedef AndroidEngineDisposer = Future<void> Function();
 typedef AndroidTrackSyncBlocker = bool Function();
 typedef AndroidTrackIgnorePredicate = bool Function(Song track);
+typedef AndroidFastStartPredicate = bool Function();
+
+@visibleForTesting
+bool shouldUseFastStartCurrentTrackOnly({
+  required bool allowFastStart,
+  required bool loadedSingleTrackOnly,
+  required bool sequenceIsEmpty,
+  required int playlistLength,
+}) {
+  return allowFastStart &&
+      (loadedSingleTrackOnly || sequenceIsEmpty) &&
+      playlistLength > AndroidAudioEngine.fastStartPlaylistThreshold;
+}
 
 class AndroidAudioEngine implements AudioEngine {
   AndroidAudioEngine({
@@ -29,6 +42,7 @@ class AndroidAudioEngine implements AudioEngine {
     required AndroidEngineDisposer disposeEngine,
     required AndroidTrackSyncBlocker shouldSuppressTrackSync,
     required AndroidTrackIgnorePredicate shouldIgnoreTrack,
+    required AndroidFastStartPredicate shouldFastStartCurrentTrackOnly,
   }) : _playerProvider = playerProvider,
        _sourcesBuilder = sourcesBuilder,
        _sourceBuilder = sourceBuilder,
@@ -36,7 +50,8 @@ class AndroidAudioEngine implements AudioEngine {
        _configurePlayer = configurePlayer,
        _disposeEngine = disposeEngine,
        _shouldSuppressTrackSync = shouldSuppressTrackSync,
-       _shouldIgnoreTrack = shouldIgnoreTrack;
+       _shouldIgnoreTrack = shouldIgnoreTrack,
+       _shouldFastStartCurrentTrackOnly = shouldFastStartCurrentTrackOnly;
 
   final AndroidPlayerProvider _playerProvider;
   final AndroidAudioSourcesBuilder _sourcesBuilder;
@@ -46,6 +61,7 @@ class AndroidAudioEngine implements AudioEngine {
   final AndroidEngineDisposer _disposeEngine;
   final AndroidTrackSyncBlocker _shouldSuppressTrackSync;
   final AndroidTrackIgnorePredicate _shouldIgnoreTrack;
+  final AndroidFastStartPredicate _shouldFastStartCurrentTrackOnly;
 
   final StreamController<PlaybackState> _controller =
       StreamController<PlaybackState>.broadcast();
@@ -57,7 +73,7 @@ class AndroidAudioEngine implements AudioEngine {
   bool _awaitingInitialSeek = false;
   bool _loadedSingleTrackOnly = false;
 
-  static const int _fastStartPlaylistThreshold = 24;
+  static const int fastStartPlaylistThreshold = 24;
 
   @override
   Stream<PlaybackState> get playbackStateStream => _controller.stream;
@@ -75,6 +91,20 @@ class AndroidAudioEngine implements AudioEngine {
     _subscriptions.add(
       player.playerStateStream.listen((state) {
         _emit(_state.copyWith(isPlaying: state.playing));
+      }),
+    );
+
+    _subscriptions.add(
+      player.playbackEventStream.listen((event) {
+        final nextDuration = event.duration ?? _state.duration;
+        _emit(
+          _state.copyWith(
+            position: event.updatePosition,
+            bufferedPosition: event.bufferedPosition,
+            duration: nextDuration,
+          ),
+        );
+        _syncTrackFromIndex(player.currentIndex);
       }),
     );
 
@@ -168,9 +198,12 @@ class AndroidAudioEngine implements AudioEngine {
     _loadedTrack = track;
     await _configurePlayer(player);
 
-    final shouldFastStartCurrentTrackOnly =
-        (_loadedSingleTrackOnly || player.sequence.isEmpty) &&
-        playlist.length > _fastStartPlaylistThreshold;
+    final shouldFastStartCurrentTrackOnly = shouldUseFastStartCurrentTrackOnly(
+      allowFastStart: _shouldFastStartCurrentTrackOnly(),
+      loadedSingleTrackOnly: _loadedSingleTrackOnly,
+      sequenceIsEmpty: player.sequence.isEmpty,
+      playlistLength: playlist.length,
+    );
 
     if (canReusePlaylist &&
         player.sequence.isNotEmpty &&

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -614,6 +614,8 @@ class PlayerService {
       shouldSuppressTrackSync: () =>
           _suppressSequenceStateUpdates || _isRebuildingPlaylist,
       shouldIgnoreTrack: (track) => track.filePath == null,
+      shouldFastStartCurrentTrackOnly: () =>
+          loopModeNotifier.value != LoopMode.all,
     );
   }
 
@@ -2806,12 +2808,19 @@ class PlayerService {
     await _updateNotificationState();
   }
 
-  void toggleLoopMode() {
+  Future<void> toggleLoopMode() async {
     final modes = LoopMode.values;
     final nextIndex = (loopModeNotifier.value.index + 1) % modes.length;
     loopModeNotifier.value = modes[nextIndex];
 
-    _updateLoopMode();
+    await _updateLoopMode();
+
+    // Repeat-all needs a real playlist loaded into just_audio. If the Android
+    // engine fast-started a single track, rebuild now so ExoPlayer can advance
+    // to the next item instead of looping the current source forever.
+    if (!_usingRustBackend && loopModeNotifier.value == LoopMode.all) {
+      await _rebuildPlaylist();
+    }
   }
 
   // ==================== Volume ====================

--- a/test/services/player_service_format_test.dart
+++ b/test/services/player_service_format_test.dart
@@ -127,4 +127,40 @@ void main() {
       );
     });
   });
+
+  group('shouldExitSingleTrackMode', () {
+    test('exits single-track mode once a real playlist is loaded', () {
+      expect(
+        shouldExitSingleTrackMode(
+          loadedSingleTrackOnly: true,
+          playerSequenceLength: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('stays in single-track mode for empty or single-item sequences', () {
+      expect(
+        shouldExitSingleTrackMode(
+          loadedSingleTrackOnly: true,
+          playerSequenceLength: 0,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldExitSingleTrackMode(
+          loadedSingleTrackOnly: true,
+          playerSequenceLength: 1,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldExitSingleTrackMode(
+          loadedSingleTrackOnly: false,
+          playerSequenceLength: 3,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/test/services/player_service_format_test.dart
+++ b/test/services/player_service_format_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/android_audio_engine.dart';
 
 void main() {
   group('canonicalPlaybackFileType', () {
@@ -85,6 +86,42 @@ void main() {
         shouldHandleManualCompletion(
           usingRustBackend: false,
           loopMode: LoopMode.all,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldUseFastStartCurrentTrackOnly', () {
+    test('disables fast-start when repeat-all is active', () {
+      expect(
+        shouldUseFastStartCurrentTrackOnly(
+          allowFastStart: false,
+          loadedSingleTrackOnly: false,
+          sequenceIsEmpty: true,
+          playlistLength: 100,
+        ),
+        isFalse,
+      );
+    });
+
+    test('allows fast-start only for large eligible playlists', () {
+      expect(
+        shouldUseFastStartCurrentTrackOnly(
+          allowFastStart: true,
+          loadedSingleTrackOnly: false,
+          sequenceIsEmpty: true,
+          playlistLength: 25,
+        ),
+        isTrue,
+      );
+
+      expect(
+        shouldUseFastStartCurrentTrackOnly(
+          allowFastStart: true,
+          loadedSingleTrackOnly: false,
+          sequenceIsEmpty: true,
+          playlistLength: 24,
         ),
         isFalse,
       );


### PR DESCRIPTION
# Summary

- Implement fast-start logic for track playback based on playlist conditions
- Add single track mode exit logic and playlist synchronization
- Enhance loop mode handling with playlist rebuilds

# Changes

## Fast-Start Logic

- Add `shouldUseFastStartCurrentTrackOnly` function to determine eligibility for fast-start
- Update `AndroidAudioEngine` to utilize new fast-start logic
- Improves playback efficiency for single track playback

## Single Track Mode

- Add `shouldExitSingleTrackMode` function to determine when to exit single-track mode
- Implement `_syncPlaylistStateFromPlayer` method for playlist state management
- Handle transition out of single-track mode when player sequence length changes

## Loop Mode Handling

- Ensure loop mode changes trigger playlist rebuilds when necessary
- Enhance playback continuity

# Files Changed

- `lib/services/android_audio_engine.dart` — Fast-start and single track mode logic
- `lib/services/player_service.dart` — Loop mode handling
- `lib/providers/player_provider.dart` — Provider update
- `test/services/player_service_format_test.dart` — New tests