### PR TITLE
Integrate Shorebird code push for in-app updates and version bump

### DIFF
--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -43,6 +43,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   );
   static const String _releaseNotesUrl =
       'https://github.com/ultraelectronica/flick_player/releases/latest';
+  static const bool _updatesComingSoon = true;
 
   // Sample settings state
   bool _gaplessPlayback = true;
@@ -1063,20 +1064,28 @@ SOFTWARE.
                           _buildActionButton(
                             context,
                             icon: LucideIcons.scanSearch,
-                            title: _isCheckingForUpdates
+                            title: _updatesComingSoon
+                                ? 'Scan for Updates'
+                                : _isCheckingForUpdates
                                 ? 'Scanning for Updates...'
                                 : 'Scan for Updates',
-                            subtitle: _isCheckingForUpdates
+                            subtitle: _updatesComingSoon
+                                ? 'Coming soon'
+                                : _isCheckingForUpdates
                                 ? 'Checking for the latest update now'
                                 : 'Check manually whenever you want',
-                            onTap: _isCheckingForUpdates || _isInstallingUpdate
+                            onTap:
+                                _updatesComingSoon ||
+                                    _isCheckingForUpdates ||
+                                    _isInstallingUpdate
                                 ? null
                                 : _scanForUpdates,
                           ),
                           _buildDivider(),
                           _buildUpdateStatusTile(context),
