### PR TITLE
Add battery optimization notice, fixed the rescanning library function for Xiaomi devices, and version bump to 0.12.0-beta.2

### DIFF
--- a/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
@@ -27,7 +27,9 @@ import android.os.Bundle
 import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
+import android.provider.Settings
 import android.util.Log
+import android.os.PowerManager
 import androidx.documentfile.provider.DocumentFile
 import com.ultraelectronica.flick.audiofx.JustAudioProcessingController
 import io.flutter.embedding.android.FlutterActivity
@@ -359,6 +361,12 @@ class MainActivity: FlutterActivity() {
                     } else {
                         result.error("INVALID_ARGUMENT", "URI is required", null)
                     }
+                }
+                "isIgnoringBatteryOptimizations" -> {
+                    result.success(isIgnoringBatteryOptimizations())
+                }
+                "openBatteryOptimizationSettings" -> {
+                    result.success(openBatteryOptimizationSettings())
                 }
                 "readTextDocument" -> {
                     val uri = call.argument<String>("uri")
@@ -925,6 +933,34 @@ class MainActivity: FlutterActivity() {
         } catch (e: Exception) {
             Log.w("MainActivity", "Failed to resolve tree URI to path: $uriString", e)
             null
+        }
+    }
+
+    private fun isIgnoringBatteryOptimizations(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true
+        }
+
+        val powerManager = getSystemService(Context.POWER_SERVICE) as? PowerManager
+        return powerManager?.isIgnoringBatteryOptimizations(packageName) ?: false
+    }
+
+    private fun openBatteryOptimizationSettings(): Boolean {
+        return try {
+            val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+            } else {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:$packageName")
+                }
+            }.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
+            true
+        } catch (e: Exception) {
+            Log.w("MainActivity", "Failed to open battery optimization settings", e)
+            false
         }
     }
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -23,6 +23,7 @@ import 'package:flick/features/settings/screens/equalizer_screen.dart';
 import 'package:flick/features/settings/screens/uac2_settings_screen.dart';
 import 'package:flick/features/settings/screens/duplicate_cleaner_screen.dart';
 import 'package:flick/features/settings/widgets/lastfm_settings_tile.dart';
+import 'package:flick/services/android_audio_device_service.dart';
 
 /// Settings screen matching the design language.
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -44,6 +45,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   int _songCount = 0;
   bool _isScanning = false;
   ScanProgress? _scanProgress;
+  bool _showBatteryOptimizationNotice = false;
+  bool _isXiaomiDevice = false;
 
   // ValueNotifier for bottom sheet progress updates
   final ValueNotifier<ScanProgress?> _scanProgressNotifier = ValueNotifier(
@@ -55,6 +58,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     super.initState();
     _loadLibraryData();
     _syncFoldersToDatabase();
+    _loadAndroidDeviceNotices();
   }
 
   @override
@@ -86,6 +90,70 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         _folders = folders;
         _songCount = count;
       });
+    }
+  }
+
+  Future<void> _loadAndroidDeviceNotices() async {
+    final permissionService = PermissionService();
+
+    try {
+      final isAndroid = Theme.of(context).platform == TargetPlatform.android;
+      if (!isAndroid) {
+        return;
+      }
+
+      final results = await Future.wait<dynamic>([
+        AndroidAudioDeviceService.instance.refresh(),
+        permissionService.isIgnoringBatteryOptimizations(),
+      ]);
+      final deviceInfo = results[0] as AndroidPlaybackDeviceInfo;
+      final isIgnoringBatteryOptimizations = results[1] as bool;
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isXiaomiDevice = deviceInfo.isXiaomiDevice;
+        _showBatteryOptimizationNotice = !isIgnoringBatteryOptimizations;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _showBatteryOptimizationNotice = false;
+      });
+    }
+  }
+
+  Future<void> _openBatteryOptimizationSettings() async {
+    final permissionService = PermissionService();
+
+    try {
+      final opened = await permissionService.openBatteryOptimizationSettings();
+      if (!mounted) {
+        return;
+      }
+
+      if (!opened) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Unable to open battery optimization settings'),
+          ),
+        );
+      }
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Failed to open battery optimization settings: $e'),
+        ),
+      );
     }
   }
 
@@ -762,6 +830,20 @@ SOFTWARE.
         children: [
           // Song count info
           _buildLibraryInfo(context),
+          if (_showBatteryOptimizationNotice) ...[
+            _buildDivider(),
+            _buildActionButton(
+              context,
+              icon: LucideIcons.batteryWarning,
+              title: _isXiaomiDevice
+                  ? 'Disable Battery Optimization (Recommended)'
+                  : 'Disable Battery Optimization',
+              subtitle: _isXiaomiDevice
+                  ? 'Required on many Xiaomi, Redmi, and POCO devices so rescans and background features keep working'
+                  : 'Allow Flick to run without aggressive background limits so rescans and background features keep working',
+              onTap: _openBatteryOptimizationSettings,
+            ),
+          ],
           _buildDivider(),
 
           // Scanning indicator (progress shown in bottom sheet)

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -462,7 +462,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.12.0-beta.1',
+            'Version 0.12.0-beta.2',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -756,7 +756,7 @@ SOFTWARE.
                             context,
                             icon: LucideIcons.info,
                             title: 'About Flick Player',
-                            subtitle: 'Version 0.12.0-beta.1',
+                            subtitle: 'Version 0.12.0-beta.2',
                             onTap: _showAboutBottomSheet,
                           ),
                           _buildDivider(),

