### PR TITLE
Add album art picker, poster save, Shorebird updates, and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ The Rust backend communicates with Flutter via `flutter_rust_bridge`, providing:
 
 ## Documentation
 
+- `docs/SHOREBIRD_SETUP.md`: Shorebird release, preview, and patch workflow for in-app updates.
+
 Additional documentation is available in the `docs/` directory:
 - `DOCUMENTATION.md`: Detailed architecture and design documentation
 - `UAC2_IMPLEMENTATION_CHECKLIST.md`: Implementation checklist for the UAC 2.0 subsystem

--- a/docs/SHOREBIRD_SETUP.md
+++ b/docs/SHOREBIRD_SETUP.md
@@ -1,0 +1,138 @@
+# Shorebird Setup
+
+This project already includes the Shorebird updater package and app id. The missing piece is how the release build is produced.
+
+## Why `flutter run --release` does not work
+
+`flutter run --release` builds a normal Flutter release binary.
+
+That binary does not include Shorebird's patched engine, so `ShorebirdUpdater.isAvailable` is `false` and the app correctly reports that updates are unavailable.
+
+To receive in-app updates, the installed app must be built with `shorebird release`, then patched with `shorebird patch`.
+
+## Current repo state
+
+- `shorebird.yaml` is present with the app id for this app.
+- `shorebird_code_push` is included in `pubspec.yaml`.
+- Automatic Shorebird checks are enabled with `auto_update: true`.
+- Manual update actions in the settings screen still work and can be used to force a check or install flow from inside the app.
+
+## One-time setup
+
+1. Install the Shorebird CLI.
+2. Sign in.
+3. Verify the toolchain.
+
+```bash
+shorebird login
+shorebird doctor
+```
+
+## Create a release build
+
+Build the app with Shorebird, not plain Flutter.
+
+For Play Store style distribution:
+
+```bash
+shorebird release android
+```
+
+For local APK testing or side loading:
+
+```bash
+shorebird release android --artifact apk
+```
+
+This creates the release record Shorebird needs and produces a binary that can actually receive patches.
+
+## Test the release locally
+
+The easiest local check is:
+
+```bash
+shorebird preview
+```
+
+That installs a Shorebird-built release on a connected device or emulator.
+
+You can also install the generated APK manually, but it still must come from `shorebird release android --artifact apk`.
+
+## Publish an update
+
+1. Start from an app version that was released with Shorebird.
+2. Make Dart-only changes.
+3. Publish a patch for the same release version.
+
+```bash
+shorebird patch android
+```
+
+After the app launches, Shorebird checks for updates in the background. A downloaded patch becomes active on the next app restart.
+
+## Version matching rules
+
+Patches only apply to the exact release version they were built for.
+
+For this project, the current app version comes from `pubspec.yaml` and Android picks it up through `flutter.versionName` and `flutter.versionCode`.
+
+Example current version at the time of writing:
+
+- release version: `0.12.0-beta.2+7`
+
+If the installed build is `0.12.0-beta.2+7`, the patch must target that same release. A patch for `+8` will not apply.
+
+## What can be patched
+
+Shorebird patches Dart code.
+
+Safe candidates:
+
+- Flutter UI changes
+- business logic in Dart
+- Riverpod logic
+- pure-Dart dependency updates
+
+Not patchable:
+
+- Android or iOS native code
+- Flutter engine changes
+- new or changed assets that the patched Dart code depends on
+
+If native or asset changes are involved, ship a new release instead of a patch.
+
+## How to confirm it is working
+
+Check device logs.
+
+- If you see log lines prefixed with `[shorebird]`, the installed app is using a Shorebird release build.
+- If there are no `[shorebird]` logs, the app was not built with `shorebird release`.
+
+Useful things to verify in logs:
+
+- the `app_id`
+- the release version being requested
+- whether Shorebird reports `no active patch`
+
+If Shorebird reports `no active patch`, first verify that the installed app version exactly matches the release version you patched.
+
+## Typical Android test flow for this repo
+
+```bash
+shorebird release android --artifact apk
+shorebird preview
+```
+
+Then:
+
+1. Make a Dart-only change.
+2. Run `shorebird patch android`.
+3. Launch the app.
+4. Wait for the automatic background check, or use the manual update action in settings.
+5. Restart the app to load the patch.
+
+## Notes for this repo
+
+- The settings UI already handles manual check and install actions.
+- Automatic checks are now enabled on launch.
+- Manual update controls remain useful for testing and for forcing an update check without restarting the app.

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -149,6 +149,31 @@ class SongRepository {
     });
   }
 
+  Future<void> updateAlbumArtPaths(
+    Iterable<String> filePaths,
+    String? albumArtPath,
+  ) async {
+    final uniquePaths = filePaths.where((path) => path.isNotEmpty).toSet();
+    if (uniquePaths.isEmpty) {
+      return;
+    }
+
+    await _isar.writeTxn(() async {
+      for (final filePath in uniquePaths) {
+        final existing = await _isar.songEntitys
+            .filter()
+            .filePathEqualTo(filePath)
+            .findFirst();
+        if (existing == null || existing.albumArtPath == albumArtPath) {
+          continue;
+        }
+
+        existing.albumArtPath = albumArtPath;
+        await _isar.songEntitys.put(existing);
+      }
+    });
+  }
+
   /// Count songs in a folder.
   Future<int> countSongsInFolder(String folderUri) async {
     return await _isar.songEntitys.filter().folderUriEqualTo(folderUri).count();

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -2843,11 +2843,28 @@ class _PlayerControls extends StatelessWidget {
                               ).withValues(alpha: 0.6),
                               shape: BoxShape.circle,
                             ),
-                            child: IconButton(
-                              onPressed: () => playerService.toggleLoopMode(),
-                              iconSize: context.responsive(18.0, 20.0, 22.0),
-                              padding: EdgeInsets.zero,
-                              icon: Icon(icon, color: color),
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                IconButton(
+                                  onPressed: () => playerService.toggleLoopMode(),
+                                  iconSize: context.responsive(18.0, 20.0, 22.0),
+                                  padding: EdgeInsets.zero,
+                                  icon: Icon(icon, color: color),
+                                ),
+                                if (loopMode == LoopMode.all)
+                                  Positioned(
+                                    bottom: 6,
+                                    child: Container(
+                                      width: 4,
+                                      height: 4,
+                                      decoration: BoxDecoration(
+                                        color: AppColors.accent,
+                                        shape: BoxShape.circle,
+                                      ),
+                                    ),
+                                  ),
+                              ],
                             ),
                           );
                         },

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -10,6 +10,7 @@ import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/albums/screens/albums_screen.dart';
 import 'package:flick/features/artists/screens/artists_screen.dart';
 import 'package:flick/features/player/widgets/ambient_background.dart';
+import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart';
 import 'package:flick/models/player_screen_mode.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
@@ -773,6 +774,20 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
                 onTap: () {
                   Navigator.pop(sheetContext);
                   _showAddToPlaylistDialog(context, song);
+                },
+              ),
+              _buildSongActionTile(
+                context: sheetContext,
+                icon: LucideIcons.image,
+                label: 'Set Album Art',
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  unawaited(
+                    Future<void>.delayed(
+                      Duration.zero,
+                      () => AlbumArtPickerBottomSheet.show(context, song),
+                    ),
+                  );
                 },
               ),
               _buildSongActionTile(
@@ -1643,7 +1658,6 @@ class _AnimatedSongScene extends StatelessWidget {
                                 letterSpacing: 0.8,
                               ),
                             ),
-                          
                           ],
                         ),
                       ],
@@ -2847,8 +2861,13 @@ class _PlayerControls extends StatelessWidget {
                               alignment: Alignment.center,
                               children: [
                                 IconButton(
-                                  onPressed: () => playerService.toggleLoopMode(),
-                                  iconSize: context.responsive(18.0, 20.0, 22.0),
+                                  onPressed: () =>
+                                      playerService.toggleLoopMode(),
+                                  iconSize: context.responsive(
+                                    18.0,
+                                    20.0,
+                                    22.0,
+                                  ),
                                   padding: EdgeInsets.zero,
                                   icon: Icon(icon, color: color),
                                 ),

--- a/lib/features/player/widgets/compact_player_info_layout.dart
+++ b/lib/features/player/widgets/compact_player_info_layout.dart
@@ -202,15 +202,33 @@ class _CompactPlayerInfoLayoutState extends State<CompactPlayerInfoLayout> {
                     icon = LucideIcons.repeat1;
                     color = context.adaptiveAccent;
                   }
-                  return IconButton(
-                    onPressed: () => widget.playerService.toggleLoopMode(),
-                    padding: EdgeInsets.all(context.responsive(6.0, 8.0, 10.0)),
-                    constraints: const BoxConstraints(),
-                    icon: Icon(
-                      icon,
-                      color: color,
-                      size: context.responsive(18.0, 20.0, 22.0),
-                    ),
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    alignment: Alignment.center,
+                    children: [
+                      IconButton(
+                        onPressed: () => widget.playerService.toggleLoopMode(),
+                        padding: EdgeInsets.all(context.responsive(6.0, 8.0, 10.0)),
+                        constraints: const BoxConstraints(),
+                        icon: Icon(
+                          icon,
+                          color: color,
+                          size: context.responsive(18.0, 20.0, 22.0),
+                        ),
+                      ),
+                      if (loopMode == LoopMode.all)
+                        Positioned(
+                          bottom: 2,
+                          child: Container(
+                            width: 4,
+                            height: 4,
+                            decoration: BoxDecoration(
+                              color: context.adaptiveAccent,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        ),
+                    ],
                   );
                 },
               ),

--- a/lib/features/recap/screens/listening_recap_screen.dart
+++ b/lib/features/recap/screens/listening_recap_screen.dart
@@ -35,6 +35,8 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = {};
   bool _isLoading = true;
   bool _isSaving = false;
+  _RecapRankingPosterType? _savingPosterType;
+  _RecapRankingPosterType? _savedPosterType;
   StreamSubscription<void>? _historySubscription;
 
   @override
@@ -134,10 +136,14 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
   Future<void> _saveRankingPoster(_RecapRankingPosterType type) async {
     if (_isSaving) return;
 
-    final recap = _currentRecap();
-    setState(() => _isSaving = true);
+    setState(() {
+      _isSaving = true;
+      _savingPosterType = type;
+      _savedPosterType = null;
+    });
 
     try {
+      final recap = _currentRecap();
       final bytes = await _captureRecapPng(_rankingPosterBoundaryKey(type));
       if (bytes == null) {
         throw const GallerySaveException(
@@ -151,9 +157,19 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
       );
 
       if (!mounted) return;
+      setState(() {
+        _savingPosterType = null;
+        _savedPosterType = type;
+      });
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('${type.title} saved to your gallery')),
       );
+
+      await Future.delayed(const Duration(milliseconds: 1500));
+      if (mounted && _savedPosterType == type) {
+        setState(() => _savedPosterType = null);
+      }
     } catch (error) {
       if (!mounted) return;
       ScaffoldMessenger.of(
@@ -161,7 +177,10 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
       ).showSnackBar(SnackBar(content: Text(_saveErrorMessage(error))));
     } finally {
       if (mounted) {
-        setState(() => _isSaving = false);
+        setState(() {
+          _isSaving = false;
+          _savingPosterType = null;
+        });
       }
     }
   }
@@ -248,6 +267,10 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
                                                 _RecapRankingPosterType
                                                     .topSongs,
                                               ),
