### PR TITLE
Implement notification sync for repeat-one loop and clean up UI

### DIFF
--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1799,26 +1799,6 @@ class _AnimatedSongScene extends StatelessWidget {
                               lyricsService: lyricsService,
                             ),
                           ),
-                          Align(
-                            alignment: Alignment.bottomCenter,
-                            child: IgnorePointer(
-                              child: Container(
-                                height: context.responsive(72.0, 84.0, 96.0),
-                                decoration: BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.topCenter,
-                                    end: Alignment.bottomCenter,
-                                    colors: [
-                                      Colors.transparent,
-                                      Colors.black.withValues(alpha: 0.04),
-                                      Colors.black.withValues(alpha: 0.14),
-                                      Colors.black.withValues(alpha: 0.26),
-                                    ],
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
                         ],
                       ),
                     ),

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -159,6 +159,25 @@ bool shouldHandleManualCompletion({
   return loopMode == LoopMode.off;
 }
 
+@visibleForTesting
+bool shouldSyncNotificationForRepeatOneLoop({
+  required LoopMode loopMode,
+  required bool sameTrack,
+  required Duration previousPosition,
+  required Duration currentPosition,
+  required Duration trackDuration,
+}) {
+  if (loopMode != LoopMode.one ||
+      !sameTrack ||
+      trackDuration <= Duration.zero) {
+    return false;
+  }
+
+  return currentPosition < previousPosition &&
+      previousPosition >= trackDuration - const Duration(seconds: 3) &&
+      currentPosition <= const Duration(milliseconds: 1500);
+}
+
 /// Singleton service to manage global audio playback state.
 ///
 /// Uses just_audio for playback with gapless playback support.
@@ -1279,6 +1298,15 @@ class PlayerService {
 
       final previousTrackId = previous?.currentTrack?.id;
       final currentTrackId = state.currentTrack?.id;
+      final shouldSyncLoopedNotification =
+          shouldSyncNotificationForRepeatOneLoop(
+            loopMode: loopModeNotifier.value,
+            sameTrack:
+                previousTrackId != null && previousTrackId == currentTrackId,
+            previousPosition: _lastPosition,
+            currentPosition: state.position,
+            trackDuration: state.duration,
+          );
       if (previousTrackId != currentTrackId) {
         if (currentTrackId != null && currentTrackId == _restoredSongId) {
           _clearRestoredPlaybackContext(songId: currentTrackId);
@@ -1315,6 +1343,13 @@ class PlayerService {
           state.currentTrack != null) {
         unawaited(_updateNotificationState());
       }
+
+      if (shouldSyncLoopedNotification && state.currentTrack != null) {
+        _lastNotificationUpdate = DateTime.now();
+        unawaited(_updateNotificationState());
+      }
+
+      _lastPosition = state.position;
 
       unawaited(
         _refreshAudioOutputDiagnostics(

--- a/test/services/player_service_notification_test.dart
+++ b/test/services/player_service_notification_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/services/player_service.dart';
+
+void main() {
+  group('shouldSyncNotificationForRepeatOneLoop', () {
+    test('returns true when repeat-one wraps from the end to the start', () {
+      expect(
+        shouldSyncNotificationForRepeatOneLoop(
+          loopMode: LoopMode.one,
+          sameTrack: true,
+          previousPosition: const Duration(minutes: 2, seconds: 58),
+          currentPosition: const Duration(milliseconds: 120),
+          trackDuration: const Duration(minutes: 3),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for normal progress updates on the same track', () {
+      expect(
+        shouldSyncNotificationForRepeatOneLoop(
+          loopMode: LoopMode.one,
+          sameTrack: true,
+          previousPosition: const Duration(minutes: 1),
+          currentPosition: const Duration(minutes: 1, seconds: 2),
+          trackDuration: const Duration(minutes: 3),
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when repeat-one is not active', () {
+      expect(
+        shouldSyncNotificationForRepeatOneLoop(
+          loopMode: LoopMode.all,
+          sameTrack: true,
+          previousPosition: const Duration(minutes: 2, seconds: 58),
+          currentPosition: const Duration(milliseconds: 120),
+          trackDuration: const Duration(minutes: 3),
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary
- Added `shouldSyncNotificationForRepeatOneLoop` function to determine when to sync notifications for tracks in repeat-one mode, enhancing user experience during playback.
- Updated `PlayerService` to utilize the new sync logic, ensuring notifications are updated correctly when looping the same track.
- Removed unused UI elements from the full player screen to streamline the layout and improve visual clarity.
- Introduced unit tests for the new notification sync functionality, validating its behavior under various playback scenarios.