-                          if (_hasAvailableUpdate ||
-                              _restartRequiredForUpdate) ...[
+                          if (!_updatesComingSoon &&
+                              (_hasAvailableUpdate ||
+                                  _restartRequiredForUpdate)) ...[
                             _buildDivider(),
                             _buildNavigationSetting(
                               context,
@@ -1086,7 +1095,8 @@ SOFTWARE.
                               onTap: _showPatchNotesBottomSheet,
                             ),
                           ],
-                          if (_hasAvailableUpdate || _isInstallingUpdate) ...[
+                          if (!_updatesComingSoon &&
+                              (_hasAvailableUpdate || _isInstallingUpdate)) ...[
                             _buildDivider(),
                             _buildActionButton(
                               context,
@@ -1516,6 +1526,14 @@ SOFTWARE.
   }
 
   ({IconData icon, String title, String subtitle}) _getUpdateStatusDetails() {
+    if (_updatesComingSoon) {
+      return (
+        icon: LucideIcons.info,
+        title: 'Coming Soon',
+        subtitle: 'In-app updates will be available in a future release',
+      );
+    }
+
     if (_isCheckingForUpdates) {
       return (
         icon: LucideIcons.refreshCw,

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -1,7 +1,11 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:http/http.dart' as http;
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:shorebird_code_push/shorebird_code_push.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
@@ -34,6 +38,12 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  static final Uri _releaseNotesApiUri = Uri.parse(
+    'https://api.github.com/repos/ultraelectronica/flick_player/releases/latest',
+  );
+  static const String _releaseNotesUrl =
+      'https://github.com/ultraelectronica/flick_player/releases/latest';
+
   // Sample settings state
   bool _gaplessPlayback = true;
 
@@ -47,6 +57,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   ScanProgress? _scanProgress;
   bool _showBatteryOptimizationNotice = false;
   bool _isXiaomiDevice = false;
+  final ShorebirdUpdater _updater = ShorebirdUpdater();
+  bool _isCheckingForUpdates = false;
+  bool _isInstallingUpdate = false;
+  bool _hasScannedForUpdates = false;
+  UpdateStatus? _lastScannedUpdateStatus;
+  String? _updateCheckErrorMessage;
 
   // ValueNotifier for bottom sheet progress updates
   final ValueNotifier<ScanProgress?> _scanProgressNotifier = ValueNotifier(
@@ -155,6 +171,299 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         ),
       );
     }
+  }
+
+  bool get _restartRequiredForUpdate {
+    return _lastScannedUpdateStatus == UpdateStatus.restartRequired;
+  }
+
+  bool get _hasAvailableUpdate {
+    return _lastScannedUpdateStatus == UpdateStatus.outdated;
+  }
+
+  void _showToast(String message) {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.removeCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+    );
+  }
+
+  Future<void> _scanForUpdates() async {
+    if (_isCheckingForUpdates || _isInstallingUpdate) {
+      return;
+    }
+
+    if (!_updater.isAvailable) {
+      setState(() {
+        _hasScannedForUpdates = true;
+        _lastScannedUpdateStatus = UpdateStatus.unavailable;
+        _updateCheckErrorMessage = null;
+      });
+      _showToast('Updates are unavailable in this build.');
+      return;
+    }
+
+    setState(() {
+      _isCheckingForUpdates = true;
+      _updateCheckErrorMessage = null;
+    });
+
+    try {
+      final status = await _updater.checkForUpdate();
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _hasScannedForUpdates = true;
+        _lastScannedUpdateStatus = status;
+      });
+
+      if (status == UpdateStatus.outdated) {
+        _showToast('Update available.');
+        return;
+      }
+
+      if (status == UpdateStatus.restartRequired) {
+        _showToast('Update finished. Restart the app to use it.');
+        return;
+      }
+
+      if (status == UpdateStatus.unavailable) {
+        _showToast('Updates are unavailable in this build.');
+        return;
+      }
+
+      _showToast('No new update found.');
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _hasScannedForUpdates = true;
+        _lastScannedUpdateStatus = null;
+        _updateCheckErrorMessage = 'Unable to reach the update service.';
+      });
+      _showToast('Failed to check for updates: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isCheckingForUpdates = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _installUpdate() async {
+    if (_isInstallingUpdate) {
+      return;
+    }
+
+    if (!_updater.isAvailable) {
+      _showToast('Updates are unavailable in this build.');
+      return;
+    }
+
+    if (_restartRequiredForUpdate) {
+      _showToast('Update finished. Restart the app to use it.');
+      return;
+    }
+
+    if (!_hasAvailableUpdate) {
+      _showToast(
+        _hasScannedForUpdates
+            ? 'No available update to install.'
+            : 'Scan for updates first.',
+      );
+      return;
+    }
+
+    setState(() {
+      _isInstallingUpdate = true;
+    });
+
+    try {
+      _showToast('Installing update in the background. Keep using the app.');
+      await _updater.update();
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _hasScannedForUpdates = true;
+        _lastScannedUpdateStatus = UpdateStatus.restartRequired;
+        _updateCheckErrorMessage = null;
+      });
+      _showToast('Update finished. Restart the app to use it.');
+    } on UpdateException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showToast('Failed to install update: ${error.message}');
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showToast('Failed to install update: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isInstallingUpdate = false;
+        });
+      }
+    }
+  }
+
+  Future<_PatchNotes> _fetchPatchNotes() async {
+    final response = await http.get(
+      _releaseNotesApiUri,
+      headers: const {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'FlickPlayer',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('HTTP ${response.statusCode}');
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final title = (data['name'] as String?)?.trim();
+    final tag = (data['tag_name'] as String?)?.trim();
+    final body = (data['body'] as String?)?.trim();
+    final htmlUrl = (data['html_url'] as String?)?.trim();
+
+    return _PatchNotes(
+      title: title?.isNotEmpty == true
+          ? title!
+          : tag?.isNotEmpty == true
+          ? tag!
+          : 'Latest Update',
+      body: body?.isNotEmpty == true ? body! : 'No patch notes available yet.',
+      url: htmlUrl?.isNotEmpty == true ? htmlUrl! : _releaseNotesUrl,
+    );
+  }
+
+  void _showPatchNotesBottomSheet() {
+    GlassBottomSheet.show(
+      context: context,
+      title: 'Patch Notes',
+      maxHeightRatio: 0.7,
+      content: FutureBuilder<_PatchNotes>(
+        future: _fetchPatchNotes(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: AppConstants.spacingLg,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: AppConstants.spacingMd),
+                  const CircularProgressIndicator(color: AppColors.textPrimary),
+                  const SizedBox(height: AppConstants.spacingMd),
+                  Text(
+                    'Loading patch notes...',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (snapshot.hasError || !snapshot.hasData) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: AppConstants.spacingMd),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(AppConstants.spacingMd),
+                  decoration: BoxDecoration(
+                    color: AppColors.glassBackground,
+                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                    border: Border.all(color: AppColors.glassBorder),
+                  ),
+                  child: Text(
+                    'Unable to load patch notes right now.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingMd),
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton.icon(
+                    onPressed: () => _launchUrl(_releaseNotesUrl),
+                    icon: const Icon(LucideIcons.externalLink),
+                    label: const Text('Open Release Notes'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppColors.textSecondary,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingMd),
+              ],
+            );
+          }
+
+          final notes = snapshot.data!;
+          return SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: AppConstants.spacingMd),
+                Text(
+                  notes.title,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingMd),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(AppConstants.spacingMd),
+                  decoration: BoxDecoration(
+                    color: AppColors.glassBackground,
+                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                    border: Border.all(color: AppColors.glassBorder),
+                  ),
+                  child: SelectableText(
+                    notes.body,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                      height: 1.5,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingMd),
+                SizedBox(
+                  width: double.infinity,
+                  child: TextButton.icon(
+                    onPressed: () => _launchUrl(notes.url),
+                    icon: const Icon(LucideIcons.externalLink),
+                    label: const Text('Open Full Notes'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppColors.textSecondary,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingMd),
+              ],
+            ),
+          );
+        },
+      ),
+    );
   }
 
   Future<void> _addFolder() async {
@@ -747,6 +1056,57 @@ SOFTWARE.
 
                       const SizedBox(height: AppConstants.spacingLg),
 
+                      _buildSectionHeader(context, 'Updates'),
+                      _buildSettingsCard(
+                        context,
+                        children: [
+                          _buildActionButton(
+                            context,
+                            icon: LucideIcons.scanSearch,
+                            title: _isCheckingForUpdates
+                                ? 'Scanning for Updates...'
+                                : 'Scan for Updates',
+                            subtitle: _isCheckingForUpdates
+                                ? 'Checking for the latest update now'
+                                : 'Check manually whenever you want',
+                            onTap: _isCheckingForUpdates || _isInstallingUpdate
+                                ? null
+                                : _scanForUpdates,
+                          ),
+                          _buildDivider(),
+                          _buildUpdateStatusTile(context),
+                          if (_hasAvailableUpdate ||
+                              _restartRequiredForUpdate) ...[
+                            _buildDivider(),
+                            _buildNavigationSetting(
+                              context,
+                              icon: LucideIcons.fileText,
+                              title: 'Patch Notes',
+                              subtitle: 'See what is new in this update',
+                              onTap: _showPatchNotesBottomSheet,
+                            ),
+                          ],
+                          if (_hasAvailableUpdate || _isInstallingUpdate) ...[
+                            _buildDivider(),
+                            _buildActionButton(
+                              context,
+                              icon: LucideIcons.download,
+                              title: _isInstallingUpdate
+                                  ? 'Installing Update...'
+                                  : 'Install Update',
+                              subtitle: _isInstallingUpdate
+                                  ? 'Downloading in the background. Keep using the app'
+                                  : 'Download now and restart the app when it finishes',
+                              onTap: _isInstallingUpdate
+                                  ? null
+                                  : _installUpdate,
+                            ),
+                          ],
+                        ],
+                      ),
+
+                      const SizedBox(height: AppConstants.spacingLg),
+
                       // About section
                       _buildSectionHeader(context, 'About'),
                       _buildSettingsCard(
@@ -1155,6 +1515,116 @@ SOFTWARE.
     );
   }
 