+                                        isSaving: _savingPosterType ==
+                                            _RecapRankingPosterType.topSongs,
+                                        isSuccess: _savedPosterType ==
+                                            _RecapRankingPosterType.topSongs,
                                         children: [
                                           for (
                                             var index = 0;
@@ -275,6 +298,10 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
                                                 _RecapRankingPosterType
                                                     .topArtists,
                                               ),
+                                        isSaving: _savingPosterType ==
+                                            _RecapRankingPosterType.topArtists,
+                                        isSuccess: _savedPosterType ==
+                                            _RecapRankingPosterType.topArtists,
                                         children: [
                                           for (
                                             var index = 0;
@@ -482,6 +509,8 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
     required List<Widget> children,
     String? actionLabel,
     VoidCallback? onActionTap,
+    bool isSaving = false,
+    bool isSuccess = false,
   }) {
     return Container(
       width: double.infinity,
@@ -520,7 +549,12 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
               ),
               if (actionLabel != null && onActionTap != null) ...[
                 const SizedBox(width: AppConstants.spacingSm),
-                _SectionPosterButton(label: actionLabel, onTap: onActionTap),
+                _SectionPosterButton(
+                  label: actionLabel,
+                  onTap: onActionTap,
+                  isSaving: isSaving,
+                  isSuccess: isSuccess,
+                ),
               ],
             ],
           ),
@@ -1673,15 +1707,22 @@ class _RankingTile extends StatelessWidget {
 class _SectionPosterButton extends StatelessWidget {
   final String label;
   final VoidCallback onTap;
+  final bool isSaving;
+  final bool isSuccess;
 
-  const _SectionPosterButton({required this.label, required this.onTap});
+  const _SectionPosterButton({
+    required this.label,
+    required this.onTap,
+    this.isSaving = false,
+    this.isSuccess = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: onTap,
+        onTap: isSaving ? null : onTap,
         borderRadius: BorderRadius.circular(AppConstants.radiusRound),
         child: Ink(
           padding: const EdgeInsets.symmetric(
@@ -1696,10 +1737,12 @@ class _SectionPosterButton extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(
-                Icons.crop_portrait_rounded,
-                size: 16,
-                color: context.adaptiveTextSecondary,
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                transitionBuilder: (child, animation) {
+                  return ScaleTransition(scale: animation, child: child);
+                },
+                child: _buildIcon(),
               ),
               const SizedBox(width: 6),
               Text(
@@ -1713,6 +1756,34 @@ class _SectionPosterButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildIcon() {
+    if (isSaving) {
+      return SizedBox(
+        key: const ValueKey('loading'),
+        width: 16,
+        height: 16,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(Colors.white.withValues(alpha: 0.7)),
+        ),
+      );
+    }
+    if (isSuccess) {
+      return Icon(
+        key: const ValueKey('success'),
+        Icons.check_rounded,
+        size: 16,
+        color: Colors.greenAccent,
+      );
+    }
+    return Icon(
+      key: const ValueKey('default'),
+      Icons.crop_portrait_rounded,
+      size: 16,
+      color: Colors.white.withValues(alpha: 0.7),
     );
   }
 }

--- a/lib/features/recap/screens/listening_recap_screen.dart
+++ b/lib/features/recap/screens/listening_recap_screen.dart
@@ -28,6 +28,8 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
       RecentlyPlayedRepository();
   final GallerySaveService _gallerySaveService = GallerySaveService();
   final GlobalKey _cardBoundaryKey = GlobalKey();
+  final GlobalKey _topSongsPosterBoundaryKey = GlobalKey();
+  final GlobalKey _topArtistsPosterBoundaryKey = GlobalKey();
 
   ListeningRecapPeriod _selectedPeriod = ListeningRecapPeriod.daily;
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = {};
@@ -122,13 +124,46 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
     }
   }
 
-  void _openRankingPoster(_RecapRankingPosterType type) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) =>
-            _RecapRankingPosterScreen(recap: _currentRecap(), type: type),
-      ),
-    );
+  GlobalKey _rankingPosterBoundaryKey(_RecapRankingPosterType type) {
+    return switch (type) {
+      _RecapRankingPosterType.topSongs => _topSongsPosterBoundaryKey,
+      _RecapRankingPosterType.topArtists => _topArtistsPosterBoundaryKey,
+    };
+  }
+
+  Future<void> _saveRankingPoster(_RecapRankingPosterType type) async {
+    if (_isSaving) return;
+
+    final recap = _currentRecap();
+    setState(() => _isSaving = true);
+
+    try {
+      final bytes = await _captureRecapPng(_rankingPosterBoundaryKey(type));
+      if (bytes == null) {
+        throw const GallerySaveException(
+          'The ranking poster is still rendering.',
+        );
+      }
+
+      await _gallerySaveService.saveImage(
+        bytes: bytes,
+        fileName: _buildRecapFileName(recap, variant: type.fileNameSuffix),
+      );
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${type.title} saved to your gallery')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_saveErrorMessage(error))));
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
   }
 
   @override
@@ -139,6 +174,7 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
       child: Scaffold(
         backgroundColor: AppColors.background,
         body: Stack(
+          clipBehavior: Clip.none,
           children: [
             const Positioned.fill(child: _RecapBackdrop()),
             SafeArea(
@@ -205,10 +241,10 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
                                         title: 'Top Songs',
                                         subtitle:
                                             'The tracks that defined this ${recap.period.label.toLowerCase()}',
-                                        actionLabel: 'Poster',
+                                        actionLabel: 'Download Poster',
                                         onActionTap: recap.topSongs.isEmpty
                                             ? null
-                                            : () => _openRankingPoster(
+                                            : () => _saveRankingPoster(
                                                 _RecapRankingPosterType
                                                     .topSongs,
                                               ),
@@ -232,10 +268,10 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
                                         title: 'Top Artists',
                                         subtitle:
                                             'Your most replayed voices and projects',
-                                        actionLabel: 'Poster',
+                                        actionLabel: 'Download Poster',
                                         onActionTap: recap.topArtists.isEmpty
                                             ? null
-                                            : () => _openRankingPoster(
+                                            : () => _saveRankingPoster(
                                                 _RecapRankingPosterType
                                                     .topArtists,
                                               ),
@@ -261,6 +297,11 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
                   ),
                 ],
               ),
+            ),
+            _HiddenRankingPosterCaptureHost(
+              recap: recap,
+              topSongsBoundaryKey: _topSongsPosterBoundaryKey,
+              topArtistsBoundaryKey: _topArtistsPosterBoundaryKey,
             ),
           ],
         ),
@@ -738,15 +779,6 @@ extension _RecapRankingPosterTypeX on _RecapRankingPosterType {
     };
   }
 
