### PR TITLE
Add folder view with expand/collapse and enhanced USB audio volume control

### DIFF
--- a/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
@@ -93,6 +93,10 @@ class MainActivity: FlutterActivity() {
     private var suppressVolumeObserverRunnable: Runnable? = null
     private var lastObservedVolume: Int = -1
     private var lastObservedMuted: Boolean = false
+    /** Direct USB + UAC2 hardware volume: last native snapshot (not STREAM_MUSIC). */
+    private var lastObservedHardwareVolume: Double = Double.NaN
+    /** Matches nativeGetRustDirectUsbHardwareMute: -1 unknown, 0/1; Int.MIN_VALUE = unset. */
+    private var lastObservedHardwareMute: Int = Int.MIN_VALUE
     // private var audioConverter: AudioConverter? = null
     // Coroutine scope for background tasks
     private val mainScope = CoroutineScope(Dispatchers.Main)
@@ -136,6 +140,8 @@ class MainActivity: FlutterActivity() {
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        // Idempotent: cached engines skip duplicate GeneratedPluginRegistrant.
+        ensurePluginsRegistered(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "openDocumentTree" -> {
@@ -1840,13 +1846,15 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun ensurePluginsRegistered(engine: FlutterEngine) {
-        val engineIdentity = System.identityHashCode(engine)
-        if (registeredMainEngineIdentity == engineIdentity) {
-            return
-        }
+        synchronized(pluginRegistrationLock) {
+            val engineIdentity = System.identityHashCode(engine)
+            if (registeredMainEngineIdentity == engineIdentity) {
+                return
+            }
 
-        GeneratedPluginRegistrant.registerWith(engine)
-        registeredMainEngineIdentity = engineIdentity
+            GeneratedPluginRegistrant.registerWith(engine)
+            registeredMainEngineIdentity = engineIdentity
+        }
     }
 
     // ========== UAC 2.0 USB Host (Android) ==========
@@ -2362,6 +2370,9 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun setDirectUsbPlaybackActive(active: Boolean): Boolean {
+        if (!active && !directUsbPlaybackActive) {
+            return true
+        }
         directUsbPlaybackActive = active
         updateDirectUsbAudioFocus()
         return true
@@ -2372,7 +2383,17 @@ class MainActivity: FlutterActivity() {
             directUsbPlaybackActive = false
             nativeSetRustDirectUsbLockEnabled(false)
             nativeClearRustDirectUsbPlayback()
-            closeDirectUsbConnection(activeDirectUsbDeviceName)
+            val deviceName = activeDirectUsbDeviceName
+            val stopped = nativeWaitRustDirectUsbSessionStopped(4_000)
+            if (!stopped) {
+                Log.w(
+                    "UAC2",
+                    "[USB] Timed out waiting for Rust direct USB shutdown; keeping connection open for ${deviceName ?: "unknown"}",
+                )
+                updateDirectUsbAudioFocus()
+                return false
+            }
+            closeDirectUsbConnection(deviceName)
             activeDirectUsbDeviceName = null
             updateDirectUsbAudioFocus()
             true
@@ -2383,7 +2404,7 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun updateDirectUsbAudioFocus() {
-        if (directUsbPlaybackActive) {
+        if (shouldHoldDirectUsbAudioFocus()) {
             if (directUsbFocusGain == null) {
                 Log.i("UAC2", "[USB] Requesting audio focus for direct USB playback")
                 requestDirectUsbAudioFocus(AudioManager.AUDIOFOCUS_GAIN)
@@ -2394,6 +2415,11 @@ class MainActivity: FlutterActivity() {
             }
             abandonDirectUsbAudioFocus()
         }
+    }
+
+    private fun shouldHoldDirectUsbAudioFocus(): Boolean {
+        return activeDirectUsbDeviceName != null &&
+            (directUsbPlaybackActive || nativeIsRustDirectUsbSessionActive())
     }
 
     private fun requestDirectUsbAudioFocus(focusGain: Int) {
@@ -2476,10 +2502,19 @@ class MainActivity: FlutterActivity() {
 
         val directUsbRegistered = activeDirectUsbDeviceName != null
         val hasSystemVolumeControl = audioManager != null && !audioManager.isVolumeFixed
-        val hasDirectUsbHardwareVolume =
-            directUsbRegistered && nativeHasRustDirectUsbHardwareVolume()
-        val hasVolumeControl = hasDirectUsbHardwareVolume || hasSystemVolumeControl
+        val hasDirectUsbHardwareVolume = hasDirectUsbHardwareVolume()
+        val hasVolumeControl = if (directUsbRegistered) {
+            hasDirectUsbHardwareVolume
+        } else {
+            hasDirectUsbHardwareVolume || hasSystemVolumeControl
+        }
+        val volumeControlWritable = when {
+            hasDirectUsbHardwareVolume -> !isLiveDirectUsbHardwareVolumeBlocked()
+            hasVolumeControl -> true
+            else -> false
+        }
         baseRoute["hasVolumeControl"] = hasVolumeControl
+        baseRoute["volumeControlWritable"] = volumeControlWritable
         baseRoute["volumeMode"] = when {
             hasDirectUsbHardwareVolume -> "hardware"
             hasVolumeControl -> "system"
@@ -2508,6 +2543,40 @@ class MainActivity: FlutterActivity() {
         baseRoute["directUsbDeviceName"] = activeDirectUsbDeviceName
 
         return baseRoute
+    }
+
+    private fun hasDirectUsbHardwareVolume(): Boolean {
+        return activeDirectUsbDeviceName != null && nativeHasRustDirectUsbHardwareVolume()
+    }
+
+    private fun canUseDirectUsbHardwareVolume(): Boolean {
+        return hasDirectUsbHardwareVolume() && !isLiveDirectUsbHardwareVolumeBlocked()
+    }
+
+    private fun isLiveDirectUsbHardwareVolumeBlocked(): Boolean {
+        return hasDirectUsbHardwareVolume() && shouldHoldDirectUsbAudioFocus()
+    }
+
+    private fun isDirectUsbSessionFrozen(): Boolean {
+        return activeDirectUsbDeviceName != null && shouldHoldDirectUsbAudioFocus()
+    }
+
+    private fun currentActiveDirectUsbDevice(): UsbDevice? {
+        val deviceName = activeDirectUsbDeviceName ?: return null
+        val usbManager = getSystemService(Context.USB_SERVICE) as? UsbManager ?: return null
+        return usbManager.deviceList?.get(deviceName)
+    }
+
+    private fun cachedDirectUsbCapabilityRoute(): MutableMap<String, Any?> {
+        val activeDevice = currentActiveDirectUsbDevice()
+        return activeDevice?.let { buildUsbRouteMap(it).toMutableMap() } ?: mutableMapOf(
+            "routeType" to "usb",
+            "routeLabel" to (currentRouteLabelHint() ?: "USB DAC"),
+            "isExternal" to true,
+            "productName" to (currentRouteLabelHint() ?: "USB DAC"),
+            "manufacturer" to Build.MANUFACTURER,
+            "deviceName" to activeDirectUsbDeviceName,
+        )
     }
 
     private fun findPreferredUsbAudioDevice(
@@ -2643,21 +2712,37 @@ class MainActivity: FlutterActivity() {
         preferredSerial: String? = null,
     ): Map<String, Any?> {
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as? AudioManager
-        val routeStatus = getRouteStatus(
-            preferredDeviceName = preferredDeviceName,
-            preferredProductName = preferredProductName,
-            preferredVendorId = preferredVendorId,
-            preferredProductId = preferredProductId,
-            preferredSerial = preferredSerial,
-        )
-        val routeType = routeStatus["routeType"] as? String ?: "unknown"
-        val preferredUsbDevice = findPreferredUsbAudioDevice(
-            preferredDeviceName = preferredDeviceName,
-            preferredProductName = preferredProductName,
-            preferredVendorId = preferredVendorId,
-            preferredProductId = preferredProductId,
-            preferredSerial = preferredSerial,
-        )
+        val freezeDirectUsbSession = isDirectUsbSessionFrozen()
+        val routeStatus = if (freezeDirectUsbSession) {
+            cachedDirectUsbCapabilityRoute().apply {
+                put("directUsbRegistered", true)
+                put("preferredUsbDeviceDetected", true)
+            }
+        } else {
+            getRouteStatus(
+                preferredDeviceName = preferredDeviceName,
+                preferredProductName = preferredProductName,
+                preferredVendorId = preferredVendorId,
+                preferredProductId = preferredProductId,
+                preferredSerial = preferredSerial,
+            )
+        }
+        val routeType = if (freezeDirectUsbSession) {
+            "usb"
+        } else {
+            routeStatus["routeType"] as? String ?: "unknown"
+        }
+        val preferredUsbDevice = if (freezeDirectUsbSession) {
+            null
+        } else {
+            findPreferredUsbAudioDevice(
+                preferredDeviceName = preferredDeviceName,
+                preferredProductName = preferredProductName,
+                preferredVendorId = preferredVendorId,
+                preferredProductId = preferredProductId,
+                preferredSerial = preferredSerial,
+            )
+        }
         val bestOutput = currentBestOutputDevice(audioManager)
         val supportedSampleRates = bestOutput
             ?.sampleRates
@@ -2793,7 +2878,7 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun getRouteVolume(): Double? {
-        if (activeDirectUsbDeviceName != null && nativeHasRustDirectUsbHardwareVolume()) {
+        if (hasDirectUsbHardwareVolume()) {
             val hardwareVolume = nativeGetRustDirectUsbHardwareVolume()
             return if (hardwareVolume.isNaN()) null else hardwareVolume.coerceIn(0.0, 1.0)
         }
@@ -2807,8 +2892,11 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun setRouteVolume(volume: Double): Boolean {
-        if (activeDirectUsbDeviceName != null && nativeHasRustDirectUsbHardwareVolume()) {
+        if (canUseDirectUsbHardwareVolume()) {
             return nativeSetRustDirectUsbHardwareVolume(volume.coerceIn(0.0, 1.0))
+        }
+        if (isLiveDirectUsbHardwareVolumeBlocked()) {
+            return false
         }
 
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return false
@@ -2828,7 +2916,7 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun getRouteMuted(): Boolean {
-        if (activeDirectUsbDeviceName != null && nativeHasRustDirectUsbHardwareVolume()) {
+        if (hasDirectUsbHardwareVolume()) {
             return nativeGetRustDirectUsbHardwareMute() == 1
         }
 
@@ -2842,8 +2930,11 @@ class MainActivity: FlutterActivity() {
     }
 
     private fun setRouteMuted(muted: Boolean): Boolean {
-        if (activeDirectUsbDeviceName != null && nativeHasRustDirectUsbHardwareVolume()) {
+        if (canUseDirectUsbHardwareVolume()) {
             return nativeSetRustDirectUsbHardwareMute(muted)
+        }
+        if (isLiveDirectUsbHardwareVolumeBlocked()) {
+            return false
         }
 
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as? AudioManager ?: return false
@@ -2896,9 +2987,18 @@ class MainActivity: FlutterActivity() {
     private fun registerVolumeContentObserver() {
         // Seed cached values so the first real change is detected
         val audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
-        val seedVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
-        lastObservedVolume = seedVolume
-        lastObservedMuted = seedVolume == 0
+        if (hasDirectUsbHardwareVolume()) {
+            lastObservedHardwareVolume = nativeGetRustDirectUsbHardwareVolume()
+            lastObservedHardwareMute = nativeGetRustDirectUsbHardwareMute()
+        } else {
+            val seedVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+            lastObservedVolume = seedVolume
+            lastObservedMuted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                seedVolume == 0 || audioManager.isStreamMute(AudioManager.STREAM_MUSIC)
+            } else {
+                seedVolume == 0
+            }
+        }
 
         volumeContentObserver = object : ContentObserver(volumeObserverHandler) {
             override fun onChange(selfChange: Boolean) {
@@ -2908,16 +3008,36 @@ class MainActivity: FlutterActivity() {
                 volumeObserverDebounceRunnable = Runnable {
                     val volume = getRouteVolume()
                     val muted = getRouteMuted()
-                    val volRaw = (getSystemService(AUDIO_SERVICE) as AudioManager)
-                        .getStreamVolume(AudioManager.STREAM_MUSIC)
-                    // Only notify Flutter if volume or mute actually changed
-                    if (volRaw != lastObservedVolume || muted != lastObservedMuted) {
-                        lastObservedVolume = volRaw
-                        lastObservedMuted = muted
-                        uac2Channel?.invokeMethod("onVolumeChanged", mapOf(
-                            "volume" to volume,
-                            "muted" to muted,
-                        ))
+                    if (hasDirectUsbHardwareVolume()) {
+                        val hwVol = nativeGetRustDirectUsbHardwareVolume()
+                        val hwMute = nativeGetRustDirectUsbHardwareMute()
+                        val hwVolChanged = when {
+                            hwVol.isNaN() && lastObservedHardwareVolume.isNaN() -> false
+                            hwVol.isNaN() != lastObservedHardwareVolume.isNaN() -> true
+                            hwVol.isNaN() -> false
+                            lastObservedHardwareVolume.isNaN() -> true
+                            else -> kotlin.math.abs(hwVol - lastObservedHardwareVolume) > 1e-6
+                        }
+                        val hwMuteChanged = hwMute != lastObservedHardwareMute
+                        if (hwVolChanged || hwMuteChanged) {
+                            lastObservedHardwareVolume = hwVol
+                            lastObservedHardwareMute = hwMute
+                            uac2Channel?.invokeMethod("onVolumeChanged", mapOf(
+                                "volume" to volume,
+                                "muted" to muted,
+                            ))
+                        }
+                    } else {
+                        val volRaw = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+                        // Only notify Flutter if volume or mute actually changed
+                        if (volRaw != lastObservedVolume || muted != lastObservedMuted) {
+                            lastObservedVolume = volRaw
+                            lastObservedMuted = muted
+                            uac2Channel?.invokeMethod("onVolumeChanged", mapOf(
+                                "volume" to volume,
+                                "muted" to muted,
+                            ))
+                        }
                     }
                 }
                 volumeObserverHandler.postDelayed(volumeObserverDebounceRunnable!!, 150)
@@ -3001,6 +3121,7 @@ class MainActivity: FlutterActivity() {
 
     companion object {
         private const val ACTION_USB_PERMISSION = "com.ultraelectronica.flick.USB_PERMISSION"
+        private val pluginRegistrationLock = Any()
         private var registeredMainEngineIdentity: Int? = null
     }
 
@@ -3027,5 +3148,7 @@ class MainActivity: FlutterActivity() {
     private external fun nativeSetRustDirectUsbHardwareMute(muted: Boolean): Boolean
     private external fun nativeGetRustAudioDebugStateJson(): String?
     private external fun nativeClearRustDirectUsbPlayback(): Boolean
+    private external fun nativeWaitRustDirectUsbSessionStopped(timeoutMs: Int): Boolean
+    private external fun nativeIsRustDirectUsbSessionActive(): Boolean
     private external fun nativeMarkRustDirectUsbFallback(reason: String?): Boolean
 }

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -263,6 +263,7 @@ class SongRepository {
       trackNumber: entity.trackNumber,
       discNumber: entity.discNumber,
       filePath: entity.filePath,
+      folderUri: entity.folderUri,
       dateAdded: entity.dateAdded,
     );
   }

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1643,17 +1643,7 @@ class _AnimatedSongScene extends StatelessWidget {
                                 letterSpacing: 0.8,
                               ),
                             ),
-                            if (playerScreenMode !=
-                                PlayerScreenMode.immersive) ...[
-                              SizedBox(
-                                width: context.responsive(6.0, 7.0, 8.0),
-                              ),
-                              _buildQueueSummaryBadge(
-                                context,
-                                count: queue.length,
-                                highlighted: hasQueue,
-                              ),
-                            ],
+                          
                           ],
                         ),
                       ],
@@ -1884,24 +1874,26 @@ class _AnimatedSongScene extends StatelessWidget {
             ],
           ),
         ),
-        SizedBox(width: context.responsive(12.0, 14.0, 16.0)),
-        if (playerScreenMode != PlayerScreenMode.immersive)
-          GestureDetector(
-            onTap: onOpenQueue,
-            child: Container(
-              padding: EdgeInsets.all(context.responsive(8.0, 9.0, 10.0)),
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Icon(
-                LucideIcons.listMusic,
-                color: Colors.white.withValues(alpha: 0.92),
-                size: context.responsive(18.0, 20.0, 22.0),
-              ),
-            ),
-          ),
+        _buildQueueButton(context),
       ],
+    );
+  }
+
+  Widget _buildQueueButton(BuildContext context) {
+    return GestureDetector(
+      onTap: onOpenQueue,
+      child: Container(
+        padding: EdgeInsets.all(context.responsive(8.0, 9.0, 10.0)),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(
+          LucideIcons.listMusic,
+          color: Colors.white.withValues(alpha: 0.92),
+          size: context.responsive(18.0, 20.0, 22.0),
+        ),
+      ),
     );
   }
 

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -42,6 +42,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   String _selectedFastToken = 'A';
   late final ProviderSubscription<Song?> _currentSongSubscription;
   bool _alignedCurrentSongAfterLoad = false;
+  final Set<String> _expandedFolders = {};
 
   @override
   void initState() {
@@ -137,9 +138,10 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                     loading: () => _buildLoadingState(),
                     error: (error, stack) => _buildErrorState(error),
                     data: (songsState) {
+                      final isFolderMode = songsState.sortOption == SongSortOption.folder;
                       final allSongs = songsState.sortedSongs;
                       var songs = allSongs;
-                      _cachedSongs = allSongs;
+                      _cachedSongs = songsState.songs;
 
                       if (_searchQuery.isNotEmpty) {
                         songs = songs.where((song) {
@@ -158,9 +160,37 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                         return _buildNoSearchResultsState();
                       }
 
+                      if (isFolderMode) {
+                        final folderGroups = songsState.folderGroups;
+                        if (_searchQuery.isNotEmpty) {
+                          final filteredGroups = <FolderGroup>[];
+                          for (final group in folderGroups) {
+                            final filtered = group.songs.where((song) {
+                              return song.title.toLowerCase().contains(_searchQuery) ||
+                                  song.artist.toLowerCase().contains(_searchQuery);
+                            }).toList();
+                            if (filtered.isNotEmpty) {
+                              filteredGroups.add(FolderGroup(
+                                name: group.name,
+                                key: group.key,
+                                folderUri: group.folderUri,
+                                songs: filtered,
+                              ));
+                            }
+                          }
+                          if (filteredGroups.isEmpty) {
+                            return _buildNoSearchResultsState();
+                          }
+                          return _buildFolderListView(filteredGroups);
+                        }
+                        if (folderGroups.isEmpty) {
+                          return _buildEmptyState();
+                        }
+                        return _buildFolderListView(folderGroups);
+                      }
+
                       _alignCurrentSongAfterSongsLoad(songs);
 
-                      // Ensure selected index is valid
                       if (_selectedIndex >= songs.length) {
                         WidgetsBinding.instance.addPostFrameCallback((_) {
                           if (mounted) {
@@ -341,6 +371,84 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
     );
   }
 
+  Widget _buildFolderListView(List<FolderGroup> folders) {
+    return ListView.builder(
+      controller: _listScrollController,
+      addAutomaticKeepAlives: false,
+      padding: const EdgeInsets.fromLTRB(
+        AppConstants.spacingLg,
+        0,
+        AppConstants.spacingXl + 30,
+        AppConstants.navBarHeight + 120,
+      ),
+      itemCount: folders.length,
+      itemBuilder: (context, index) {
+        final folder = folders[index];
+        final isExpanded = _expandedFolders.contains(folder.key);
+
+        return Column(
+          key: ValueKey('folder_${folder.key}'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _FolderHeader(
+              name: folder.name,
+              songCount: folder.songs.length,
+              isExpanded: isExpanded,
+              onTap: () {
+                setState(() {
+                  if (isExpanded) {
+                    _expandedFolders.remove(folder.key);
+                  } else {
+                    _expandedFolders.add(folder.key);
+                  }
+                });
+              },
+              onPlayAll: () async {
+                await _playSongAndOpenPlayer(
+                  songs: folder.songs,
+                  index: 0,
+                );
+              },
+            ),
+            if (isExpanded) ...[
+              for (final song in folder.songs) ...[
+                Padding(
+                  key: ValueKey(song.id),
+                  padding: const EdgeInsets.only(
+                    left: AppConstants.spacingLg,
+                    bottom: AppConstants.spacingSm,
+                  ),
+                  child: _QueueSwipeListItem(
+                    onQueued: () async {
+                      await _queueSong(song);
+                    },
+                    onFavorited: () async {
+                      await _favoriteSong(song);
+                    },
+                    child: _SongListTile(
+                      song: song,
+                      isSelected: false,
+                      onTap: () async {
+                        await _playSongAndOpenPlayer(
+                          songs: folder.songs,
+                          index: folder.songs.indexOf(song),
+                        );
+                      },
+                      onLongPress: () {
+                        SongActionsBottomSheet.show(context, song);
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ],
+            const SizedBox(height: AppConstants.spacingXxs),
+          ],
+        );
+      },
+    );
+  }
+
   Map<String, int> _buildFastIndexMap(List<Song> songs) {
     final songsAsync = ref.read(songsProvider);
     final sortOption =
@@ -370,8 +478,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         if (year == null) return '#';
         return year.toString();
       case SongSortOption.fileType:
-        // For file type sorting, use the file type itself
         return song.fileType.toUpperCase();
+      case SongSortOption.folder:
+        text = SongsState.folderDisplayName(song.folderUri, song.filePath);
     }
 
     return _extractToken(text);
@@ -903,6 +1012,23 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                         ],
                       ),
                     ),
+                    PopupMenuItem<SongSortOption>(
+                      value: SongSortOption.folder,
+                      child: Row(
+                        children: [
+                          if (currentSort == SongSortOption.folder)
+                            const Icon(Icons.check, size: 18),
+                          if (currentSort == SongSortOption.folder)
+                            const SizedBox(width: 8),
+                          Text(
+                            'Folder',
+                            style: TextStyle(
+                              color: context.adaptiveTextPrimary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                     const PopupMenuDivider(),
                     PopupMenuItem<void>(
                       enabled: false,
@@ -1418,6 +1544,137 @@ class _QueueSwipeListItemState extends State<_QueueSwipeListItem> {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _FolderHeader extends StatelessWidget {
+  final String name;
+  final int songCount;
+  final bool isExpanded;
+  final VoidCallback onTap;
+  final VoidCallback onPlayAll;
+
+  const _FolderHeader({
+    required this.name,
+    required this.songCount,
+    required this.isExpanded,
+    required this.onTap,
+    required this.onPlayAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: AppConstants.spacingXxs),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.surfaceLight.withValues(alpha: 0.85),
+            AppColors.surface.withValues(alpha: 0.95),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        border: Border.all(
+          color: isExpanded
+              ? AppColors.accent.withValues(alpha: 0.35)
+              : AppColors.glassBorder,
+        ),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppConstants.spacingMd,
+              vertical: AppConstants.spacingSm + 2,
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  isExpanded
+                      ? LucideIcons.chevronDown
+                      : LucideIcons.chevronRight,
+                  size: 18,
+                  color: context.adaptiveTextSecondary,
+                ),
+                const SizedBox(width: AppConstants.spacingSm),
+                Icon(
+                  LucideIcons.folder,
+                  size: 20,
+                  color: AppColors.accent.withValues(alpha: 0.8),
+                ),
+                const SizedBox(width: AppConstants.spacingSm),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: context.adaptiveTextPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 1),
+                      Text(
+                        '$songCount ${songCount == 1 ? 'song' : 'songs'}',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: context.adaptiveTextTertiary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (isExpanded) ...[
+                  const SizedBox(width: AppConstants.spacingSm),
+                  GestureDetector(
+                    onTap: onPlayAll,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.spacingSm,
+                        vertical: AppConstants.spacingXxs + 1,
+                      ),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(
+                          AppConstants.radiusMd,
+                        ),
+                        border: Border.all(
+                          color: AppColors.accent.withValues(alpha: 0.4),
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            LucideIcons.play,
+                            size: 14,
+                            color: AppColors.accent,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Play all',
+                            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: AppColors.accent,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -42,6 +42,9 @@ class Song {
   /// File path on device
   final String? filePath;
 
+  /// URI of the folder containing this song
+  final String? folderUri;
+
   /// Date the song was added to the library
   final DateTime? dateAdded;
 
@@ -60,6 +63,7 @@ class Song {
     this.trackNumber,
     this.discNumber,
     this.filePath,
+    this.folderUri,
     this.dateAdded,
   });
 
@@ -91,6 +95,7 @@ class Song {
     int? trackNumber,
     int? discNumber,
     String? filePath,
+    String? folderUri,
     DateTime? dateAdded,
   }) {
     return Song(
@@ -108,6 +113,7 @@ class Song {
       trackNumber: trackNumber ?? this.trackNumber,
       discNumber: discNumber ?? this.discNumber,
       filePath: filePath ?? this.filePath,
+      folderUri: folderUri ?? this.folderUri,
       dateAdded: dateAdded ?? this.dateAdded,
     );
   }

--- a/lib/providers/songs_provider.dart
+++ b/lib/providers/songs_provider.dart
@@ -11,7 +11,22 @@ final songRepositoryProvider = Provider<SongRepository>((ref) {
 });
 
 /// Sort options for the song list.
-enum SongSortOption { albumArtist, title, artist, dateAdded, fileType }
+enum SongSortOption { albumArtist, title, artist, dateAdded, fileType, folder }
+
+/// A group of songs within the same folder.
+class FolderGroup {
+  final String name;
+  final String key;
+  final String? folderUri;
+  final List<Song> songs;
+
+  const FolderGroup({
+    required this.name,
+    required this.key,
+    this.folderUri,
+    required this.songs,
+  });
+}
 
 /// Filter options for file types.
 enum SongFileTypeFilter { all, flac, mp3, wav, aac, ogg, alac }
@@ -155,8 +170,130 @@ class SongsState {
         });
       case SongSortOption.fileType:
         result.sort((a, b) => a.fileType.compareTo(b.fileType));
+      case SongSortOption.folder:
+        result.sort((a, b) {
+          final folderA = _extractRelativeSubfolder(a.folderUri, a.filePath);
+          final folderB = _extractRelativeSubfolder(b.folderUri, b.filePath);
+          final folderCompare = folderA.compareTo(folderB);
+          if (folderCompare != 0) return folderCompare;
+          return a.title.compareTo(b.title);
+        });
     }
     return result;
+  }
+
+  static String _extractRelativeSubfolder(String? folderUri, String? filePath) {
+    if (filePath == null || filePath.isEmpty) return '';
+
+    String rootId = '';
+    if (folderUri != null && folderUri.isNotEmpty) {
+      final uri = Uri.tryParse(folderUri);
+      if (uri != null && uri.scheme == 'content') {
+        final segments = uri.pathSegments;
+        final treeIndex = segments.indexOf('tree');
+        if (treeIndex >= 0 && treeIndex + 1 < segments.length) {
+          rootId = Uri.decodeComponent(segments[treeIndex + 1])
+              .replaceAll('\\', '/')
+              .replaceAll(RegExp(r'/+$'), '');
+        }
+      } else {
+        rootId = folderUri.replaceAll('\\', '/').replaceAll(RegExp(r'/+$'), '');
+      }
+    }
+
+    String fileDocPath = '';
+    final fileUri = Uri.tryParse(filePath);
+    if (fileUri != null && fileUri.scheme == 'content') {
+      final segments = fileUri.pathSegments;
+      final docIndex = segments.indexOf('document');
+      if (docIndex >= 0 && docIndex + 1 < segments.length) {
+        fileDocPath = Uri.decodeComponent(segments[docIndex + 1])
+            .replaceAll('\\', '/')
+            .replaceAll(RegExp(r'/+$'), '');
+      }
+    } else {
+      fileDocPath = filePath.replaceAll('\\', '/').replaceAll(RegExp(r'/+$'), '');
+    }
+
+    if (fileDocPath.isEmpty) return '';
+
+    if (rootId.isNotEmpty && fileDocPath.startsWith(rootId)) {
+      var relative = fileDocPath.substring(rootId.length);
+      if (relative.startsWith('/')) relative = relative.substring(1);
+      final lastSlash = relative.lastIndexOf('/');
+      if (lastSlash > 0) {
+        return relative.substring(0, lastSlash);
+      }
+      return '';
+    }
+
+    final lastSlash = fileDocPath.lastIndexOf('/');
+    if (lastSlash > 0) {
+      return fileDocPath.substring(0, lastSlash);
+    }
+    return '';
+  }
+
+  static String folderDisplayName(String? folderUri, String? filePath) {
+    final subfolder = _extractRelativeSubfolder(folderUri, filePath);
+    if (subfolder.isNotEmpty) {
+      final parts = subfolder.split('/').where((p) => p.isNotEmpty).toList();
+      return parts.isNotEmpty ? parts.last : subfolder;
+    }
+    if (folderUri != null && folderUri.isNotEmpty) {
+      final uri = Uri.tryParse(folderUri);
+      if (uri != null && uri.scheme == 'content') {
+        final segments = uri.pathSegments;
+        final treeIndex = segments.indexOf('tree');
+        if (treeIndex >= 0 && treeIndex + 1 < segments.length) {
+          final decoded = Uri.decodeComponent(segments[treeIndex + 1]);
+          final normalized = decoded.replaceAll('\\', '/').replaceAll(RegExp(r'/+'), '/');
+          final parts = normalized.split('/');
+          final nonEmpty = parts.where((p) => p.isNotEmpty).toList();
+          if (nonEmpty.isNotEmpty) return nonEmpty.last;
+        }
+      }
+      final normalized = folderUri.replaceAll('\\', '/').replaceAll(RegExp(r'/+'), '/');
+      final parts = normalized.split('/');
+      final nonEmpty = parts.where((p) => p.isNotEmpty).toList();
+      return nonEmpty.isNotEmpty ? nonEmpty.last : normalized;
+    }
+    return 'Unknown';
+  }
+
+  List<FolderGroup> get folderGroups {
+    if (sortOption != SongSortOption.folder) return [];
+
+    var result = List<Song>.from(songs);
+
+    if (fileTypeFilter != SongFileTypeFilter.all) {
+      result = result
+          .where((song) => fileTypeFilter.matches(song.fileType))
+          .toList();
+    }
+
+    final groups = <String, FolderGroup>{};
+    for (final song in result) {
+      final subfolder = _extractRelativeSubfolder(song.folderUri, song.filePath);
+      final key = subfolder.isEmpty ? (song.folderUri ?? '__root__') : subfolder;
+      final displayName = subfolder.isEmpty
+          ? folderDisplayName(song.folderUri, song.filePath)
+          : subfolder.split('/').where((p) => p.isNotEmpty).last;
+      groups.putIfAbsent(
+        key,
+        () => FolderGroup(
+          name: displayName,
+          key: key,
+          folderUri: song.folderUri,
+          songs: [],
+        ),
+      );
+      groups[key]!.songs.add(song);
+    }
+
+    final sorted = groups.values.toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    return sorted;
   }
 }
 

--- a/lib/services/android_audio_device_service.dart
+++ b/lib/services/android_audio_device_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flick/services/uac2_service.dart';
 
 class AndroidPlaybackDeviceInfo {
   const AndroidPlaybackDeviceInfo({
@@ -119,6 +120,10 @@ class AndroidAudioDeviceService {
       return AndroidPlaybackDeviceInfo.unknown;
     }
 
+    if (Uac2Service.instance.shouldFreezeAndroidDirectUsbSessionQueries) {
+      return deviceInfoNotifier.value;
+    }
+
     final inFlight = _refreshInFlight;
     if (inFlight != null) {
       return inFlight;
@@ -141,6 +146,9 @@ class AndroidAudioDeviceService {
       _channel.setMethodCallHandler((call) async {
         if (call.method == 'onPlaybackDevicesChanged') {
           debugPrint('[Engine] Audio device change detected');
+          if (Uac2Service.instance.shouldFreezeAndroidDirectUsbSessionQueries) {
+            return;
+          }
           await refresh();
         }
       });

--- a/lib/services/audio_session_manager.dart
+++ b/lib/services/audio_session_manager.dart
@@ -225,7 +225,9 @@ class AudioSessionManager {
   }
 
   Future<AudioEngineType> _resolvePreferredMode({bool refresh = false}) async {
-    final info = refresh
+    final freezeDirectUsbSessionQueries =
+        _uac2Service.shouldFreezeAndroidDirectUsbSessionQueries;
+    final info = refresh && !freezeDirectUsbSessionQueries
         ? await _deviceService.refresh()
         : _deviceService.deviceInfoNotifier.value;
     final hiFiModeEnabled = await _preferencesService.getHiFiModeEnabled();

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -224,6 +224,10 @@ class PlayerService {
   RustAudioEngine? _rustEngine;
   StreamSubscription<PlaybackState>? _playbackStateSubscription;
   PlaybackState? _lastPlaybackState;
+  Timer? _playbackDiagnosticsDebounceTimer;
+  static const Duration _playbackDiagnosticsDebounce = Duration(
+    milliseconds: 300,
+  );
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
   final ReplayPlayTracker _replayPlayTracker = ReplayPlayTracker();
@@ -348,7 +352,24 @@ class PlayerService {
     _uac2Service.bitPerfectEnabledNotifier.addListener(() {
       unawaited(_handleBitPerfectPreferenceChanged());
     });
+    _uac2Service.addStatusListener(_mirrorUsbHardwareVolumeFromUac2Status);
     _notifyQueueChanged();
+  }
+
+  /// When the DAC/route reports a new hardware level (e.g. device keys), keep
+  /// [_currentVolume] aligned so bit-perfect sync does not fight the DAC.
+  void _mirrorUsbHardwareVolumeFromUac2Status(Uac2DeviceStatus? status) {
+    if (status == null || !Platform.isAndroid) return;
+    if (currentEngineType != AudioEngineType.usbDacExperimental) return;
+    if (!isBitPerfectModeEnabled) return;
+    if (!status.hasVolumeControl ||
+        status.volumeMode != Uac2VolumeMode.hardware) {
+      return;
+    }
+    final v = status.volume;
+    if (v == null) return;
+    if ((v - _currentVolume).abs() <= 0.01) return;
+    _currentVolume = v.clamp(0.0, 1.0);
   }
 
   Future<void> _handleBitPerfectPreferenceChanged() async {
@@ -779,33 +800,34 @@ class PlayerService {
         routeStatus?.volumeMode == Uac2VolumeMode.hardware;
   }
 
-  Future<void> _syncBitPerfectUsbHardwareVolumeIfNeeded() async {
-    if (!_hasBitPerfectUsbHardwareVolumeControl()) {
-      return;
-    }
-
-    final routeVolume = _uac2Service.currentDeviceStatus?.volume;
-    if (routeVolume != null && (routeVolume - _currentVolume).abs() <= 0.01) {
-      return;
-    }
-
-    await _uac2Service.setVolume(_currentVolume);
-  }
+  /// Prefer [primary], then the current-song notifier, then the last engine
+  /// playback snapshot so USB focus stays latched when Rust is ahead of or
+  /// behind the notifier during gapless / crossfade / buffering.
+  Song? _songForUac2Sync(Song? primary) =>
+      primary ??
+      currentSongNotifier.value ??
+      _playbackManager.latestState?.currentTrack;
 
   Future<void> _syncUac2PlaybackStatus(
     Song? song, {
     required bool isPlaying,
   }) async {
+    final resolved = _songForUac2Sync(song);
+    // Rust state can flicker (idle between gapless segments, short internal
+    // restarts) while the UI session is still "playing". Releasing direct USB
+    // audio focus in that window races libusb teardown and surfaces as EIO.
+    final directUsb = currentEngineType == AudioEngineType.usbDacExperimental;
+    final effectiveIsPlaying =
+        isPlaying || (directUsb && isPlayingNotifier.value && resolved != null);
     await _uac2Service.syncPlaybackStatus(
-      song: song,
-      isPlaying: isPlaying,
-      formatOverride: _deriveUac2FormatFromSong(song),
+      song: resolved,
+      isPlaying: effectiveIsPlaying,
+      formatOverride: _deriveUac2FormatFromSong(resolved),
       playbackMode: currentEngineType,
     );
-    await _syncBitPerfectUsbHardwareVolumeIfNeeded();
     await _refreshAudioOutputDiagnostics(
       reason: 'UAC2 status sync',
-      activeSong: song,
+      activeSong: resolved,
     );
   }
 
@@ -1269,14 +1291,18 @@ class PlayerService {
       if (!_usingRustBackend) return;
 
       final rustState = _rustAudioService.stateNotifier.value;
-      final isPlaying =
+      // Treat buffering like playback for Android direct USB: releasing audio
+      // focus while the Rust isochronous pump is still starting starves the
+      // stream and surfaces as libusb I/O errors.
+      final pipelineActive =
           rustState == RustPlaybackState.playing ||
-          rustState == RustPlaybackState.crossfading;
+          rustState == RustPlaybackState.crossfading ||
+          rustState == RustPlaybackState.buffering;
 
       unawaited(
         _syncUac2PlaybackStatus(
           currentSongNotifier.value,
-          isPlaying: isPlaying,
+          isPlaying: pipelineActive,
         ),
       );
     };
@@ -1314,6 +1340,8 @@ class PlayerService {
   }
 
   void _bindPlaybackState() {
+    _playbackDiagnosticsDebounceTimer?.cancel();
+    _playbackDiagnosticsDebounceTimer = null;
     _playbackStateSubscription?.cancel();
     _playbackStateSubscription = _playbackManager.playbackState.listen((state) {
       final previous = _lastPlaybackState;
@@ -1413,12 +1441,36 @@ class PlayerService {
 
       _lastPosition = state.position;
 
-      unawaited(
-        _refreshAudioOutputDiagnostics(
-          reason: 'playback state changed',
-          activeSong: state.currentTrack,
-        ),
-      );
+      final criticalDiagnosticsChange =
+          previous == null ||
+          previous.engine != state.engine ||
+          previous.currentTrack?.id != state.currentTrack?.id ||
+          previous.isPlaying != state.isPlaying;
+      if (criticalDiagnosticsChange) {
+        _playbackDiagnosticsDebounceTimer?.cancel();
+        _playbackDiagnosticsDebounceTimer = null;
+        unawaited(
+          _refreshAudioOutputDiagnostics(
+            reason: 'playback state changed',
+            activeSong: state.currentTrack,
+          ),
+        );
+      } else {
+        _playbackDiagnosticsDebounceTimer?.cancel();
+        _playbackDiagnosticsDebounceTimer = Timer(
+          _playbackDiagnosticsDebounce,
+          () {
+            _playbackDiagnosticsDebounceTimer = null;
+            final snap = _lastPlaybackState;
+            unawaited(
+              _refreshAudioOutputDiagnostics(
+                reason: 'playback state changed',
+                activeSong: snap?.currentTrack,
+              ),
+            );
+          },
+        );
+      }
     });
   }
 
@@ -1968,11 +2020,6 @@ class PlayerService {
       final routeStatus = _uac2Service.currentDeviceStatus;
       if (playbackMode == AudioEngineType.usbDacExperimental &&
           routeStatus != null &&
-          routeStatus.hasVolumeControl &&
-          routeStatus.volumeMode == Uac2VolumeMode.hardware) {
-        await _uac2Service.setVolume(_currentVolume);
-      } else if (playbackMode == AudioEngineType.usbDacExperimental &&
-          routeStatus != null &&
           !routeStatus.hasVolumeControl) {
         debugPrint(
           '[Engine] Direct USB bit-perfect is active without Android route volume control; output level is full-scale unless the DAC itself provides hardware attenuation',
@@ -2310,24 +2357,34 @@ class PlayerService {
             _sessionManager.initializedMode ==
                 AudioEngineType.usbDacExperimental &&
             _rustEngine != null;
+        final requestedUsbOutputFormat = alreadyInUsbMode
+            ? await _uac2Service.suggestAndroidExperimentalUsbOutputFormat(
+                requested: trackFormat,
+              )
+            : trackFormat;
         final currentUsbFormat =
             _uac2Service.lastKnownFormat ??
             _uac2Service.currentDeviceStatus?.currentFormat;
+        final targetUsbOutputFormat = requestedUsbOutputFormat ?? trackFormat;
         final formatMatches =
-            alreadyInUsbMode && _sameUac2Format(currentUsbFormat, trackFormat);
+            alreadyInUsbMode &&
+            _sameUac2Format(currentUsbFormat, targetUsbOutputFormat);
 
         if (formatMatches) {
           debugPrint(
             '[Engine] USB engine already active with matching format '
-            '(${trackFormat.sampleRate}Hz/${trackFormat.bitDepth}-bit/'
-            '${trackFormat.channels}ch), skipping re-preparation',
+            '(${targetUsbOutputFormat.sampleRate}Hz/'
+            '${targetUsbOutputFormat.bitDepth}-bit/'
+            '${targetUsbOutputFormat.channels}ch), skipping re-preparation',
           );
           _sessionManager.clearFallbackReason();
           return normalizedEngine;
         }
 
         final prepared = await _uac2Service
-            .prepareAndroidExperimentalUsbPlayback(format: trackFormat);
+            .prepareAndroidExperimentalUsbPlayback(
+              format: targetUsbOutputFormat,
+            );
         if (!prepared) {
           await _uac2Service.markAndroidDirectUsbFallback(
             'experimental direct USB path could not be prepared',
@@ -3198,6 +3255,8 @@ class PlayerService {
   }
 
   void dispose() {
+    _playbackDiagnosticsDebounceTimer?.cancel();
+    _playbackDiagnosticsDebounceTimer = null;
     _positionSaveTimer?.cancel();
     unawaited(_audioFocusSubscription?.cancel());
     cancelSleepTimer();

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -70,6 +70,7 @@ class Uac2DeviceStatus {
   final bool isExternalRoute;
   final Uac2VolumeMode volumeMode;
   final bool hasVolumeControl;
+  final bool volumeControlWritable;
   final double? volume;
   final bool? muted;
 
@@ -84,6 +85,7 @@ class Uac2DeviceStatus {
     this.isExternalRoute = false,
     this.volumeMode = Uac2VolumeMode.unavailable,
     this.hasVolumeControl = false,
+    this.volumeControlWritable = true,
     this.volume,
     this.muted,
   });
@@ -99,6 +101,7 @@ class Uac2DeviceStatus {
     bool? isExternalRoute,
     Uac2VolumeMode? volumeMode,
     bool? hasVolumeControl,
+    bool? volumeControlWritable,
     Object? volume = _unset,
     Object? muted = _unset,
   }) {
@@ -121,6 +124,8 @@ class Uac2DeviceStatus {
       isExternalRoute: isExternalRoute ?? this.isExternalRoute,
       volumeMode: volumeMode ?? this.volumeMode,
       hasVolumeControl: hasVolumeControl ?? this.hasVolumeControl,
+      volumeControlWritable:
+          volumeControlWritable ?? this.volumeControlWritable,
       volume: identical(volume, _unset) ? this.volume : volume as double?,
       muted: identical(muted, _unset) ? this.muted : muted as bool?,
     );
@@ -143,11 +148,15 @@ class Uac2Service {
   Uac2AudioFormat? _lastKnownFormat;
   bool _lastKnownIsPlaying = false;
   bool _lastKnownHasSong = false;
+  bool? _lastDirectUsbPlaybackActive;
+  int _playbackStatusSyncGeneration = 0;
   Timer? _androidRouteRefreshDebounceTimer;
 
   Uac2DeviceStatus? get currentDeviceStatus => _currentDeviceStatus;
   Uac2AudioFormat? get lastKnownFormat => _lastKnownFormat;
   bool get isBitPerfectEnabledSync => bitPerfectEnabledNotifier.value;
+  bool get shouldFreezeAndroidDirectUsbSessionQueries =>
+      _hasFrozenAndroidDirectUsbSession();
 
   bool get isAvailable {
     if (Platform.isAndroid) return true;
@@ -273,7 +282,19 @@ class Uac2Service {
   }
 
   Future<List<Uac2DeviceInfo>> listDevices() async {
-    if (Platform.isAndroid) return _listDevicesAndroid();
+    if (Platform.isAndroid) {
+      final currentPlaybackDevice = _currentAndroidPlaybackDeviceIfReusable(
+        requireActivatableDeviceName: false,
+      );
+      if (currentPlaybackDevice != null) {
+        debugPrint(
+          'Uac2Service.listDevices (Android): reusing frozen direct USB device '
+          '${_describeAndroidDevice(currentPlaybackDevice)}',
+        );
+        return [currentPlaybackDevice];
+      }
+      return _listDevicesAndroid();
+    }
     if (!rust_uac2.uac2IsAvailable()) return [];
     try {
       return rust_uac2.uac2ListDevices();
@@ -764,13 +785,7 @@ class Uac2Service {
     }
 
     final preferredDevice = await _resolvePreferredAndroidDevice(null);
-    try {
-      await _channel.invokeMethod<bool>('setDirectUsbPlaybackActive', {
-        'active': false,
-      });
-    } catch (e) {
-      debugPrint('Uac2Service.setDirectUsbPlaybackActive(false) failed: $e');
-    }
+    await _setAndroidDirectUsbPlaybackActive(false);
     try {
       await _channel.invokeMethod<bool>('clearDirectUsbPlaybackFormat');
     } catch (e) {
@@ -889,15 +904,7 @@ class Uac2Service {
       debugPrint('Uac2Service.disconnect failed: $e');
     } finally {
       if (Platform.isAndroid) {
-        try {
-          await _channel.invokeMethod<bool>('setDirectUsbPlaybackActive', {
-            'active': false,
-          });
-        } catch (e) {
-          debugPrint(
-            'Uac2Service.setDirectUsbPlaybackActive(false) failed: $e',
-          );
-        }
+        await _setAndroidDirectUsbPlaybackActive(false);
         try {
           await _channel.invokeMethod<bool>('deactivateDirectUsb');
         } catch (e) {
@@ -918,6 +925,11 @@ class Uac2Service {
   Future<bool> setVolume(double volume) async {
     if (_currentDeviceStatus == null) return false;
     if (volume < 0.0 || volume > 1.0) return false;
+    if (Platform.isAndroid &&
+        _currentDeviceStatus!.hasVolumeControl &&
+        !_currentDeviceStatus!.volumeControlWritable) {
+      return false;
+    }
 
     try {
       if (Platform.isAndroid) {
@@ -960,6 +972,11 @@ class Uac2Service {
 
   Future<bool> setMute(bool muted) async {
     if (_currentDeviceStatus == null) return false;
+    if (Platform.isAndroid &&
+        _currentDeviceStatus!.hasVolumeControl &&
+        !_currentDeviceStatus!.volumeControlWritable) {
+      return false;
+    }
 
     try {
       if (Platform.isAndroid) {
@@ -1172,41 +1189,78 @@ class Uac2Service {
     Uac2AudioFormat? formatOverride,
     AudioEngineType? playbackMode,
   }) async {
+    final syncGeneration = ++_playbackStatusSyncGeneration;
+    final hasActiveSong = song != null;
     _lastKnownFormat = formatOverride;
     _lastKnownIsPlaying = isPlaying;
-    _lastKnownHasSong = song != null;
+    _lastKnownHasSong = hasActiveSong;
 
     if (Platform.isAndroid) {
       final usingExperimentalUsb =
           playbackMode == AudioEngineType.usbDacExperimental;
+      final shouldMarkDirectPlaybackActive =
+          _shouldKeepAndroidDirectUsbPlaybackActive(
+            usingExperimentalUsb: usingExperimentalUsb,
+            isPlaying: isPlaying,
+            hasActiveSong: hasActiveSong,
+          );
       Uac2DeviceInfo? resolvedPreferredDevice;
       if (usingExperimentalUsb) {
         resolvedPreferredDevice =
+            _currentAndroidPlaybackDeviceIfReusable(
+              requireActivatableDeviceName: true,
+            ) ??
             await _resolvePreferredAndroidActivationDevice(null);
+        if (!_isCurrentPlaybackStatusSync(syncGeneration)) {
+          return;
+        }
         if (resolvedPreferredDevice != null &&
             (resolvedPreferredDevice.deviceName?.isNotEmpty ?? false) &&
             _shouldActivateAndroidDirectUsb(resolvedPreferredDevice)) {
           await selectDevice(resolvedPreferredDevice);
+          if (!_isCurrentPlaybackStatusSync(syncGeneration)) {
+            return;
+          }
         }
       } else {
         resolvedPreferredDevice = await _resolvePreferredAndroidDevice(null);
+        if (!_isCurrentPlaybackStatusSync(syncGeneration)) {
+          return;
+        }
       }
 
-      final shouldMarkDirectPlaybackActive =
-          usingExperimentalUsb && isPlaying && song != null;
-      try {
-        await _channel.invokeMethod<bool>('setDirectUsbPlaybackActive', {
-          'active': shouldMarkDirectPlaybackActive,
-        });
-      } catch (e) {
-        debugPrint('Uac2Service.setDirectUsbPlaybackActive failed: $e');
+      // Caller should pass isPlaying=true while Rust holds the live USB stream
+      // (including buffering), and a non-null [song] whenever a track is loaded
+      // so we do not abandon direct USB audio focus mid-stream.
+      await _setAndroidDirectUsbPlaybackActive(shouldMarkDirectPlaybackActive);
+      if (!_isCurrentPlaybackStatusSync(syncGeneration)) {
+        return;
+      }
+
+      if (_canReuseActiveAndroidDirectPlaybackStatus(
+        preferredDevice: resolvedPreferredDevice,
+        directPlaybackActive: shouldMarkDirectPlaybackActive,
+        hasActiveSong: hasActiveSong,
+      )) {
+        _updateStatus(
+          _currentDeviceStatus!.copyWith(
+            device: resolvedPreferredDevice ?? _currentDeviceStatus!.device,
+            state: isPlaying
+                ? Uac2State.streaming
+                : _currentDeviceStatus!.state,
+            errorMessage: null,
+            currentFormat: formatOverride ?? _lastKnownFormat,
+          ),
+        );
+        return;
       }
 
       await _refreshAndroidRouteStatus(
         preferredDevice: resolvedPreferredDevice,
         formatOverride: formatOverride,
         isPlaying: isPlaying,
-        hasActiveSong: song != null,
+        hasActiveSong: hasActiveSong,
+        syncGeneration: syncGeneration,
       );
       return;
     }
@@ -1226,13 +1280,22 @@ class Uac2Service {
     Uac2AudioFormat? formatOverride,
     bool? isPlaying,
     bool? hasActiveSong,
+    int? syncGeneration,
   }) async {
     final resolvedPreferredDevice = await _resolvePreferredAndroidDevice(
       preferredDevice,
     );
+    if (syncGeneration != null &&
+        !_isCurrentPlaybackStatusSync(syncGeneration)) {
+      return;
+    }
     final routeStatus = await _getAndroidRouteStatus(
       preferredDevice: resolvedPreferredDevice,
     );
+    if (syncGeneration != null &&
+        !_isCurrentPlaybackStatusSync(syncGeneration)) {
+      return;
+    }
     final effectiveFormat = formatOverride ?? _lastKnownFormat;
     final effectiveIsPlaying = isPlaying ?? _lastKnownIsPlaying;
     final effectiveHasSong = hasActiveSong ?? _lastKnownHasSong;
@@ -1277,6 +1340,8 @@ class Uac2Service {
       routeStatus['volumeMode'] as String?,
     );
     final hasVolumeControl = routeStatus['hasVolumeControl'] == true;
+    final volumeControlWritable =
+        hasVolumeControl && routeStatus['volumeControlWritable'] != false;
     final volume = (routeStatus['volume'] as num?)?.toDouble();
     final muted = routeStatus['muted'] as bool?;
 
@@ -1308,6 +1373,7 @@ class Uac2Service {
           isExternalRoute: false,
           volumeMode: volumeMode,
           hasVolumeControl: hasVolumeControl,
+          volumeControlWritable: volumeControlWritable,
           volume: volume,
           muted: muted,
         ),
@@ -1349,6 +1415,7 @@ class Uac2Service {
             isExternal || preferredUsbDetected || directUsbRegistered,
         volumeMode: volumeMode,
         hasVolumeControl: hasVolumeControl,
+        volumeControlWritable: volumeControlWritable,
         volume: volume,
         muted: muted,
       ),
@@ -1363,6 +1430,11 @@ class Uac2Service {
         routeLabel: null,
         maxSampleRate: null,
       );
+    }
+
+    final frozenCapabilityInfo = _frozenAndroidAudioCapabilityInfo();
+    if (frozenCapabilityInfo != null) {
+      return frozenCapabilityInfo;
     }
 
     final resolvedPreferredDevice = await _resolvePreferredAndroidDevice(null);
@@ -1412,6 +1484,23 @@ class Uac2Service {
         maxSampleRate: null,
       );
     }
+  }
+
+  rust_audio.AudioCapabilityInfo? _frozenAndroidAudioCapabilityInfo() {
+    if (!_hasFrozenAndroidDirectUsbSession()) {
+      return null;
+    }
+
+    final currentStatus = _currentDeviceStatus!;
+
+    return rust_audio.AudioCapabilityInfo(
+      capabilities: const [rust_audio.AudioCapabilityType.usbDac],
+      routeType: 'usb',
+      routeLabel: currentStatus.routeLabel ?? currentStatus.device.productName,
+      maxSampleRate:
+          currentStatus.currentFormat?.sampleRate ??
+          _lastKnownFormat?.sampleRate,
+    );
   }
 
   Future<Map<String, dynamic>?> getAndroidPlaybackDebugState() async {
@@ -1474,6 +1563,15 @@ class Uac2Service {
     Uac2DeviceInfo? preferredDevice, {
     required bool requireActivatableDeviceName,
   }) async {
+    final currentPlaybackDevice = _currentAndroidPlaybackDeviceIfReusable(
+      requireActivatableDeviceName: requireActivatableDeviceName,
+    );
+    if (currentPlaybackDevice != null &&
+        (preferredDevice == null ||
+            _isSameAndroidDevice(currentPlaybackDevice, preferredDevice))) {
+      return currentPlaybackDevice;
+    }
+
     final preferredRouteLabelHint =
         _currentDeviceStatus?.routeLabel ?? preferredDevice?.productName;
 
@@ -1551,6 +1649,20 @@ class Uac2Service {
   ) async {
     if (!Platform.isAndroid || preferredDevice == null) {
       return preferredDevice;
+    }
+
+    final currentPlaybackDevice = _currentAndroidPlaybackDeviceIfReusable(
+      requireActivatableDeviceName: false,
+    );
+    if (currentPlaybackDevice != null &&
+        (_isSameAndroidDevice(currentPlaybackDevice, preferredDevice) ||
+            currentPlaybackDevice.deviceName == preferredDevice.deviceName ||
+            _matchesAndroidIdentifierAlias(
+              preferredDevice.serial,
+              currentPlaybackDevice.deviceName,
+            ) ||
+            preferredDevice.serial == currentPlaybackDevice.serial)) {
+      return currentPlaybackDevice;
     }
 
     final devices = await _listDevicesAndroid();
@@ -1688,8 +1800,108 @@ class Uac2Service {
       return true;
     }
 
-    return currentStatus.state == Uac2State.error ||
-        !currentStatus.isExternalRoute;
+    // Retry activation only after an explicit error. Do not use
+    // !isExternalRoute: Android route labels flicker (e.g. internal codename vs
+    // "USB-Audio - …") while the DAC is stable; syncPlaybackStatus would then
+    // call selectDevice/activateDirectUsb again during libusb streaming and can
+    // trigger libusb_handle_events I/O failures.
+    return currentStatus.state == Uac2State.error;
+  }
+
+  Uac2DeviceInfo? _currentAndroidPlaybackDeviceIfReusable({
+    required bool requireActivatableDeviceName,
+  }) {
+    final currentStatus = _currentDeviceStatus;
+    if (currentStatus == null ||
+        currentStatus.state == Uac2State.error ||
+        !_hasFrozenAndroidDirectUsbSession()) {
+      return null;
+    }
+
+    final device = currentStatus.device;
+    if (requireActivatableDeviceName &&
+        !(device.deviceName?.isNotEmpty ?? false)) {
+      return null;
+    }
+    return device;
+  }
+
+  bool _canReuseActiveAndroidDirectPlaybackStatus({
+    required Uac2DeviceInfo? preferredDevice,
+    required bool directPlaybackActive,
+    required bool hasActiveSong,
+  }) {
+    if (!directPlaybackActive || !hasActiveSong) {
+      return false;
+    }
+
+    final currentStatus = _currentDeviceStatus;
+    if (currentStatus == null ||
+        currentStatus.state == Uac2State.error ||
+        currentStatus.routeType != Uac2RouteType.externalUsb) {
+      return false;
+    }
+
+    if (preferredDevice == null) {
+      return true;
+    }
+    return _isSameAndroidDevice(currentStatus.device, preferredDevice);
+  }
+
+  bool _shouldKeepAndroidDirectUsbPlaybackActive({
+    required bool usingExperimentalUsb,
+    required bool isPlaying,
+    required bool hasActiveSong,
+  }) {
+    if (!usingExperimentalUsb || !hasActiveSong) {
+      return false;
+    }
+    if (isPlaying) {
+      return true;
+    }
+
+    return _hasFrozenAndroidDirectUsbSession();
+  }
+
+  bool _hasFrozenAndroidDirectUsbSession() {
+    if (!Platform.isAndroid) {
+      return false;
+    }
+
+    final currentStatus = _currentDeviceStatus;
+    if (currentStatus == null || currentStatus.state == Uac2State.error) {
+      return false;
+    }
+
+    final looksLikeActiveUsbRoute =
+        currentStatus.routeType == Uac2RouteType.externalUsb ||
+        (currentStatus.isExternalRoute &&
+            _hasUsbLookupIdentity(currentStatus.device));
+    if (!looksLikeActiveUsbRoute) {
+      return false;
+    }
+
+    return _lastDirectUsbPlaybackActive == true ||
+        currentStatus.state == Uac2State.streaming;
+  }
+
+  bool _isCurrentPlaybackStatusSync(int generation) {
+    return generation == _playbackStatusSyncGeneration;
+  }
+
+  Future<void> _setAndroidDirectUsbPlaybackActive(bool active) async {
+    if (_lastDirectUsbPlaybackActive == active) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<bool>('setDirectUsbPlaybackActive', {
+        'active': active,
+      });
+      _lastDirectUsbPlaybackActive = active;
+    } catch (e) {
+      debugPrint('Uac2Service.setDirectUsbPlaybackActive failed: $e');
+    }
   }
 
   bool _isSameAndroidDevice(Uac2DeviceInfo a, Uac2DeviceInfo b) {

--- a/lib/widgets/uac2/uac2_volume_control.dart
+++ b/lib/widgets/uac2/uac2_volume_control.dart
@@ -82,6 +82,8 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
 
     final effectiveVolume = _draggingVolume ?? (deviceStatus.volume ?? 1.0);
     final effectiveMuted = deviceStatus.muted ?? false;
+    final volumeControlWritable =
+        deviceStatus.volumeControlWritable && !_muteUpdateInFlight;
 
     return Container(
       padding: const EdgeInsets.all(AppConstants.spacingMd),
@@ -131,7 +133,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                   effectiveMuted ? LucideIcons.volumeX : LucideIcons.volume2,
                   size: 20,
                 ),
-                onPressed: _muteUpdateInFlight ? null : _toggleMute,
+                onPressed: volumeControlWritable ? _toggleMute : null,
                 color: effectiveMuted
                     ? Colors.red.shade400
                     : context.adaptiveTextSecondary,
@@ -154,8 +156,10 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                   max: 1.0,
                   divisions: 100,
                   label: '${(effectiveVolume * 100).round()}%',
-                  onChanged: _onSliderChanged,
-                  onChangeEnd: _onSliderChangeEnd,
+                  onChanged: volumeControlWritable ? _onSliderChanged : null,
+                  onChangeEnd: volumeControlWritable
+                      ? _onSliderChangeEnd
+                      : null,
                   activeColor: AppColors.accent,
                   inactiveColor: AppColors.textTertiary.withValues(alpha: 0.3),
                 ),
@@ -179,6 +183,15 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
               ),
             ],
           ),
+          if (!deviceStatus.volumeControlWritable) ...[
+            const SizedBox(height: AppConstants.spacingXs),
+            Text(
+              'Hardware volume is detected, but writes stay blocked while live direct USB playback is active.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextTertiary,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "flutter_rust_bridge",
  "jni",
  "jwalk",
+ "libc",
  "libusb1-sys",
  "lofty",
  "log",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] } # Often useful particularly w
 serde_json = "1.0"
 parking_lot = "0.12"             # Faster mutexes
 once_cell = "1.19"               # Lazy static initialization
+libc = "0.2"
 
 # Error handling (UAC2 + general)
 thiserror = "1.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -129,15 +129,26 @@ pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeRegist
     let serial = read_string(&mut env, serial);
     let device_name = read_string(&mut env, device_name);
 
-    match crate::uac2::register_android_usb_device(crate::uac2::AndroidDirectUsbDevice {
+    let device = match crate::uac2::AndroidDirectUsbDevice::try_new(
         fd,
-        vendor_id: vendor_id as u16,
-        product_id: product_id as u16,
+        vendor_id as u16,
+        product_id as u16,
         product_name,
         manufacturer,
         serial,
         device_name,
-    }) {
+    ) {
+        Ok(device) => device,
+        Err(error) => {
+            eprintln!(
+                "Failed to prepare Android direct USB DAC registration: {}",
+                error
+            );
+            return 0;
+        }
+    };
+
+    match crate::uac2::register_android_usb_device(device) {
         Ok(()) => 1,
         Err(error) => {
             eprintln!("Failed to register Android direct USB DAC: {}", error);
@@ -400,6 +411,27 @@ pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeClearR
 
 #[cfg(all(target_os = "android", feature = "uac2"))]
 #[no_mangle]
+pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeWaitRustDirectUsbSessionStopped(
+    _env: JNIEnv<'_>,
+    _activity: JObject<'_>,
+    timeout_ms: jint,
+) -> jboolean {
+    crate::uac2::wait_for_android_usb_session_stop(std::time::Duration::from_millis(
+        timeout_ms.max(0) as u64,
+    )) as jboolean
+}
+
+#[cfg(all(target_os = "android", feature = "uac2"))]
+#[no_mangle]
+pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeIsRustDirectUsbSessionActive(
+    _env: JNIEnv<'_>,
+    _activity: JObject<'_>,
+) -> jboolean {
+    crate::uac2::is_usb_session_active() as jboolean
+}
+
+#[cfg(all(target_os = "android", feature = "uac2"))]
+#[no_mangle]
 pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeMarkRustDirectUsbFallback(
     mut env: JNIEnv<'_>,
     _activity: JObject<'_>,
@@ -432,6 +464,25 @@ pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeMarkRu
 #[cfg(all(target_os = "android", not(feature = "uac2")))]
 #[no_mangle]
 pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeClearRustDirectUsbPlayback(
+    _env: JNIEnv<'_>,
+    _activity: JObject<'_>,
+) -> jboolean {
+    0
+}
+
+#[cfg(all(target_os = "android", not(feature = "uac2")))]
+#[no_mangle]
+pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeWaitRustDirectUsbSessionStopped(
+    _env: JNIEnv<'_>,
+    _activity: JObject<'_>,
+    _timeout_ms: jint,
+) -> jboolean {
+    1
+}
+
+#[cfg(all(target_os = "android", not(feature = "uac2")))]
+#[no_mangle]
+pub extern "system" fn Java_com_ultraelectronica_flick_MainActivity_nativeIsRustDirectUsbSessionActive(
     _env: JNIEnv<'_>,
     _activity: JObject<'_>,
 ) -> jboolean {

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -141,9 +141,23 @@ fn transport_container_preference_rank(
     }
 }
 
+#[derive(Debug)]
+struct AndroidDirectUsbOwnedFd(RawFd);
+
+impl Drop for AndroidDirectUsbOwnedFd {
+    fn drop(&mut self) {
+        if self.0 >= 0 {
+            unsafe {
+                libc::close(self.0);
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AndroidDirectUsbDevice {
     pub fd: RawFd,
+    _fd_owner: Arc<AndroidDirectUsbOwnedFd>,
     pub vendor_id: u16,
     pub product_id: u16,
     pub product_name: String,
@@ -152,7 +166,38 @@ pub struct AndroidDirectUsbDevice {
     pub device_name: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+impl AndroidDirectUsbDevice {
+    pub fn try_new(
+        fd: RawFd,
+        vendor_id: u16,
+        product_id: u16,
+        product_name: String,
+        manufacturer: String,
+        serial: Option<String>,
+        device_name: Option<String>,
+    ) -> Result<Self, String> {
+        let duplicated_fd = unsafe { libc::dup(fd) };
+        if duplicated_fd < 0 {
+            return Err(format!(
+                "Failed to duplicate Android USB file descriptor: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+
+        Ok(Self {
+            fd: duplicated_fd,
+            _fd_owner: Arc::new(AndroidDirectUsbOwnedFd(duplicated_fd)),
+            vendor_id,
+            product_id,
+            product_name,
+            manufacturer,
+            serial,
+            device_name,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AndroidDirectUsbPlaybackFormat {
     pub sample_rate: u32,
     pub bit_depth: u8,
@@ -776,8 +821,14 @@ static DIRECT_USB_STATE: Lazy<Mutex<Option<AndroidDirectUsbState>>> =
 static DIRECT_USB_LOCK: Lazy<Mutex<Option<AndroidDirectUsbLock>>> = Lazy::new(|| Mutex::new(None));
 static DIRECT_USB_LIFECYCLE_STATE: Lazy<Mutex<AndroidDirectUsbLifecycleState>> =
     Lazy::new(|| Mutex::new(AndroidDirectUsbLifecycleState::default()));
+/// Serializes JNI hardware volume/mute control transfers. Reusing the idle
+/// `DIRECT_USB_LOCK` handle for feature-unit writes would require partial
+/// interface release; a second transient open remains necessary, but we avoid
+/// overlapping transient claims from concurrent UI/sync calls.
+static ANDROID_DIRECT_HARDWARE_VOLUME_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 static DIRECT_USB_DISCOVERY_DISABLED: Once = Once::new();
 static ANDROID_DIRECT_USB_ENABLED: AtomicBool = AtomicBool::new(true);
+static USB_SESSION_CLEAR_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// Global guard: only one USB streaming session may be active at a time.
 /// Prevents "Resource busy" from concurrent or overlapping claim attempts.
@@ -795,27 +846,77 @@ pub fn is_usb_session_active() -> bool {
     USB_SESSION_ACTIVE.load(Ordering::SeqCst)
 }
 
+fn is_same_android_usb_device(a: &AndroidDirectUsbDevice, b: &AndroidDirectUsbDevice) -> bool {
+    if a.device_name.is_some() && b.device_name.is_some() && a.device_name == b.device_name {
+        return true;
+    }
+
+    if a.vendor_id != b.vendor_id || a.product_id != b.product_id {
+        return false;
+    }
+
+    if a.serial.is_some() && b.serial.is_some() {
+        return a.serial == b.serial;
+    }
+
+    a.product_name == b.product_name && a.manufacturer == b.manufacturer
+}
+
+fn clear_android_usb_device_state() {
+    release_idle_lock();
+    if DIRECT_USB_LIFECYCLE_STATE.lock().engine_state != AndroidDirectUsbEngineState::Fallback {
+        set_android_usb_engine_state(AndroidDirectUsbEngineState::Idle, None);
+    }
+    *DIRECT_USB_STATE.lock() = None;
+}
+
+fn clear_android_usb_device_now() {
+    USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
+    USB_SESSION_CLEAR_PENDING.store(false, Ordering::SeqCst);
+    clear_android_usb_device_state();
+}
+
+fn complete_pending_android_usb_clear_if_idle() {
+    if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
+        return;
+    }
+    if !USB_SESSION_CLEAR_PENDING.swap(false, Ordering::SeqCst) {
+        return;
+    }
+
+    eprintln!("Android USB direct: applying deferred clear after session stop");
+    clear_android_usb_device_state();
+}
+
 /// Force-release the USB session guard. Called before re-initialization or on
 /// unrecoverable errors to ensure the next attempt can proceed.
 pub fn force_release_usb_session() {
     if USB_SESSION_ACTIVE.swap(false, Ordering::SeqCst) {
         eprintln!("Android USB direct: force-released USB session guard");
     }
+    complete_pending_android_usb_clear_if_idle();
 }
 
 pub fn register_android_usb_device(device: AndroidDirectUsbDevice) -> Result<(), String> {
+    let mut guard = DIRECT_USB_STATE.lock();
     if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
-        eprintln!(
-            "Android USB direct: USB session active while registering '{}'; \
-             new idle lock will be created after the session ends",
+        if let Some(current_state) = guard.as_ref() {
+            if is_same_android_usb_device(&current_state.device, &device) {
+                eprintln!(
+                    "Android USB direct: ignoring duplicate registration for '{}' while the session is active",
+                    device.product_name
+                );
+                return Ok(());
+            }
+        }
+        return Err(format!(
+            "Android direct USB session is still active; refusing to replace registration for '{}'",
             device.product_name
-        );
+        ));
     }
 
-    let existing_format = DIRECT_USB_STATE
-        .lock()
-        .as_ref()
-        .and_then(|state| state.playback_format);
+    USB_SESSION_CLEAR_PENDING.store(false, Ordering::SeqCst);
+    let existing_format = guard.as_ref().and_then(|state| state.playback_format);
 
     let capability_model = inspect_android_usb_capabilities(&device).ok();
     let dac_clock_policy =
@@ -832,7 +933,7 @@ pub fn register_android_usb_device(device: AndroidDirectUsbDevice) -> Result<(),
 
     release_idle_lock();
     set_android_usb_engine_state(AndroidDirectUsbEngineState::Idle, None);
-    *DIRECT_USB_STATE.lock() = Some(AndroidDirectUsbState {
+    *guard = Some(AndroidDirectUsbState {
         device,
         requested_playback_format: existing_format,
         playback_format: existing_format,
@@ -874,13 +975,23 @@ pub fn set_android_usb_playback_format(
     };
 
     let sanitized = playback_format.map(|format| {
-        let mut format = sanitize_android_usb_playback_format(format);
+        let format = sanitize_android_usb_playback_format(format);
         match state.dac_clock_policy {
             DacClockPolicy::Force48kHzOnly => {}
             DacClockPolicy::RequireVerifiedRate | DacClockPolicy::AllowUnverified => {}
         }
         format
     });
+
+    if USB_SESSION_ACTIVE.load(Ordering::SeqCst)
+        && state.playback_format == sanitized
+        && state.requested_playback_format == sanitized
+    {
+        eprintln!(
+            "[USB] Keeping active direct USB verification state for unchanged playback format"
+        );
+        return Ok(());
+    }
 
     state.playback_format = sanitized;
     state.requested_playback_format = sanitized;
@@ -921,12 +1032,26 @@ pub fn set_android_usb_lock_enabled(enabled: bool) -> Result<(), String> {
 }
 
 pub fn clear_android_usb_device() {
-    release_idle_lock();
-    USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
-    if DIRECT_USB_LIFECYCLE_STATE.lock().engine_state != AndroidDirectUsbEngineState::Fallback {
-        set_android_usb_engine_state(AndroidDirectUsbEngineState::Idle, None);
+    USB_SESSION_CLEAR_PENDING.store(true, Ordering::SeqCst);
+    if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
+        eprintln!("Android USB direct: deferring clear until the active session stops");
+        return;
     }
-    *DIRECT_USB_STATE.lock() = None;
+
+    clear_android_usb_device_now();
+}
+
+pub fn wait_for_android_usb_session_stop(timeout: Duration) -> bool {
+    let started_at = Instant::now();
+    while USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
+        if started_at.elapsed() >= timeout {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    complete_pending_android_usb_clear_if_idle();
+    true
 }
 
 pub fn android_direct_output_signature(preferred_sample_rate: Option<u32>) -> Option<String> {
@@ -2372,6 +2497,7 @@ pub fn android_direct_cached_hardware_mute() -> Option<bool> {
 }
 
 pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
+    let _hold = ANDROID_DIRECT_HARDWARE_VOLUME_MUTEX.lock();
     let state = DIRECT_USB_STATE
         .lock()
         .as_ref()
@@ -2414,6 +2540,7 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
 }
 
 pub fn android_direct_set_hardware_mute(muted: bool) -> Result<(), String> {
+    let _hold = ANDROID_DIRECT_HARDWARE_VOLUME_MUTEX.lock();
     let state = DIRECT_USB_STATE
         .lock()
         .as_ref()
@@ -2626,6 +2753,14 @@ pub fn create_android_usb_backend(
     event_tx: Sender<AudioEvent>,
     preferred_sample_rate: u32,
 ) -> Result<Option<AndroidDirectUsbBackend>, String> {
+    if USB_SESSION_CLEAR_PENDING.load(Ordering::SeqCst) {
+        eprintln!(
+            "Android USB direct backend skipped: clear requested before startup for preferred {} Hz",
+            preferred_sample_rate
+        );
+        return Ok(None);
+    }
+
     // Wait for any previous USB session to finish cleanup (up to 1.5s).
     // This prevents "Resource busy" when the engine is recreated for a
     // new track before the old backend's threads have fully stopped.
@@ -3464,6 +3599,7 @@ impl AndroidDirectUsbBackend {
                 .map_err(|_| "Android USB direct output thread panicked".to_string())?;
         }
         USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
+        complete_pending_android_usb_clear_if_idle();
         Ok(())
     }
 }
@@ -3472,6 +3608,7 @@ impl Drop for AndroidDirectUsbBackend {
     fn drop(&mut self) {
         let _ = self.stop();
         USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
+        complete_pending_android_usb_clear_if_idle();
     }
 }
 
@@ -3946,6 +4083,15 @@ fn run_usb_output_loop(
         candidate.service_interval_us,
     );
     let transfer_slot_count = ANDROID_USB_TRANSFER_QUEUE_DEPTH.max(1);
+    let feedback_endpoint = candidate
+        .feedback_endpoint
+        .filter(|feedback| feedback.transfer_type == TransferType::Interrupt);
+    if candidate.feedback_endpoint.is_some() && feedback_endpoint.is_none() {
+        log_info!(
+            "[USB] Skipping live isochronous feedback polling on endpoint 0x{:02x} to keep the libusb event loop single-threaded",
+            candidate.feedback_endpoint.unwrap().address,
+        );
+    }
     runtime_stats
         .transfer_queue_depth
         .store(transfer_slot_count, Ordering::Relaxed);
@@ -4087,7 +4233,7 @@ fn run_usb_output_loop(
                 .consumer_frames
                 .fetch_add(queued_frame_count, Ordering::Relaxed);
 
-            if let Some(feedback_endpoint) = candidate.feedback_endpoint {
+            if let Some(feedback_endpoint) = feedback_endpoint {
                 match read_feedback_report(&context, &handle, feedback_endpoint, device_fd) {
                     Ok(Some(feedback_report)) => {
                         scheduler
@@ -4193,7 +4339,7 @@ fn run_usb_output_loop(
                 if !completed_underrun {
                     set_usb_stream_stable(true);
                     if !logged_usb_stabilized {
-                        if candidate.feedback_endpoint.is_none() {
+                        if feedback_endpoint.is_none() {
                             scheduler.lock_to_nominal_packet_timing();
                             log_info!(
                                 "[USB] USB stream stabilized after {} isochronous transfers (nominal packet timing locked)",
@@ -4242,6 +4388,7 @@ fn run_usb_output_loop(
     set_runtime_stats(None);
     set_usb_stream_stable(false);
     USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
+    complete_pending_android_usb_clear_if_idle();
     if stop.load(Ordering::Acquire) {
         set_android_usb_engine_state(AndroidDirectUsbEngineState::Idle, None);
     }
@@ -4262,7 +4409,10 @@ fn read_feedback_report(
 ) -> Result<Option<AndroidUsbFeedbackReport>, String> {
     let raw_bytes = match feedback_endpoint.transfer_type {
         TransferType::Interrupt => read_interrupt_feedback_packet(handle, feedback_endpoint)?,
-        TransferType::Isochronous => read_iso_feedback_packet(context, handle, feedback_endpoint)?,
+        TransferType::Isochronous => {
+            let _ = context;
+            return Ok(None);
+        }
         other => {
             return Err(format!(
                 "Unsupported feedback transfer type {}",
@@ -4287,6 +4437,7 @@ fn read_feedback_report(
     }))
 }
 
+#[allow(dead_code)]
 fn read_interrupt_feedback_packet(
     handle: &DeviceHandle<Context>,
     feedback_endpoint: AndroidUsbFeedbackEndpoint,
@@ -5688,6 +5839,7 @@ extern "system" fn iso_transfer_callback(transfer: *mut libusb_transfer) {
     completion.condvar.notify_all();
 }
 
+#[allow(dead_code)]
 fn submit_iso_transfer(
     context: &Context,
     handle: &DeviceHandle<Context>,
@@ -5777,6 +5929,7 @@ fn submit_iso_transfer(
     }
 }
 
+#[allow(dead_code)]
 fn read_iso_feedback_packet(
     context: &Context,
     handle: &DeviceHandle<Context>,

--- a/rust/src/uac2/mod.rs
+++ b/rust/src/uac2/mod.rs
@@ -69,8 +69,9 @@ pub use android_direct::{
     create_android_usb_backend, force_release_usb_session, is_usb_session_active,
     mark_android_usb_fallback, negotiate_android_direct_output_sample_rate,
     register_android_usb_device, set_android_direct_usb_enabled, set_android_usb_lock_enabled,
-    set_android_usb_playback_format, validate_android_direct_request, AndroidDirectUsbBackend,
-    AndroidDirectUsbDebugState, AndroidDirectUsbDevice, AndroidDirectUsbPlaybackFormat,
+    set_android_usb_playback_format, validate_android_direct_request,
+    wait_for_android_usb_session_stop, AndroidDirectUsbBackend, AndroidDirectUsbDebugState,
+    AndroidDirectUsbDevice, AndroidDirectUsbPlaybackFormat,
 };
 #[cfg(feature = "uac2")]
 pub use audio_format::{


### PR DESCRIPTION
# Summary

- Add folder view in `SongsScreen` with expand/collapse functionality
- Add `folderUri` to Song model for folder organization
- Enhance direct USB audio management with volume and session handling
- Add user feedback for blocked volume writes during live USB playback

# Changes

## Folder View

- Add `folderUri` property to Song model
- Add folder-based sorting to `SongSortOption`
- Add folder grouping logic in `SongsState`
- Implement `FolderHeader` widget with expand/collapse
- Display songs organized by folders in `SongsScreen`

## USB Audio Management

- Add hardware volume and mute state tracking in MainActivity
- Add direct USB audio focus and session state methods
- Implement Isochronous packet scheduling improvements
- Add debounce mechanism for playback diagnostics updates
- Freeze direct USB session queries based on playback state

## Volume Control

- Add writable volume control flag to `Uac2DeviceStatus`
- Disable volume controls when not writable
- Add user feedback for blocked volume writes
- Synchronize playback status with hardware volume controls

## Other

- Add `libc` dependency for system calls
- Refactor queue button in player screen

# Files Changed

- `lib/models/song.dart` — folderUri property
- `lib/providers/songs_provider.dart` — Folder grouping logic
- `lib/features/songs/screens/songs_screen.dart` — Folder view UI
- `lib/services/player_service.dart` — Volume sync
- `lib/services/uac2_service.dart` — Session handling
- `android/app/src/main/kotlin/.../MainActivity.kt` — Native methods
- `lib/widgets/uac2/uac2_volume_control.dart` — Volume widget
- `rust/Cargo.toml` — libc dependency