--- a/lib/services/android_audio_device_service.dart
+++ b/lib/services/android_audio_device_service.dart
@@ -49,6 +49,14 @@ class AndroidPlaybackDeviceInfo {
     return dapKeywords.any(haystack.contains);
   }
 
+  bool get isXiaomiDevice {
+    final haystack = '${manufacturer.toLowerCase()} ${model.toLowerCase()}';
+    return haystack.contains('xiaomi') ||
+        haystack.contains('redmi') ||
+        haystack.contains('poco') ||
+        haystack.contains('miui');
+  }
+
   String get routeSummary => routeLabel ?? routeType ?? 'unknown';
 
   factory AndroidPlaybackDeviceInfo.fromMap(Map<Object?, Object?> raw) {

--- a/lib/services/library_scanner_service.dart
+++ b/lib/services/library_scanner_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:flick/services/android_audio_device_service.dart';
 import '../core/utils/audio_metadata_utils.dart';
 import '../data/database.dart';
 import '../data/repositories/song_repository.dart';
@@ -69,10 +70,14 @@ class LibraryScannerService {
     _currentlyScanning.add(scanKey);
     try {
       if (Platform.isAndroid) {
+        final deviceInfo = await AndroidAudioDeviceService.instance.refresh();
+        final shouldPreferSafScan = deviceInfo.isXiaomiDevice;
         final resolvedScanRoot = await _musicFolderService
             .resolveFilesystemPath(folderUri);
 
-        if (resolvedScanRoot != null && resolvedScanRoot.isNotEmpty) {
+        if (!shouldPreferSafScan &&
+            resolvedScanRoot != null &&
+            resolvedScanRoot.isNotEmpty) {
           try {
             yield* _scanFolderRust(
               resolvedScanRoot,
@@ -86,6 +91,12 @@ class LibraryScannerService {
               'Rust Android scan fallback for $displayName failed at $resolvedScanRoot: $e',
             );
           }
+        }
+
+        if (shouldPreferSafScan) {
+          debugPrint(
+            'Using SAF scan path for $displayName on Xiaomi-family device',
+          );
         }
 
         yield* _scanFolderAndroid(folderUri, displayName, scanPreferences);
@@ -518,11 +529,31 @@ class LibraryScannerService {
     _isCancelled = false;
     final folders = await _folderRepository.getAllFolders();
     final scanPlan = _deduplicateFoldersForScan(folders);
+    var runningLibrarySongCount = await _songRepository.getSongCount();
 
     for (final folder in scanPlan) {
       if (_isCancelled) break;
+      final existingFolderSongCount = await _songRepository.countSongsInFolder(
+        folder.uri,
+      );
+
       await for (final progress in scanFolder(folder.uri, folder.displayName)) {
-        yield progress;
+        final adjustedSongsFound =
+            (runningLibrarySongCount - existingFolderSongCount) +
+            progress.songsFound;
+        final aggregatedProgress = ScanProgress(
+          songsFound: adjustedSongsFound < 0 ? 0 : adjustedSongsFound,
+          totalFiles: progress.totalFiles,
+          currentFile: progress.currentFile,
+          currentFolder: progress.currentFolder,
+          isComplete: progress.isComplete,
+        );
+
+        if (progress.isComplete) {
+          runningLibrarySongCount = aggregatedProgress.songsFound;
+        }
+
+        yield aggregatedProgress;
       }
     }
   }

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -106,6 +106,40 @@ class PermissionService {
       throw StorageException('Failed to get persisted URIs: ${e.message}');
     }
   }
+
+  Future<bool> isIgnoringBatteryOptimizations() async {
+    if (!Platform.isAndroid) {
+      return true;
+    }
+
+    try {
+      return await _channel.invokeMethod<bool>(
+            'isIgnoringBatteryOptimizations',
+          ) ??
+          false;
+    } on PlatformException catch (e) {
+      throw StorageException(
+        'Failed to read battery optimization status: ${e.message}',
+      );
+    }
+  }
+
+  Future<bool> openBatteryOptimizationSettings() async {
+    if (!Platform.isAndroid) {
+      return false;
+    }
+
+    try {
+      return await _channel.invokeMethod<bool>(
+            'openBatteryOptimizationSettings',
+          ) ??
+          false;
+    } on PlatformException catch (e) {
+      throw StorageException(
+        'Failed to open battery optimization settings: ${e.message}',
+      );
+    }
+  }
 }
 
 /// Exception for storage-related errors.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.11.0-beta.1+5
+version: 0.12.0-beta.2+6
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
# Summary

- Add battery optimization notice for Xiaomi, Redmi, and POCO devices
- Add methods to check if app is ignoring battery optimizations
- Add ability to open battery optimization settings
- Update library scanner to prefer SAF scanning on Xiaomi devices
- Version bump to 0.12.0-beta.2

# Changes

## Battery Optimization

- Implement logic to detect Xiaomi devices and display battery optimization notice
- Add methods to check if app is ignoring battery optimizations
- Add method to open battery optimization settings
- Ensure background features work correctly on devices with aggressive battery management

## Library Scanning

- Update library scanner to prefer SAF scanning on Xiaomi devices for better compatibility

## Version

- Update version number from 0.12.0-beta.1 to 0.12.0-beta.2 in `pubspec.yaml` and settings screen

# Files Changed

- `lib/features/settings/screens/settings_screen.dart` — Battery notice UI
- `lib/services/android_audio_device_service.dart` — Xiaomi device detection
- `lib/services/permission_service.dart` — Battery optimization methods
- `android/app/src/main/kotlin/.../MainActivity.kt` — Native battery methods
- `lib/services/library_scanner_service.dart` — SAF scanning preference
- `pubspec.yaml` — Version bump
