### PR TITLE
Update settings screen with SVG logo and version bump to 0.12.0-beta.1

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -394,7 +394,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.11.0-beta.1',
+            'Version 0.12.0-beta.1',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -688,7 +688,7 @@ SOFTWARE.
                             context,
                             icon: LucideIcons.info,
                             title: 'About Flick Player',
-                            subtitle: 'Version 0.11.0-beta.1',
+                            subtitle: 'Version 0.12.0-beta.1',
                             onTap: _showAboutBottomSheet,
                           ),
                           _buildDivider(),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flick/core/theme/app_colors.dart';
@@ -367,7 +368,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         mainAxisSize: MainAxisSize.min,
         children: [
           const SizedBox(height: AppConstants.spacingMd),
-          // App icon
+          // App logo
           Container(
             width: 80,
             height: 80,
@@ -376,10 +377,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               borderRadius: BorderRadius.circular(AppConstants.radiusLg),
               border: Border.all(color: AppColors.glassBorder),
             ),
-            child: const Icon(
-              LucideIcons.music2,
-              color: AppColors.textPrimary,
-              size: 40,
+            child: SvgPicture.asset(
+              'assets/icons/flicklogo_svg.svg',
+              fit: BoxFit.contain,
             ),
           ),
           const SizedBox(height: AppConstants.spacingMd),


### PR DESCRIPTION
# Summary

- Replace app icon with SVG logo in settings screen
- Update version number to 0.12.0-beta.1

# Changes

## Settings Screen

- Update settings screen to use SVG logo instead of previous icon representation
- Adjust comments for clarity regarding logo's purpose

## Version Bump

- Change displayed version number from 0.11.0-beta.1 to 0.12.0-beta.1

# Files Changed

- `lib/features/settings/screens/settings_screen.dart` — Logo update and version bump