-  String get subtitle {
-    return switch (this) {
-      _RecapRankingPosterType.topSongs =>
-        'The tracks that owned this replay window',
-      _RecapRankingPosterType.topArtists =>
-        'The voices and projects that stayed on repeat',
-    };
-  }
-
   String get fileNameSuffix {
     return switch (this) {
       _RecapRankingPosterType.topSongs => 'top_songs',
@@ -800,176 +832,6 @@ extension _RecapRankingPosterTypeX on _RecapRankingPosterType {
         Color(0x006ECFFF),
       ],
     };
-  }
-}
-
-class _RecapRankingPosterScreen extends StatefulWidget {
-  final ListeningRecap recap;
-  final _RecapRankingPosterType type;
-
-  const _RecapRankingPosterScreen({required this.recap, required this.type});
-
-  @override
-  State<_RecapRankingPosterScreen> createState() =>
-      _RecapRankingPosterScreenState();
-}
-
-class _RecapRankingPosterScreenState extends State<_RecapRankingPosterScreen> {
-  final GlobalKey _posterBoundaryKey = GlobalKey();
-  final GallerySaveService _gallerySaveService = GallerySaveService();
-  bool _isSaving = false;
-
-  Future<void> _savePoster() async {
-    if (_isSaving) return;
-    setState(() => _isSaving = true);
-
-    try {
-      final bytes = await _captureRecapPng(_posterBoundaryKey);
-      if (bytes == null) {
-        throw const GallerySaveException(
-          'The ranking poster is still rendering.',
-        );
-      }
-
-      await _gallerySaveService.saveImage(
-        bytes: bytes,
-        fileName: _buildRecapFileName(
-          widget.recap,
-          variant: widget.type.fileNameSuffix,
-        ),
-      );
-
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Recap saved to your gallery')),
-      );
-    } catch (error) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(_saveErrorMessage(error))));
-    } finally {
-      if (mounted) {
-        setState(() => _isSaving = false);
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: Stack(
-        children: [
-          const Positioned.fill(child: _RecapBackdrop()),
-          SafeArea(
-            child: Stack(
-              children: [
-                Positioned.fill(
-                  child: Center(
-                    child: FittedBox(
-                      fit: BoxFit.contain,
-                      alignment: Alignment.center,
-                      child: RepaintBoundary(
-                        key: _posterBoundaryKey,
-                        child: _RecapRankingPosterCard(
-                          recap: widget.recap,
-                          type: widget.type,
-                          frameSize: _RecapPosterDimensions.referenceSize,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(AppConstants.spacingMd),
-                  child: Row(
-                    children: [
-                      _PosterActionIcon(
-                        icon: LucideIcons.arrowLeft,
-                        onTap: () => Navigator.of(context).pop(),
-                      ),
-                      const Spacer(),
-                      _PosterActionIcon(
-                        icon: _isSaving
-                            ? Icons.hourglass_top_rounded
-                            : Icons.download_rounded,
-                        onTap: _isSaving ? null : _savePoster,
-                      ),
-                    ],
-                  ),
-                ),
-                Positioned(
-                  left: AppConstants.spacingLg,
-                  right: AppConstants.spacingLg,
-                  bottom: AppConstants.spacingLg,
-                  child: IgnorePointer(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Container(
-                          width: double.infinity,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppConstants.spacingMd,
-                            vertical: AppConstants.spacingSm,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.32),
-                            borderRadius: BorderRadius.circular(
-                              AppConstants.radiusRound,
-                            ),
-                            border: Border.all(
-                              color: Colors.white.withValues(alpha: 0.08),
-                            ),
-                          ),
-                          child: Text(
-                            _rankingPosterSupportMessage(
-                              widget.recap,
-                              widget.type,
-                            ),
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(
-                                  height: 1.4,
-                                  color: Colors.white.withValues(alpha: 0.86),
-                                ),
-                          ),
-                        ),
-                        const SizedBox(height: AppConstants.spacingSm),
-                        Container(
-                          width: double.infinity,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppConstants.spacingMd,
-                            vertical: AppConstants.spacingSm,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.36),
-                            borderRadius: BorderRadius.circular(
-                              AppConstants.radiusRound,
-                            ),
-                            border: Border.all(
-                              color: Colors.white.withValues(alpha: 0.08),
-                            ),
-                          ),
-                          child: Text(
-                            'Use your device screenshot gesture here, or save the poster directly to your gallery.',
-                            textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodySmall
-                                ?.copyWith(
-                                  color: Colors.white.withValues(alpha: 0.8),
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }
 
@@ -1349,6 +1211,51 @@ class _RecapPosterDimensions {
   static const double referenceHeight = 760;
   static const Size referenceSize = Size(referenceWidth, referenceHeight);
   static const double aspectRatio = referenceWidth / referenceHeight;
+}
+
+class _HiddenRankingPosterCaptureHost extends StatelessWidget {
+  final ListeningRecap recap;
+  final GlobalKey topSongsBoundaryKey;
+  final GlobalKey topArtistsBoundaryKey;
+
+  const _HiddenRankingPosterCaptureHost({
+    required this.recap,
+    required this.topSongsBoundaryKey,
+    required this.topArtistsBoundaryKey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final offset = context.screenWidth + _RecapPosterDimensions.referenceWidth;
+
+    return IgnorePointer(
+      child: Transform.translate(
+        offset: Offset(offset, 0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            RepaintBoundary(
+              key: topSongsBoundaryKey,
+              child: _RecapRankingPosterCard(
+                recap: recap,
+                type: _RecapRankingPosterType.topSongs,
+                frameSize: _RecapPosterDimensions.referenceSize,
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingLg),
+            RepaintBoundary(
+              key: topArtistsBoundaryKey,
+              child: _RecapRankingPosterCard(
+                recap: recap,
+                type: _RecapRankingPosterType.topArtists,
+                frameSize: _RecapPosterDimensions.referenceSize,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _RecapBackdrop extends StatelessWidget {
@@ -2076,28 +1983,6 @@ class _RecapActionButton extends StatelessWidget {
   }
 }
 
-class _PosterActionIcon extends StatelessWidget {
-  final IconData icon;
-  final VoidCallback? onTap;
-
-  const _PosterActionIcon({required this.icon, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.glassBackground,
-        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-        border: Border.all(color: AppColors.glassBorder),
-      ),
-      child: IconButton(
-        onPressed: onTap,
-        icon: Icon(icon, color: Colors.white),
-      ),
-    );
-  }
-}
-
 Future<Uint8List?> _captureRecapPng(GlobalKey boundaryKey) async {
   await Future.delayed(const Duration(milliseconds: 32));
 
@@ -2158,26 +2043,6 @@ String _heroClosingLine(ListeningRecap recap) {
   }
 
   return 'Your listening pattern is starting to take shape.';
-}
-
-String _rankingPosterSupportMessage(
-  ListeningRecap recap,
-  _RecapRankingPosterType type,
-) {
-  final items = switch (type) {
-    _RecapRankingPosterType.topSongs => recap.topSongs,
-    _RecapRankingPosterType.topArtists => recap.topArtists,
-  };
-
-  if (items.isEmpty) {
-    return recap.period.emptyMessage;
-  }
-
-  if (items.length == 1) {
-    return 'Keep listening to expand this list.';
-  }
-
-  return type.subtitle;
 }
 
 String _formatRecapRange(ListeningRecap recap) {

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -43,7 +43,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   );
   static const String _releaseNotesUrl =
       'https://github.com/ultraelectronica/flick_player/releases/latest';
-  static const bool _updatesComingSoon = true;
+  static const bool _updatesComingSoon = false;
 
   // Sample settings state
   bool _gaplessPlayback = true;
@@ -196,16 +196,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       return;
     }
 
-    if (!_updater.isAvailable) {
-      setState(() {
-        _hasScannedForUpdates = true;
-        _lastScannedUpdateStatus = UpdateStatus.unavailable;
-        _updateCheckErrorMessage = null;
-      });
-      _showToast('Updates are unavailable in this build.');
-      return;
-    }
-
     setState(() {
       _isCheckingForUpdates = true;
       _updateCheckErrorMessage = null;
@@ -260,11 +250,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   Future<void> _installUpdate() async {
     if (_isInstallingUpdate) {
-      return;
-    }
-
-    if (!_updater.isAvailable) {
-      _showToast('Updates are unavailable in this build.');
       return;
     }
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -64,6 +64,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   bool _hasScannedForUpdates = false;
   UpdateStatus? _lastScannedUpdateStatus;
   String? _updateCheckErrorMessage;
+  bool _scanSettingsExpanded = false;
 
   // ValueNotifier for bottom sheet progress updates
   final ValueNotifier<ScanProgress?> _scanProgressNotifier = ValueNotifier(
@@ -1263,58 +1264,7 @@ SOFTWARE.
             _buildAutoSyncToggle(context),
           ],
           _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.scanSearch,
-            title: 'Filter Non-Music Files & Folders',
-            subtitle: 'Skip unsupported files and hidden .nomedia directories',
-            value: libraryScanPreferences.filterNonMusicFilesAndFolders,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setFilterNonMusicFilesAndFolders(value);
-            },
-          ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.fileMinus,
-            title: 'Ignore Tracks Under 500 KB',
-            subtitle: 'Exclude tiny clips, previews, and accidental scraps',
-            value: libraryScanPreferences.ignoreTracksSmallerThan500Kb,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setIgnoreTracksSmallerThan500Kb(value);
-            },
-          ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.timerOff,
-            title: 'Ignore Tracks Under 60 Seconds',
-            subtitle: 'Hide short stingers, ringtones, and voice fragments',
-            value: libraryScanPreferences.ignoreTracksShorterThan60Seconds,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setIgnoreTracksShorterThan60Seconds(value);
-            },
-          ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.listMusic,
-            title: 'Import M3U/M3U8 Playlists',
-            subtitle:
-                'Create or refresh playlists found inside scanned folders',
-            value: libraryScanPreferences.createPlaylistsFromM3uFiles,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setCreatePlaylistsFromM3uFiles(value);
-            },
-          ),
+          _buildExpandableScanSettings(context, libraryScanPreferences),
         ],
       ),
     );
@@ -1833,6 +1783,125 @@ SOFTWARE.
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildExpandableScanSettings(
+    BuildContext context,
+    LibraryScanPreferences prefs,
+  ) {
+    return Column(
+      children: [
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: () => setState(() => _scanSettingsExpanded = !_scanSettingsExpanded),
+            child: Padding(
+              padding: const EdgeInsets.all(AppConstants.spacingMd),
+              child: Row(
+                children: [
+                  Container(
+                    width: context.scaleSize(AppConstants.containerSizeSm),
+                    height: context.scaleSize(AppConstants.containerSizeSm),
+                    decoration: BoxDecoration(
+                      color: AppColors.glassBackgroundStrong,
+                      borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+                    ),
+                    child: Icon(
+                      LucideIcons.settings2,
+                      color: context.adaptiveTextSecondary,
+                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    ),
+                  ),
+                  const SizedBox(width: AppConstants.spacingMd),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Scanning Settings',
+                          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            color: context.adaptiveTextPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          'Filter files, size limits, and playlist import options',
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.adaptiveTextTertiary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    _scanSettingsExpanded
+                        ? LucideIcons.chevronUp
+                        : LucideIcons.chevronDown,
+                    color: context.adaptiveTextTertiary,
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (_scanSettingsExpanded) ...[
+          _buildDivider(),
+          _buildToggleSetting(
+            context,
+            icon: LucideIcons.scanSearch,
+            title: 'Filter Non-Music Files & Folders',
+            subtitle: 'Skip unsupported files and hidden .nomedia directories',
+            value: prefs.filterNonMusicFilesAndFolders,
+            onChanged: (value) {
+              ref
+                  .read(libraryScanPreferencesProvider.notifier)
+                  .setFilterNonMusicFilesAndFolders(value);
+            },
+          ),
+          _buildDivider(),
+          _buildToggleSetting(
+            context,
+            icon: LucideIcons.fileMinus,
+            title: 'Ignore Tracks Under 500 KB',
+            subtitle: 'Exclude tiny clips, previews, and accidental scraps',
+            value: prefs.ignoreTracksSmallerThan500Kb,
+            onChanged: (value) {
+              ref
+                  .read(libraryScanPreferencesProvider.notifier)
+                  .setIgnoreTracksSmallerThan500Kb(value);
+            },
+          ),
+          _buildDivider(),
+          _buildToggleSetting(
+            context,
+            icon: LucideIcons.timerOff,
+            title: 'Ignore Tracks Under 60 Seconds',
+            subtitle: 'Hide short stingers, ringtones, and voice fragments',
+            value: prefs.ignoreTracksShorterThan60Seconds,
+            onChanged: (value) {
+              ref
+                  .read(libraryScanPreferencesProvider.notifier)
+                  .setIgnoreTracksShorterThan60Seconds(value);
+            },
+          ),
+          _buildDivider(),
+          _buildToggleSetting(
+            context,
+            icon: LucideIcons.listMusic,
+            title: 'Import M3U/M3U8 Playlists',
+            subtitle:
+                'Create or refresh playlists found inside scanned folders',
+            value: prefs.createPlaylistsFromM3uFiles,
+            onChanged: (value) {
+              ref
+                  .read(libraryScanPreferencesProvider.notifier)
+                  .setCreatePlaylistsFromM3uFiles(value);
+            },
+          ),
+        ],
+      ],
     );
   }
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -37,7 +37,8 @@ class SettingsScreen extends ConsumerStatefulWidget {
   ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+class _SettingsScreenState extends ConsumerState<SettingsScreen>
+    with SingleTickerProviderStateMixin {
   static final Uri _releaseNotesApiUri = Uri.parse(
     'https://api.github.com/repos/ultraelectronica/flick_player/releases/latest',
   );
@@ -65,6 +66,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   UpdateStatus? _lastScannedUpdateStatus;
   String? _updateCheckErrorMessage;
   bool _scanSettingsExpanded = false;
+  late final AnimationController _scanSettingsController;
+  late final Animation<double> _scanSettingsRotation;
 
   // ValueNotifier for bottom sheet progress updates
   final ValueNotifier<ScanProgress?> _scanProgressNotifier = ValueNotifier(
@@ -74,6 +77,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   void initState() {
     super.initState();
+    _scanSettingsController = AnimationController(
+      duration: AppConstants.animationFast,
+      vsync: this,
+    );
+    _scanSettingsRotation = Tween<double>(begin: 0, end: 0.5).animate(
+      CurvedAnimation(
+        parent: _scanSettingsController,
+        curve: Curves.easeInOut,
+      ),
+    );
     _loadLibraryData();
     _syncFoldersToDatabase();
     _loadAndroidDeviceNotices();
@@ -82,6 +95,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   @override
   void dispose() {
     _scanProgressNotifier.dispose();
+    _scanSettingsController.dispose();
     super.dispose();
   }
 
@@ -1780,7 +1794,14 @@ SOFTWARE.
         Material(
           color: Colors.transparent,
           child: InkWell(
-            onTap: () => setState(() => _scanSettingsExpanded = !_scanSettingsExpanded),
+            onTap: () {
+              setState(() => _scanSettingsExpanded = !_scanSettingsExpanded);
+              if (_scanSettingsExpanded) {
+                _scanSettingsController.forward();
+              } else {
+                _scanSettingsController.reverse();
+              }
+            },
             child: Padding(
               padding: const EdgeInsets.all(AppConstants.spacingMd),
               child: Row(
@@ -1819,73 +1840,79 @@ SOFTWARE.
                       ],
                     ),
                   ),
-                  Icon(
-                    _scanSettingsExpanded
-                        ? LucideIcons.chevronUp
-                        : LucideIcons.chevronDown,
-                    color: context.adaptiveTextTertiary,
-                    size: 20,
+                  RotationTransition(
+                    turns: _scanSettingsRotation,
+                    child: Icon(
+                      LucideIcons.chevronDown,
+                      color: context.adaptiveTextTertiary,
+                      size: 20,
+                    ),
                   ),
                 ],
               ),
             ),
           ),
         ),
-        if (_scanSettingsExpanded) ...[
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.scanSearch,
-            title: 'Filter Non-Music Files & Folders',
-            subtitle: 'Skip unsupported files and hidden .nomedia directories',
-            value: prefs.filterNonMusicFilesAndFolders,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setFilterNonMusicFilesAndFolders(value);
-            },
+        SizeTransition(
+          sizeFactor: _scanSettingsController,
+          child: Column(
+            children: [
+              _buildDivider(),
+              _buildToggleSetting(
+                context,
+                icon: LucideIcons.scanSearch,
+                title: 'Filter Non-Music Files & Folders',
+                subtitle: 'Skip unsupported files and hidden .nomedia directories',
+                value: prefs.filterNonMusicFilesAndFolders,
+                onChanged: (value) {
+                  ref
+                      .read(libraryScanPreferencesProvider.notifier)
+                      .setFilterNonMusicFilesAndFolders(value);
+                },
+              ),
+              _buildDivider(),
+              _buildToggleSetting(
+                context,
+                icon: LucideIcons.fileMinus,
+                title: 'Ignore Tracks Under 500 KB',
+                subtitle: 'Exclude tiny clips, previews, and accidental scraps',
+                value: prefs.ignoreTracksSmallerThan500Kb,
+                onChanged: (value) {
+                  ref
+                      .read(libraryScanPreferencesProvider.notifier)
+                      .setIgnoreTracksSmallerThan500Kb(value);
+                },
+              ),
+              _buildDivider(),
+              _buildToggleSetting(
+                context,
+                icon: LucideIcons.timerOff,
+                title: 'Ignore Tracks Under 60 Seconds',
+                subtitle: 'Hide short stingers, ringtones, and voice fragments',
+                value: prefs.ignoreTracksShorterThan60Seconds,
+                onChanged: (value) {
+                  ref
+                      .read(libraryScanPreferencesProvider.notifier)
+                      .setIgnoreTracksShorterThan60Seconds(value);
+                },
+              ),
+              _buildDivider(),
+              _buildToggleSetting(
+                context,
+                icon: LucideIcons.listMusic,
+                title: 'Import M3U/M3U8 Playlists',
+                subtitle:
+                    'Create or refresh playlists found inside scanned folders',
+                value: prefs.createPlaylistsFromM3uFiles,
+                onChanged: (value) {
+                  ref
+                      .read(libraryScanPreferencesProvider.notifier)
+                      .setCreatePlaylistsFromM3uFiles(value);
+                },
+              ),
+            ],
           ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.fileMinus,
-            title: 'Ignore Tracks Under 500 KB',
-            subtitle: 'Exclude tiny clips, previews, and accidental scraps',
-            value: prefs.ignoreTracksSmallerThan500Kb,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setIgnoreTracksSmallerThan500Kb(value);
-            },
-          ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.timerOff,
-            title: 'Ignore Tracks Under 60 Seconds',
-            subtitle: 'Hide short stingers, ringtones, and voice fragments',
-            value: prefs.ignoreTracksShorterThan60Seconds,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setIgnoreTracksShorterThan60Seconds(value);
-            },
-          ),
-          _buildDivider(),
-          _buildToggleSetting(
-            context,
-            icon: LucideIcons.listMusic,
-            title: 'Import M3U/M3U8 Playlists',
-            subtitle:
-                'Create or refresh playlists found inside scanned folders',
-            value: prefs.createPlaylistsFromM3uFiles,
-            onChanged: (value) {
-              ref
-                  .read(libraryScanPreferencesProvider.notifier)
-                  .setCreatePlaylistsFromM3uFiles(value);
-            },
-          ),
-        ],
+        ),
       ],
     );
   }

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -21,16 +21,14 @@ class Uac2PreferencesScreen extends ConsumerStatefulWidget {
 class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
   @override
   Widget build(BuildContext context) {
-    final preferencesService = ref.watch(uac2PreferencesServiceProvider);
-    final autoConnectAsync = ref.watch(uac2AutoConnectProvider);
-    final autoSelectAsync = ref.watch(uac2AutoSelectDeviceProvider);
-    final formatPrefAsync = ref.watch(uac2FormatPreferenceProvider);
-    final preferredFormatAsync = ref.watch(uac2PreferredFormatProvider);
-    final hiFiModeAsync = ref.watch(uac2HiFiModeProvider);
-    final bitPerfectAsync = ref.watch(uac2BitPerfectEnabledProvider);
-    final audioEngineAsync = ref.watch(audioEnginePreferenceProvider);
-    final developerModeAsync = ref.watch(developerModeEnabledProvider);
-    final diagnostics = ref.watch(audioOutputDiagnosticsProvider);
+                    final preferencesService = ref.watch(uac2PreferencesServiceProvider);
+                    final formatPrefAsync = ref.watch(uac2FormatPreferenceProvider);
+                    final preferredFormatAsync = ref.watch(uac2PreferredFormatProvider);
+                    final hiFiModeAsync = ref.watch(uac2HiFiModeProvider);
+                    final bitPerfectAsync = ref.watch(uac2BitPerfectEnabledProvider);
+                    final audioEngineAsync = ref.watch(audioEnginePreferenceProvider);
+                    final developerModeAsync = ref.watch(developerModeEnabledProvider);
+                    final diagnostics = ref.watch(audioOutputDiagnosticsProvider);
 
     return DisplayModeWrapper(
       child: Scaffold(
@@ -47,17 +45,9 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
                   padding: const EdgeInsets.symmetric(
                     horizontal: AppConstants.spacingMd,
                   ),
-                  child: Column(
+                    child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      _buildSectionHeader(context, 'Connection'),
-                      _buildConnectionPreferences(
-                        context,
-                        preferencesService,
-                        autoConnectAsync,
-                        autoSelectAsync,
-                      ),
-                      const SizedBox(height: AppConstants.spacingLg),
                       _buildSectionHeader(context, 'Audio Format'),
                       _buildFormatPreferences(
                         context,
@@ -127,56 +117,6 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
           letterSpacing: 1.2,
           fontWeight: FontWeight.w600,
         ),
-      ),
-    );
-  }
-
-  Widget _buildConnectionPreferences(
-    BuildContext context,
-    Uac2PreferencesService service,
-    AsyncValue<bool> autoConnectAsync,
-    AsyncValue<bool> autoSelectAsync,
-  ) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.surface.withValues(alpha: 0.6),
-        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-        border: Border.all(color: AppColors.glassBorder),
-      ),
-      child: Column(
-        children: [
-          autoConnectAsync.when(
-            data: (autoConnect) => _buildSwitchTile(
-              context,
-              icon: LucideIcons.power,
-              title: 'Auto-Connect',
-              subtitle: 'Automatically connect to last used device on startup',
-              value: autoConnect,
-              onChanged: (value) async {
-                await service.setAutoConnect(value);
-                ref.invalidate(uac2AutoConnectProvider);
-              },
-            ),
-            loading: () => _buildLoadingTile(context),
-            error: (_, _) => _buildErrorTile(context),
-          ),
-          _buildDivider(),
-          autoSelectAsync.when(
-            data: (autoSelect) => _buildSwitchTile(
-              context,
-              icon: LucideIcons.zap,
-              title: 'Auto-Select Device',
-              subtitle: 'Automatically select first available USB audio device',
-              value: autoSelect,
-              onChanged: (value) async {
-                await service.setAutoSelectDevice(value);
-                ref.invalidate(uac2AutoSelectDeviceProvider);
-              },
-            ),
-            loading: () => _buildLoadingTile(context),
-            error: (_, _) => _buildErrorTile(context),
-          ),
-        ],
       ),
     );
   }
@@ -1162,8 +1102,6 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
               await ref
                   .read(uac2ServiceProvider)
                   .setBitPerfectEnabled(false, persist: false);
-              ref.invalidate(uac2AutoConnectProvider);
-              ref.invalidate(uac2AutoSelectDeviceProvider);
               ref.invalidate(uac2FormatPreferenceProvider);
               ref.invalidate(uac2PreferredFormatProvider);
               ref.invalidate(uac2HiFiModeProvider);

--- a/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
+++ b/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
@@ -1,0 +1,700 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/models/song.dart';
+import 'package:flick/services/album_art_import_service.dart';
+import 'package:flick/services/player_service.dart';
+import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/glass_bottom_sheet.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+class AlbumArtPickerBottomSheet extends StatefulWidget {
+  const AlbumArtPickerBottomSheet({super.key, required this.song});
+
+  final Song song;
+
+  static Future<void> show(BuildContext context, Song song) async {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final result = await showModalBottomSheet<_AlbumArtSheetResult>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => AppBottomSheetSurface(
+        maxHeightRatio: 0.88,
+        child: AlbumArtPickerBottomSheet(song: song),
+      ),
+    );
+
+    if (!context.mounted || messenger == null || result == null) {
+      return;
+    }
+
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(result.message),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+  }
+
+  @override
+  State<AlbumArtPickerBottomSheet> createState() =>
+      _AlbumArtPickerBottomSheetState();
+}
+
+class _AlbumArtPickerBottomSheetState extends State<AlbumArtPickerBottomSheet> {
+  final AlbumArtImportService _service = AlbumArtImportService.instance;
+  final PlayerService _playerService = PlayerService();
+
+  List<AlbumArtCandidate> _candidates = const [];
+  String? _searchError;
+  int _selectedCandidateIndex = 0;
+  bool _isSearching = false;
+  bool _isWorking = false;
+  late bool _hasCustomArtwork;
+
+  @override
+  void initState() {
+    super.initState();
+    _hasCustomArtwork = _service.isCustomArtworkPath(widget.song.albumArt);
+    _searchOnlineCandidates();
+  }
+
+  AlbumArtCandidate? get _selectedCandidate {
+    if (_selectedCandidateIndex < 0 ||
+        _selectedCandidateIndex >= _candidates.length) {
+      return null;
+    }
+    return _candidates[_selectedCandidateIndex];
+  }
+
+  Future<void> _searchOnlineCandidates() async {
+    if (_isWorking) {
+      return;
+    }
+
+    setState(() {
+      _isSearching = true;
+      _searchError = null;
+    });
+
+    try {
+      final candidates = await _service.searchOnlineCandidates(widget.song);
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _candidates = candidates;
+        _selectedCandidateIndex = 0;
+        _searchError = null;
+      });
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _candidates = const [];
+        _selectedCandidateIndex = 0;
+        _searchError = error.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSearching = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _pickLocalImage() async {
+    if (_isWorking) {
+      return;
+    }
+
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp'],
+        withData: kIsWeb,
+      );
+      final file = result?.files.single;
+      if (file == null) {
+        return;
+      }
+
+      final bytes = file.bytes ?? await _readFileBytes(file.path);
+      if (bytes == null || bytes.isEmpty) {
+        throw const AlbumArtImportException(
+          'Could not read the selected image.',
+        );
+      }
+
+      await _runMutation(
+        action: () => _service.applyImageBytes(song: widget.song, bytes: bytes),
+        successMessage: (result) =>
+            'Updated album art for "${result.albumName}".',
+      );
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showInlineMessage(error.toString());
+    }
+  }
+
+  Future<void> _applySelectedCandidate() async {
+    final candidate = _selectedCandidate;
+    if (candidate == null || _isWorking) {
+      return;
+    }
+
+    await _runMutation(
+      action: () => _service.applyOnlineCandidate(
+        song: widget.song,
+        candidate: candidate,
+      ),
+      successMessage: (result) =>
+          'Updated album art for "${result.albumName}".',
+    );
+  }
+
+  Future<void> _removeCustomArtwork() async {
+    if (_isWorking) {
+      return;
+    }
+
+    await _runMutation(
+      action: () => _service.removeCustomArtwork(widget.song),
+      successMessage: (result) =>
+          'Removed custom album art for "${result.albumName}".',
+    );
+  }
+
+  Future<void> _runMutation({
+    required Future<AlbumArtUpdateResult> Function() action,
+    required String Function(AlbumArtUpdateResult result) successMessage,
+  }) async {
+    setState(() {
+      _isWorking = true;
+    });
+
+    try {
+      final result = await action();
+      _playerService.syncAlbumArtPaths(
+        filePaths: result.filePaths,
+        albumArtPath: result.albumArtPath,
+      );
+      if (!mounted) {
+        return;
+      }
+
+      Navigator.of(
+        context,
+      ).pop(_AlbumArtSheetResult(message: successMessage(result)));
+    } catch (error) {
+      if (!mounted) {
+        return;
+      }
+      _showInlineMessage(error.toString());
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isWorking = false;
+        });
+      }
+    }
+  }
+
+  Future<Uint8List?> _readFileBytes(String? path) async {
+    if (path == null || path.isEmpty) {
+      return null;
+    }
+
+    final file = File(path);
+    if (!await file.exists()) {
+      return null;
+    }
+
+    return file.readAsBytes();
+  }
+
+  void _showInlineMessage(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedCandidate = _selectedCandidate;
+    final previewPath = selectedCandidate?.previewUrl ?? widget.song.albumArt;
+    final previewSourcePath = selectedCandidate == null
+        ? widget.song.filePath
+        : null;
+    final albumName = widget.song.album?.trim();
+    final albumArtist = widget.song.albumArtist?.trim();
+    final effectiveAlbumArtist = (albumArtist != null && albumArtist.isNotEmpty)
+        ? albumArtist
+        : widget.song.artist;
+
+    return Stack(
+      children: [
+        SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildDragHandle(),
+              const SizedBox(height: AppConstants.spacingMd),
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Set Album Art',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 20,
+                            fontWeight: FontWeight.w700,
+                            color: context.adaptiveTextPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          albumName != null && albumName.isNotEmpty
+                              ? '$albumName • $effectiveAlbumArtist'
+                              : widget.song.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 14,
+                            color: context.adaptiveTextSecondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _isSearching || _isWorking
+                        ? null
+                        : _searchOnlineCandidates,
+                    icon: const Icon(LucideIcons.refreshCw, size: 18),
+                    color: context.adaptiveTextSecondary,
+                    tooltip: 'Search Again',
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppConstants.spacingSm),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.surfaceLight,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: AppColors.glassBorder),
+                ),
+                child: Text(
+                  'Applied to the whole album',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: context.adaptiveTextSecondary,
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppConstants.spacingLg),
+              _buildPreviewCard(
+                context,
+                imagePath: previewPath,
+                audioSourcePath: previewSourcePath,
+                title: selectedCandidate == null
+                    ? (_hasCustomArtwork
+                          ? 'Current custom art'
+                          : 'Current artwork')
+                    : selectedCandidate.title,
+                subtitle: selectedCandidate == null
+                    ? effectiveAlbumArtist
+                    : _candidateSubtitle(selectedCandidate),
+              ),
+              const SizedBox(height: AppConstants.spacingMd),
+              Wrap(
+                spacing: AppConstants.spacingSm,
+                runSpacing: AppConstants.spacingSm,
+                children: [
+                  FilledButton.icon(
+                    onPressed: _isWorking ? null : _pickLocalImage,
+                    icon: const Icon(LucideIcons.folderOpen, size: 18),
+                    label: const Text('Pick Image'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: AppColors.accent,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                  if (selectedCandidate != null)
+                    OutlinedButton.icon(
+                      onPressed: _isWorking ? null : _applySelectedCandidate,
+                      icon: const Icon(LucideIcons.check, size: 18),
+                      label: const Text('Apply Selected'),
+                    ),
+                  if (_hasCustomArtwork)
+                    OutlinedButton.icon(
+                      onPressed: _isWorking ? null : _removeCustomArtwork,
+                      icon: const Icon(LucideIcons.trash2, size: 18),
+                      label: const Text('Remove Custom Art'),
+                    ),
+                ],
+              ),
+              const SizedBox(height: AppConstants.spacingLg),
+              Row(
+                children: [
+                  Text(
+                    'Online Results',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: context.adaptiveTextPrimary,
+                    ),
+                  ),
+                  if (_isSearching) ...[
+                    const SizedBox(width: AppConstants.spacingSm),
+                    const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ],
+                ],
+              ),
+              const SizedBox(height: AppConstants.spacingSm),
+              _buildOnlineResults(context),
+            ],
+          ),
+        ),
+        if (_isWorking)
+          Positioned.fill(
+            child: ColoredBox(
+              color: Colors.black.withValues(alpha: 0.18),
+              child: const Center(child: CircularProgressIndicator()),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildOnlineResults(BuildContext context) {
+    if (_isSearching && _candidates.isEmpty) {
+      return _buildInfoCard(
+        context,
+        icon: LucideIcons.search,
+        title: 'Searching online',
+        subtitle:
+            'Looking for cover art from MusicBrainz and Cover Art Archive.',
+      );
+    }
+
+    if (_searchError != null) {
+      return _buildInfoCard(
+        context,
+        icon: LucideIcons.wifiOff,
+        title: 'Search failed',
+        subtitle: _searchError!,
+      );
+    }
+
+    if (_candidates.isEmpty) {
+      final albumName = widget.song.album?.trim();
+      return _buildInfoCard(
+        context,
+        icon: LucideIcons.imageOff,
+        title: 'No online artwork found',
+        subtitle: albumName == null || albumName.isEmpty
+            ? 'This song is missing album metadata, so online matching is limited.'
+            : 'Try picking a local image if the release metadata is uncommon.',
+      );
+    }
+
+    return SizedBox(
+      height: 176,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: _candidates.length,
+        separatorBuilder: (_, _) =>
+            const SizedBox(width: AppConstants.spacingSm),
+        itemBuilder: (context, index) {
+          final candidate = _candidates[index];
+          final isSelected = index == _selectedCandidateIndex;
+          return GestureDetector(
+            onTap: _isWorking
+                ? null
+                : () {
+                    setState(() {
+                      _selectedCandidateIndex = index;
+                    });
+                  },
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
+              width: 132,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceLight,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: isSelected ? AppColors.accent : AppColors.glassBorder,
+                  width: isSelected ? 1.6 : 1,
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: SizedBox(
+                      width: 116,
+                      height: 116,
+                      child: CachedImageWidget(
+                        imagePath: candidate.previewUrl,
+                        fit: BoxFit.cover,
+                        placeholder: const ColoredBox(
+                          color: AppColors.surface,
+                          child: Icon(
+                            LucideIcons.image,
+                            color: AppColors.textTertiary,
+                          ),
+                        ),
+                        errorWidget: const ColoredBox(
+                          color: AppColors.surface,
+                          child: Icon(
+                            LucideIcons.imageOff,
+                            color: AppColors.textTertiary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    candidate.sourceLabel,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: isSelected
+                          ? AppColors.accent
+                          : context.adaptiveTextSecondary,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    candidate.releaseDate?.isNotEmpty == true
+                        ? candidate.releaseDate!
+                        : candidate.artist,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 11,
+                      color: context.adaptiveTextTertiary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildPreviewCard(
+    BuildContext context, {
+    required String? imagePath,
+    required String? audioSourcePath,
+    required String title,
+    required String subtitle,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(16),
+            child: SizedBox(
+              width: 112,
+              height: 112,
+              child: CachedImageWidget(
+                imagePath: imagePath,
+                audioSourcePath: audioSourcePath,
+                fit: BoxFit.cover,
+                placeholder: const ColoredBox(
+                  color: AppColors.surface,
+                  child: Icon(
+                    LucideIcons.image,
+                    color: AppColors.textTertiary,
+                    size: 30,
+                  ),
+                ),
+                errorWidget: const ColoredBox(
+                  color: AppColors.surface,
+                  child: Icon(
+                    LucideIcons.imageOff,
+                    color: AppColors.textTertiary,
+                    size: 30,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  subtitle,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 13,
+                    color: context.adaptiveTextSecondary,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Imported art is saved inside the app and synced to every song in this album.',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 12,
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoCard(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(icon, size: 18, color: context.adaptiveTextSecondary),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 13,
+                    color: context.adaptiveTextSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDragHandle() {
+    return Center(
+      child: Container(
+        width: 40,
+        height: 4,
+        decoration: BoxDecoration(
+          color: AppColors.glassBorderStrong,
+          borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+        ),
+      ),
+    );
+  }
+
+  String _candidateSubtitle(AlbumArtCandidate candidate) {
+    if (candidate.releaseDate != null && candidate.releaseDate!.isNotEmpty) {
+      return '${candidate.artist} • ${candidate.releaseDate}';
+    }
+    return candidate.artist;
+  }
+}
+
+class _AlbumArtSheetResult {
+  const _AlbumArtSheetResult({required this.message});
+
+  final String message;
+}

--- a/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
+++ b/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
@@ -344,7 +344,7 @@ class _AlbumArtPickerBottomSheetState extends State<AlbumArtPickerBottomSheet> {
                     label: const Text('Pick Image'),
                     style: FilledButton.styleFrom(
                       backgroundColor: AppColors.accent,
-                      foregroundColor: Colors.white,
+                      foregroundColor: Colors.black,
                     ),
                   ),
                   if (selectedCandidate != null)

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
@@ -12,8 +15,13 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 /// Bottom sheet with actions for a song (add to playlist, favorites, view metadata, etc.)
 class SongActionsBottomSheet extends ConsumerWidget {
   final Song song;
+  final BuildContext rootContext;
 
-  const SongActionsBottomSheet({super.key, required this.song});
+  const SongActionsBottomSheet({
+    super.key,
+    required this.song,
+    required this.rootContext,
+  });
 
   /// Show the song actions bottom sheet
   static Future<void> show(BuildContext context, Song song) {
@@ -21,8 +29,9 @@ class SongActionsBottomSheet extends ConsumerWidget {
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (sheetContext) =>
-          AppBottomSheetSurface(child: SongActionsBottomSheet(song: song)),
+      builder: (sheetContext) => AppBottomSheetSurface(
+        child: SongActionsBottomSheet(song: song, rootContext: context),
+      ),
     );
   }
 
@@ -73,6 +82,20 @@ class SongActionsBottomSheet extends ConsumerWidget {
             onTap: () {
               Navigator.pop(context);
               _showAddToPlaylistSheet(context);
+            },
+          ),
+          _buildActionTile(
+            context: context,
+            icon: LucideIcons.image,
+            label: 'Set Album Art',
+            onTap: () {
+              Navigator.pop(context);
+              unawaited(
+                Future<void>.delayed(
+                  Duration.zero,
+                  () => AlbumArtPickerBottomSheet.show(rootContext, song),
+                ),
+              );
             },
           ),
           _buildActionTile(

--- a/lib/providers/uac2_provider.dart
+++ b/lib/providers/uac2_provider.dart
@@ -157,16 +157,6 @@ final uac2PreferencesServiceProvider = Provider((ref) {
   return Uac2PreferencesService();
 });
 
-final uac2AutoConnectProvider = FutureProvider<bool>((ref) async {
-  final service = ref.watch(uac2PreferencesServiceProvider);
-  return service.getAutoConnect();
-});
-
-final uac2AutoSelectDeviceProvider = FutureProvider<bool>((ref) async {
-  final service = ref.watch(uac2PreferencesServiceProvider);
-  return service.getAutoSelectDevice();
-});
-
 final uac2FormatPreferenceProvider = FutureProvider<Uac2FormatPreference>((
   ref,
 ) async {

--- a/lib/services/album_art_import_service.dart
+++ b/lib/services/album_art_import_service.dart
@@ -1,0 +1,624 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../data/repositories/song_repository.dart';
+import '../models/song.dart';
+
+class AlbumArtImportException implements Exception {
+  const AlbumArtImportException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class AlbumArtCandidate {
+  const AlbumArtCandidate({
+    required this.previewUrl,
+    required this.imageUrl,
+    required this.title,
+    required this.artist,
+    required this.sourceLabel,
+    this.releaseDate,
+  });
+
+  final String previewUrl;
+  final String imageUrl;
+  final String title;
+  final String artist;
+  final String sourceLabel;
+  final String? releaseDate;
+}
+
+class AlbumArtUpdateResult {
+  const AlbumArtUpdateResult({
+    required this.albumName,
+    required this.albumArtist,
+    required this.albumArtPath,
+    required this.filePaths,
+  });
+
+  final String albumName;
+  final String albumArtist;
+  final String? albumArtPath;
+  final List<String> filePaths;
+}
+
+class AlbumArtImportService {
+  AlbumArtImportService._({SongRepository? songRepository, http.Client? client})
+    : _songRepository = songRepository ?? SongRepository(),
+      _client = client ?? http.Client();
+
+  static final AlbumArtImportService instance = AlbumArtImportService._();
+  static const String _customArtworkDirectoryName = 'album_art_overrides';
+  static const Duration _requestTimeout = Duration(seconds: 12);
+  static const String _musicBrainzHost = 'musicbrainz.org';
+  static const String _coverArtHost = 'coverartarchive.org';
+
+  final SongRepository _songRepository;
+  final http.Client _client;
+
+  bool isCustomArtworkPath(String? path) {
+    if (path == null || path.isEmpty) {
+      return false;
+    }
+
+    final normalized = path.replaceAll('\\', '/');
+    return normalized.contains('/$_customArtworkDirectoryName/');
+  }
+
+  Future<List<AlbumArtCandidate>> searchOnlineCandidates(Song song) async {
+    final album = _searchAlbumName(song);
+    if (album == null) {
+      return const [];
+    }
+
+    final artist = _searchArtistName(song);
+    final candidates = <AlbumArtCandidate>[];
+    Object? lastError;
+
+    try {
+      candidates.addAll(
+        await _searchCoverArtArchive(
+          entityType: 'release-group',
+          titleField: 'releasegroup',
+          album: album,
+          artist: artist,
+        ),
+      );
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (candidates.length < 8) {
+      try {
+        candidates.addAll(
+          await _searchCoverArtArchive(
+            entityType: 'release',
+            titleField: 'release',
+            album: album,
+            artist: artist,
+          ),
+        );
+      } catch (error) {
+        lastError ??= error;
+      }
+    }
+
+    final deduped = _dedupeCandidates(candidates);
+    if (deduped.isEmpty && lastError != null) {
+      throw _asImportException(lastError);
+    }
+
+    return deduped;
+  }
+
+  Future<AlbumArtUpdateResult> applyOnlineCandidate({
+    required Song song,
+    required AlbumArtCandidate candidate,
+  }) async {
+    final response = await _client
+        .get(Uri.parse(candidate.imageUrl), headers: _downloadHeaders())
+        .timeout(_requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw AlbumArtImportException(
+        'Failed to download album art (HTTP ${response.statusCode}).',
+      );
+    }
+
+    return applyImageBytes(song: song, bytes: response.bodyBytes);
+  }
+
+  Future<AlbumArtUpdateResult> applyImageBytes({
+    required Song song,
+    required Uint8List bytes,
+  }) async {
+    if (!_looksLikeImage(bytes)) {
+      throw const AlbumArtImportException(
+        'Selected file is not a supported image.',
+      );
+    }
+
+    final group = await _resolveAlbumGroup(song);
+    final filePaths = _albumFilePaths(group);
+    final file = await _writeCustomArtwork(group.key, bytes);
+
+    await _songRepository.updateAlbumArtPaths(filePaths, file.path);
+
+    return AlbumArtUpdateResult(
+      albumName: group.albumName,
+      albumArtist: group.albumArtist,
+      albumArtPath: file.path,
+      filePaths: filePaths,
+    );
+  }
+
+  Future<AlbumArtUpdateResult> removeCustomArtwork(Song song) async {
+    final group = await _resolveAlbumGroup(song);
+    final filePaths = _albumFilePaths(group);
+    final customPaths = group.songs
+        .map((entry) => entry.albumArt)
+        .whereType<String>()
+        .where(isCustomArtworkPath)
+        .toSet();
+
+    if (customPaths.isEmpty) {
+      throw const AlbumArtImportException('No custom album art is set yet.');
+    }
+
+    await _songRepository.updateAlbumArtPaths(filePaths, null);
+
+    for (final path in customPaths) {
+      try {
+        final file = File(path);
+        if (await file.exists()) {
+          await file.delete();
+        }
+      } catch (_) {
+        // Best effort cleanup.
+      }
+    }
+
+    return AlbumArtUpdateResult(
+      albumName: group.albumName,
+      albumArtist: group.albumArtist,
+      albumArtPath: null,
+      filePaths: filePaths,
+    );
+  }
+
+  Future<List<AlbumArtCandidate>> _searchCoverArtArchive({
+    required String entityType,
+    required String titleField,
+    required String album,
+    required String artist,
+  }) async {
+    final matches = await _searchMusicBrainz(
+      entityType: entityType,
+      titleField: titleField,
+      album: album,
+      artist: artist,
+    );
+    if (matches.isEmpty) {
+      return const [];
+    }
+
+    final results = await Future.wait(
+      matches.take(4).map(_loadCoverArtCandidatesForMatch),
+    );
+
+    return results.expand((items) => items).toList();
+  }
+
+  Future<List<_MusicBrainzMatch>> _searchMusicBrainz({
+    required String entityType,
+    required String titleField,
+    required String album,
+    required String artist,
+  }) async {
+    final query = _buildMusicBrainzQuery(
+      titleField: titleField,
+      album: album,
+      artist: artist,
+    );
+    final response = await _getJson(
+      Uri.https(_musicBrainzHost, '/ws/2/$entityType', {
+        'query': query,
+        'fmt': 'json',
+        'limit': '8',
+      }),
+    );
+
+    final listKey = entityType == 'release-group'
+        ? 'release-groups'
+        : 'releases';
+    final entries = response[listKey];
+    if (entries is! List) {
+      return const [];
+    }
+
+    final matches = <_MusicBrainzMatch>[];
+    for (final entry in entries) {
+      if (entry is! Map<String, dynamic>) {
+        continue;
+      }
+
+      final id = (entry['id'] as String?)?.trim();
+      final title = (entry['title'] as String?)?.trim();
+      if (id == null || id.isEmpty || title == null || title.isEmpty) {
+        continue;
+      }
+
+      final resultArtist = _artistCreditLabel(entry['artist-credit']);
+      final releaseDate =
+          ((entry['first-release-date'] ?? entry['date']) as String?)?.trim();
+      final primaryType = (entry['primary-type'] as String?)?.trim();
+      final score = _matchScore(
+        title: title,
+        artist: resultArtist,
+        album: album,
+        expectedArtist: artist,
+        primaryType: primaryType,
+      );
+
+      matches.add(
+        _MusicBrainzMatch(
+          id: id,
+          entityType: entityType,
+          title: title,
+          artist: resultArtist,
+          releaseDate: releaseDate,
+          score: score,
+        ),
+      );
+    }
+
+    matches.sort((a, b) {
+      final scoreCompare = b.score.compareTo(a.score);
+      if (scoreCompare != 0) {
+        return scoreCompare;
+      }
+      return a.title.compareTo(b.title);
+    });
+
+    return matches;
+  }
+
+  Future<List<AlbumArtCandidate>> _loadCoverArtCandidatesForMatch(
+    _MusicBrainzMatch match,
+  ) async {
+    try {
+      final response = await _getJson(
+        Uri.https(_coverArtHost, '/${match.entityType}/${match.id}'),
+      );
+      final images = response['images'];
+      if (images is! List || images.isEmpty) {
+        return const [];
+      }
+
+      final frontImages = images.whereType<Map<String, dynamic>>().where((
+        image,
+      ) {
+        return image['front'] == true;
+      }).toList();
+      final preferredImages = frontImages.isNotEmpty
+          ? frontImages
+          : images.whereType<Map<String, dynamic>>().take(1).toList();
+
+      final candidates = <AlbumArtCandidate>[];
+      for (final image in preferredImages.take(2)) {
+        final imageUrl = (image['image'] as String?)?.trim();
+        if (imageUrl == null || imageUrl.isEmpty) {
+          continue;
+        }
+
+        final thumbnails = image['thumbnails'];
+        final previewUrl = thumbnails is Map<String, dynamic>
+            ? ((thumbnails['500'] ?? thumbnails['250']) as String?)?.trim() ??
+                  imageUrl
+            : imageUrl;
+
+        candidates.add(
+          AlbumArtCandidate(
+            previewUrl: previewUrl,
+            imageUrl: imageUrl,
+            title: match.title,
+            artist: match.artist,
+            sourceLabel: match.entityType == 'release-group'
+                ? 'MusicBrainz release group'
+                : 'MusicBrainz release',
+            releaseDate: match.releaseDate,
+          ),
+        );
+      }
+
+      return candidates;
+    } on _AlbumArtHttpException catch (error) {
+      if (error.statusCode == 404) {
+        return const [];
+      }
+      rethrow;
+    }
+  }
+
+  Future<Map<String, dynamic>> _getJson(Uri uri) async {
+    final response = await _client
+        .get(uri, headers: _jsonHeaders())
+        .timeout(_requestTimeout);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw _AlbumArtHttpException(
+        statusCode: response.statusCode,
+        message: 'HTTP ${response.statusCode}',
+      );
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic>) {
+      throw const AlbumArtImportException(
+        'Artwork lookup returned invalid data.',
+      );
+    }
+
+    return decoded;
+  }
+
+  Map<String, String> _jsonHeaders() {
+    return const {
+      'Accept': 'application/json',
+      'User-Agent': 'FlickPlayer/0.12.0 (album-art-lookup)',
+    };
+  }
+
+  Map<String, String> _downloadHeaders() {
+    return const {'User-Agent': 'FlickPlayer/0.12.0 (album-art-lookup)'};
+  }
+
+  Future<AlbumGroup> _resolveAlbumGroup(Song song) async {
+    final group = await _songRepository.getAlbumGroupForSong(song);
+    if (group == null || group.songs.isEmpty) {
+      throw const AlbumArtImportException(
+        'Could not resolve the album for this song.',
+      );
+    }
+    return group;
+  }
+
+  List<String> _albumFilePaths(AlbumGroup group) {
+    final filePaths = group.songs
+        .map((entry) => entry.filePath)
+        .whereType<String>()
+        .where((path) => path.isNotEmpty)
+        .toSet()
+        .toList();
+    if (filePaths.isEmpty) {
+      throw const AlbumArtImportException(
+        'No library files were found for this album.',
+      );
+    }
+    return filePaths;
+  }
+
+  Future<File> _writeCustomArtwork(String albumKey, Uint8List bytes) async {
+    final documentsDirectory = await getApplicationDocumentsDirectory();
+    final artworkDirectory = Directory(
+      '${documentsDirectory.path}${Platform.pathSeparator}$_customArtworkDirectoryName',
+    );
+    if (!await artworkDirectory.exists()) {
+      await artworkDirectory.create(recursive: true);
+    }
+
+    final digest = md5.convert(utf8.encode(albumKey)).toString();
+    final file = File(
+      '${artworkDirectory.path}${Platform.pathSeparator}$digest.cover',
+    );
+    await file.writeAsBytes(bytes, flush: true);
+    return file;
+  }
+
+  List<AlbumArtCandidate> _dedupeCandidates(
+    List<AlbumArtCandidate> candidates,
+  ) {
+    final deduped = <String, AlbumArtCandidate>{};
+    for (final candidate in candidates) {
+      deduped.putIfAbsent(candidate.imageUrl, () => candidate);
+    }
+    return deduped.values.take(12).toList(growable: false);
+  }
+
+  String _buildMusicBrainzQuery({
+    required String titleField,
+    required String album,
+    required String artist,
+  }) {
+    final clauses = <String>['$titleField:"${_escapeQueryValue(album)}"'];
+    if (artist.trim().isNotEmpty) {
+      clauses.add('artist:"${_escapeQueryValue(artist)}"');
+    }
+    return clauses.join(' AND ');
+  }
+
+  String _escapeQueryValue(String value) {
+    return value.replaceAll('"', ' ').trim();
+  }
+
+  String _artistCreditLabel(Object? artistCredit) {
+    if (artistCredit is! List) {
+      return '';
+    }
+
+    final parts = <String>[];
+    for (final item in artistCredit) {
+      if (item is! Map<String, dynamic>) {
+        continue;
+      }
+
+      final name = (item['name'] as String?)?.trim();
+      if (name != null && name.isNotEmpty) {
+        parts.add(name);
+      }
+
+      final joinPhrase = item['joinphrase'] as String?;
+      if (joinPhrase != null && joinPhrase.isNotEmpty) {
+        parts.add(joinPhrase);
+      }
+    }
+
+    return parts.join();
+  }
+
+  int _matchScore({
+    required String title,
+    required String artist,
+    required String album,
+    required String expectedArtist,
+    String? primaryType,
+  }) {
+    final normalizedTitle = _normalize(title);
+    final normalizedAlbum = _normalize(album);
+    final normalizedArtist = _normalize(artist);
+    final normalizedExpectedArtist = _normalize(expectedArtist);
+
+    var score = 0;
+    if (normalizedTitle == normalizedAlbum) {
+      score += 120;
+    } else if (normalizedTitle.contains(normalizedAlbum) ||
+        normalizedAlbum.contains(normalizedTitle)) {
+      score += 70;
+    }
+
+    if (normalizedExpectedArtist.isNotEmpty) {
+      if (normalizedArtist == normalizedExpectedArtist) {
+        score += 60;
+      } else if (normalizedArtist.contains(normalizedExpectedArtist) ||
+          normalizedExpectedArtist.contains(normalizedArtist)) {
+        score += 30;
+      }
+    }
+
+    if ((primaryType ?? '').toLowerCase() == 'album') {
+      score += 10;
+    }
+
+    return score;
+  }
+
+  String _normalize(String value) {
+    return value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), ' ').trim();
+  }
+
+  String? _searchAlbumName(Song song) {
+    final album = song.album?.trim();
+    if (album == null || album.isEmpty) {
+      return null;
+    }
+    return album;
+  }
+
+  String _searchArtistName(Song song) {
+    final albumArtist = song.albumArtist?.trim();
+    if (albumArtist != null && albumArtist.isNotEmpty) {
+      return albumArtist;
+    }
+    return song.artist.trim();
+  }
+
+  bool _looksLikeImage(Uint8List bytes) {
+    if (bytes.isEmpty) {
+      return false;
+    }
+
+    if (bytes.length >= 8 &&
+        bytes[0] == 0x89 &&
+        bytes[1] == 0x50 &&
+        bytes[2] == 0x4E &&
+        bytes[3] == 0x47) {
+      return true;
+    }
+
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xFF &&
+        bytes[1] == 0xD8 &&
+        bytes[2] == 0xFF) {
+      return true;
+    }
+
+    if (bytes.length >= 12 &&
+        bytes[0] == 0x52 &&
+        bytes[1] == 0x49 &&
+        bytes[2] == 0x46 &&
+        bytes[3] == 0x46 &&
+        bytes[8] == 0x57 &&
+        bytes[9] == 0x45 &&
+        bytes[10] == 0x42 &&
+        bytes[11] == 0x50) {
+      return true;
+    }
+
+    if (bytes.length >= 6 &&
+        bytes[0] == 0x47 &&
+        bytes[1] == 0x49 &&
+        bytes[2] == 0x46) {
+      return true;
+    }
+
+    if (bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D) {
+      return true;
+    }
+
+    return false;
+  }
+
+  AlbumArtImportException _asImportException(Object error) {
+    if (error is AlbumArtImportException) {
+      return error;
+    }
+    if (error is _AlbumArtHttpException) {
+      if (error.statusCode == 503) {
+        return const AlbumArtImportException(
+          'Artwork lookup is temporarily unavailable.',
+        );
+      }
+      return AlbumArtImportException(
+        'Artwork lookup failed (HTTP ${error.statusCode}).',
+      );
+    }
+    return const AlbumArtImportException('Failed to search album art online.');
+  }
+}
+
+class _MusicBrainzMatch {
+  const _MusicBrainzMatch({
+    required this.id,
+    required this.entityType,
+    required this.title,
+    required this.artist,
+    required this.releaseDate,
+    required this.score,
+  });
+
+  final String id;
+  final String entityType;
+  final String title;
+  final String artist;
+  final String? releaseDate;
+  final int score;
+}
+
+class _AlbumArtHttpException implements Exception {
+  const _AlbumArtHttpException({
+    required this.statusCode,
+    required this.message,
+  });
+
+  final int statusCode;
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -267,7 +267,7 @@ class PlayerService {
   Timer? _positionSaveTimer;
 
   // State Notifiers
-  final ValueNotifier<Song?> currentSongNotifier = ValueNotifier(null);
+  final ValueNotifier<Song?> currentSongNotifier = _MutableValueNotifier(null);
   final ValueNotifier<bool> isPlayingNotifier = ValueNotifier(false);
   final ValueNotifier<Duration> positionNotifier = ValueNotifier(Duration.zero);
   final ValueNotifier<Duration> durationNotifier = ValueNotifier(Duration.zero);
@@ -423,6 +423,85 @@ class PlayerService {
     _playlistQueueEntryIds
       ..clear()
       ..addAll(List<int?>.filled(songs.length, null));
+  }
+
+  void syncAlbumArtPaths({
+    required Iterable<String> filePaths,
+    required String? albumArtPath,
+  }) {
+    final targetPaths = filePaths.where((path) => path.isNotEmpty).toSet();
+    if (targetPaths.isEmpty) {
+      return;
+    }
+
+    Song syncSong(Song song) {
+      final path = song.filePath;
+      if (path == null || !targetPaths.contains(path)) {
+        return song;
+      }
+      if (song.albumArt == albumArtPath) {
+        return song;
+      }
+      return _copySongWithAlbumArt(song, albumArtPath);
+    }
+
+    var queueChanged = false;
+
+    for (var i = 0; i < _playlist.length; i++) {
+      final updated = syncSong(_playlist[i]);
+      if (!identical(updated, _playlist[i])) {
+        _playlist[i] = updated;
+      }
+    }
+
+    for (var i = 0; i < _originalPlaylist.length; i++) {
+      final updated = syncSong(_originalPlaylist[i]);
+      if (!identical(updated, _originalPlaylist[i])) {
+        _originalPlaylist[i] = updated;
+      }
+    }
+
+    for (var i = 0; i < _queuedEntries.length; i++) {
+      final entry = _queuedEntries[i];
+      final updatedSong = syncSong(entry.song);
+      if (!identical(updatedSong, entry.song)) {
+        _queuedEntries[i] = _QueueEntry(id: entry.id, song: updatedSong);
+        queueChanged = true;
+      }
+    }
+
+    final currentSong = currentSongNotifier.value;
+    if (currentSong != null) {
+      final updatedCurrentSong = syncSong(currentSong);
+      if (!identical(updatedCurrentSong, currentSong)) {
+        currentSongNotifier.value = updatedCurrentSong;
+      }
+    }
+
+    if (queueChanged) {
+      _notifyQueueChanged();
+    }
+  }
+
+  Song _copySongWithAlbumArt(Song song, String? albumArtPath) {
+    return Song(
+      id: song.id,
+      title: song.title,
+      artist: song.artist,
+      albumArt: albumArtPath,
+      duration: song.duration,
+      fileType: song.fileType,
+      resolution: song.resolution,
+      sampleRate: song.sampleRate,
+      bitDepth: song.bitDepth,
+      album: song.album,
+      albumArtist: song.albumArtist,
+      trackNumber: song.trackNumber,
+      discNumber: song.discNumber,
+      filePath: song.filePath,
+      folderUri: song.folderUri,
+      dateAdded: song.dateAdded,
+    );
   }
 
   void _insertQueuedEntriesAfterCurrent() {
@@ -3317,4 +3396,22 @@ class _QueueEntry {
   final Song song;
 
   const _QueueEntry({required this.id, required this.song});
+}
+
+class _MutableValueNotifier<T> extends ValueNotifier<T> {
+  _MutableValueNotifier(super.value) : _currentValue = value;
+
+  T _currentValue;
+
+  @override
+  T get value => _currentValue;
+
+  @override
+  set value(T newValue) {
+    if (identical(_currentValue, newValue)) {
+      return;
+    }
+    _currentValue = newValue;
+    notifyListeners();
+  }
 }

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -10,10 +10,8 @@ enum AudioEnginePreference { exoPlayer, rustOboe, isochronousUsb }
 class Uac2PreferencesService {
   static final ValueNotifier<bool> developerModeNotifier = ValueNotifier(false);
   static const _keySelectedDevice = 'uac2_selected_device';
-  static const _keyAutoConnect = 'uac2_auto_connect';
   static const _keyPreferredFormat = 'uac2_preferred_format';
   static const _keyFormatPreference = 'uac2_format_preference';
-  static const _keyAutoSelectDevice = 'uac2_auto_select_device';
   static const _keyHiFiModeEnabled = 'uac2_hifi_mode_enabled';
   static const _keyBitPerfectEnabled = 'uac2_bit_perfect_enabled';
   static const _keyExclusiveDacModeEnabled = 'uac2_exclusive_dac_mode_enabled';
@@ -69,25 +67,6 @@ class Uac2PreferencesService {
     }
   }
 
-  Future<void> setAutoConnect(bool enabled) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_keyAutoConnect, enabled);
-    } catch (e) {
-      debugPrint('Failed to save auto-connect setting: $e');
-    }
-  }
-
-  Future<bool> getAutoConnect() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getBool(_keyAutoConnect) ?? false;
-    } catch (e) {
-      debugPrint('Failed to load auto-connect setting: $e');
-      return false;
-    }
-  }
-
   Future<void> savePreferredFormat(Uac2AudioFormat format) async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -109,25 +88,6 @@ class Uac2PreferencesService {
     } catch (e) {
       debugPrint('Failed to load preferred format: $e');
       return null;
-    }
-  }
-
-  Future<void> setAutoSelectDevice(bool enabled) async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(_keyAutoSelectDevice, enabled);
-    } catch (e) {
-      debugPrint('Failed to save auto-select device setting: $e');
-    }
-  }
-
-  Future<bool> getAutoSelectDevice() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      return prefs.getBool(_keyAutoSelectDevice) ?? false;
-    } catch (e) {
-      debugPrint('Failed to load auto-select device setting: $e');
-      return false;
     }
   }
 
@@ -265,10 +225,8 @@ class Uac2PreferencesService {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_keySelectedDevice);
-      await prefs.remove(_keyAutoConnect);
       await prefs.remove(_keyPreferredFormat);
       await prefs.remove(_keyFormatPreference);
-      await prefs.remove(_keyAutoSelectDevice);
       await prefs.remove(_keyHiFiModeEnabled);
       await prefs.remove(_keyBitPerfectEnabled);
       await prefs.remove(_keyExclusiveDacModeEnabled);

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -208,7 +208,6 @@ class Uac2Service {
       );
     }
 
-    final autoConnect = await _preferencesService.getAutoConnect();
     final bitPerfectEnabled = await _preferencesService.getBitPerfectEnabled();
     bitPerfectEnabledNotifier.value = bitPerfectEnabled;
     final savedDevice = await _preferencesService.loadSelectedDevice();
@@ -227,10 +226,6 @@ class Uac2Service {
         return;
       }
       await selectDevice(matchingDevice);
-      return;
-    }
-
-    if (!autoConnect) {
       return;
     }
 

--- a/shorebird.yaml
+++ b/shorebird.yaml
@@ -10,5 +10,5 @@ app_id: ba373382-260e-45ac-b450-01104f4030bb
 # auto_update controls if Shorebird should automatically update in the background on launch.
 # If auto_update: false, you will need to use package:shorebird_code_push to trigger updates.
 # https://pub.dev/packages/shorebird_code_push
-# Uncomment the following line to disable automatic updates.
-auto_update: false
+# Automatic checks are enabled on app launch. Manual checks in the UI still work.
+auto_update: true


### PR DESCRIPTION
# Summary

- Add album art import service with MusicBrainz/Cover Art Archive search
- Add `AlbumArtPickerBottomSheet` for selecting and applying album art
- Update recap to save ranking posters directly from screen
- Enable Shorebird auto updates with documentation
- Add loop all indicator to player controls
- Group scan settings into expandable animated section

# Changes

## Album Art

- Add `AlbumArtImportService` for album art retrieval using MusicBrainz/Cover Art Archive
- Add `AlbumArtPickerBottomSheet` with local image picking and online search
- Add `updateAlbumArtPaths` method in `SongRepository`
- Add album art action to song actions bottom sheet and full player screen

## Recap & Posters

- Replace poster preview with direct download flow
- Render posters offscreen and capture via hidden `RepaintBoundary`
- Add saving/success states to poster buttons with loading indicators

## Shorebird Updates

- Add Shorebird setup documentation (`docs/SHOREBIRD_SETUP.md`)
- Enable auto updates in `shorebird.yaml`

## UI Improvements

- Add loop all indicator dot to player controls
- Group scan settings into expandable section with rotation animation
- Clean up UAC2 preferences (remove unused auto-connect/auto-select)
- Update foreground color of "Pick Image" button to black

# Files Changed

- `lib/services/album_art_import_service.dart` — New import service
- `lib/features/songs/widgets/album_art_picker_bottom_sheet.dart` — New picker
- `lib/features/recap/screens/listening_recap_screen.dart` — Poster save flow
- `lib/features/settings/screens/settings_screen.dart` — Settings updates
- `lib/features/player/screens/full_player_screen.dart` — Loop indicator, album art action
- `lib/data/repositories/song_repository.dart` — Album art paths
- `docs/SHOREBIRD_SETUP.md` — New documentation
- `shorebird.yaml` — Auto updates enabled