+  ({IconData icon, String title, String subtitle}) _getUpdateStatusDetails() {
+    if (_isCheckingForUpdates) {
+      return (
+        icon: LucideIcons.refreshCw,
+        title: 'Checking for Updates',
+        subtitle: 'Looking for a new update right now',
+      );
+    }
+
+    if (_isInstallingUpdate) {
+      return (
+        icon: LucideIcons.download,
+        title: 'Installing Update',
+        subtitle: 'The download is running in the background',
+      );
+    }
+
+    if (_restartRequiredForUpdate) {
+      return (
+        icon: LucideIcons.badgeCheck,
+        title: 'Update Ready',
+        subtitle: 'Restart the app to finish updating',
+      );
+    }
+
+    if (_hasAvailableUpdate) {
+      return (
+        icon: LucideIcons.download,
+        title: 'Update Available',
+        subtitle: 'A new update is ready to download',
+      );
+    }
+
+    if (_updateCheckErrorMessage != null) {
+      return (
+        icon: LucideIcons.info,
+        title: 'Could Not Check for Updates',
+        subtitle: _updateCheckErrorMessage!,
+      );
+    }
+
+    if (_lastScannedUpdateStatus == UpdateStatus.unavailable) {
+      return (
+        icon: LucideIcons.info,
+        title: 'Updates Unavailable',
+        subtitle: 'This build does not support in-app updates',
+      );
+    }
+
+    if (_lastScannedUpdateStatus == UpdateStatus.upToDate) {
+      return (
+        icon: LucideIcons.badgeCheck,
+        title: 'No Update Available',
+        subtitle: 'You already have the latest update',
+      );
+    }
+
+    return (
+      icon: LucideIcons.info,
+      title: 'No Update Scan Yet',
+      subtitle: 'Run a manual scan to see whether an update is available',
+    );
+  }
+
+  Widget _buildUpdateStatusTile(BuildContext context) {
+    final details = _getUpdateStatusDetails();
+
+    return Padding(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      child: Row(
+        children: [
+          Container(
+            width: context.scaleSize(AppConstants.containerSizeSm),
+            height: context.scaleSize(AppConstants.containerSizeSm),
+            decoration: BoxDecoration(
+              color: AppColors.glassBackgroundStrong,
+              borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+            ),
+            child: Icon(
+              details.icon,
+              color: context.adaptiveTextSecondary,
+              size: context.responsiveIcon(AppConstants.iconSizeMd),
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  details.title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  details.subtitle,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildAutoSyncToggle(BuildContext context) {
     return Consumer(
       builder: (context, ref, child) {
@@ -1480,4 +1950,16 @@ SOFTWARE.
       ),
     );
   }
+}
+
+class _PatchNotes {
+  const _PatchNotes({
+    required this.title,
+    required this.body,
+    required this.url,
+  });
+
+  final String title;
+  final String body;
+  final String url;
 }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -178,6 +178,19 @@ bool shouldSyncNotificationForRepeatOneLoop({
       currentPosition <= const Duration(milliseconds: 1500);
 }
 
+@visibleForTesting
+bool shouldTrackReplayFromPlaybackState({
+  required bool usingRustBackend,
+  required Duration? previousPosition,
+  required Duration currentPosition,
+}) {
+  if (usingRustBackend) {
+    return false;
+  }
+
+  return previousPosition == null || previousPosition != currentPosition;
+}
+
 /// Singleton service to manage global audio playback state.
 ///
 /// Uses just_audio for playback with gapless playback support.
@@ -1295,6 +1308,11 @@ class PlayerService {
       if (_usingRustBackend != shouldUseRust) {
         _usingRustBackend = shouldUseRust;
       }
+      final shouldTrackReplayFromState = shouldTrackReplayFromPlaybackState(
+        usingRustBackend: shouldUseRust,
+        previousPosition: previous?.position,
+        currentPosition: state.position,
+      );
 
       final previousTrackId = previous?.currentTrack?.id;
       final currentTrackId = state.currentTrack?.id;
@@ -1347,6 +1365,10 @@ class PlayerService {
       if (shouldSyncLoopedNotification && state.currentTrack != null) {
         _lastNotificationUpdate = DateTime.now();
         unawaited(_updateNotificationState());
+      }
+
+      if (shouldTrackReplayFromState) {
+        _trackReplayProgress(state.position);
       }
 
       _lastPosition = state.position;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1110,6 +1110,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  shorebird_code_push:
+    dependency: "direct main"
+    description:
+      name: shorebird_code_push
+      sha256: "82203f39a66c78548da944dbe4079c2aa2a60fa5bc1105ed707b144c94f04349"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   skeletonizer:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.12.0-beta.2+6
+version: 0.12.0-beta.2+7
 
 environment:
   sdk: ^3.10.4
@@ -57,6 +57,7 @@ dependencies:
   rust_lib_flick_player:
     path: rust_builder
   shared_preferences: ^2.2.2
+  shorebird_code_push: ^2.0.5
   skeletonizer: ^2.1.2
   url_launcher: ^6.3.2
 
@@ -108,6 +109,7 @@ flutter:
     - assets/icons/svg/settings_white.svg
     - assets/icons/svg/shuffle_black.svg
     - assets/icons/svg/shuffle_white.svg
+    - shorebird.yaml
 
   fonts:
     - family: ProductSans

--- a/shorebird.yaml
+++ b/shorebird.yaml
@@ -1,0 +1,14 @@
+# This file is used to configure the Shorebird updater used by your app.
+# Learn more at https://docs.shorebird.dev
+# This file does not contain any sensitive information and should be checked into version control.
+
+# Your app_id is the unique identifier assigned to your app.
+# It is used to identify your app when requesting patches from Shorebird's servers.
+# It is not a secret and can be shared publicly.
+app_id: ba373382-260e-45ac-b450-01104f4030bb
+
+# auto_update controls if Shorebird should automatically update in the background on launch.
+# If auto_update: false, you will need to use package:shorebird_code_push to trigger updates.
+# https://pub.dev/packages/shorebird_code_push
+# Uncomment the following line to disable automatic updates.
+auto_update: false

--- a/test/services/player_service_notification_test.dart
+++ b/test/services/player_service_notification_test.dart
@@ -42,4 +42,39 @@ void main() {
       );
     });
   });
+
+  group('shouldTrackReplayFromPlaybackState', () {
+    test('tracks progress updates for non-Rust playback', () {
+      expect(
+        shouldTrackReplayFromPlaybackState(
+          usingRustBackend: false,
+          previousPosition: const Duration(seconds: 10),
+          currentPosition: const Duration(seconds: 11),
+        ),
+        isTrue,
+      );
+    });
+
+    test('ignores duplicate playback-state positions', () {
+      expect(
+        shouldTrackReplayFromPlaybackState(
+          usingRustBackend: false,
+          previousPosition: const Duration(seconds: 10),
+          currentPosition: const Duration(seconds: 10),
+        ),
+        isFalse,
+      );
+    });
+
+    test('defers to the dedicated Rust position listener', () {
+      expect(
+        shouldTrackReplayFromPlaybackState(
+          usingRustBackend: true,
+          previousPosition: const Duration(seconds: 10),
+          currentPosition: const Duration(seconds: 11),
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
# Summary

- Integrate Shorebird code push for in-app updates
- Add playback state tracking for replay functionality
- Add updates coming soon feature in settings

# Changes

## Shorebird Code Push

- Add `shorebird_code_push` dependency for in-app updates
- Implement update checking and installation logic in settings screen
- Add `shorebird.yaml` configuration file with app ID and auto-update options

## Replay Tracking

- Add `shouldTrackReplayFromPlaybackState` function to determine replay tracking eligibility
- Update `PlayerService` for non-Rust backend replay functionality
- Add unit tests for tracking function

## Settings Updates

- Add `_updatesComingSoon` constant for upcoming updates indicator
- Update action button titles and subtitles based on update status

# Files Changed

- `lib/features/settings/screens/settings_screen.dart` — Update integration
- `pubspec.yaml` — Shorebird dependency and version
- `shorebird.yaml` — New Shorebird configuration
- `lib/services/player_service.dart` — Replay tracking logic
- `test/services/player_service_format_test.dart` — Unit tests
