### PR TITLE
 Add external playback integration with Locker app support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
             <!-- USB device attached: open app when a UAC 2.0 device is connected -->
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />

--- a/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
@@ -3,6 +3,7 @@ package com.ultraelectronica.flick
 import android.Manifest
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
+import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
@@ -54,9 +55,12 @@ import kotlin.math.roundToInt
 class MainActivity: FlutterActivity() {
     private val CHANNEL = "com.ultraelectronica.flick/storage"
     private val PLAYER_CHANNEL = "com.ultraelectronica.flick/player"
+    private val INTEGRATION_CHANNEL = "com.ultraelectronica.flick/integration"
     private val UAC2_CHANNEL = "com.ultraelectronica.flick/uac2"
     private val AUDIO_DEVICE_CHANNEL = "com.ultraelectronica.flick/audio_device"
     private val EQUALIZER_CHANNEL = "com.ultraelectronica.flick/equalizer"
+    private val LOCKER_PACKAGE = "com.ultraelectronica.locker"
+    private val LOCKER_RETURN_URI = "locker://return?source=flick"
     // private val CONVERTER_CHANNEL = "com.ultraelectronica.flick/converter"
     private val REQUEST_OPEN_DOCUMENT_TREE = 1001
     private val REQUEST_OPEN_DOCUMENT = 1003
@@ -86,6 +90,8 @@ class MainActivity: FlutterActivity() {
         }
     private var cachedMusicVolumeBeforeMute: Int? = null
     private val justAudioProcessingController = JustAudioProcessingController()
+    private var integrationChannel: MethodChannel? = null
+    private var pendingExternalPlaybackPayload: Map<String, Any?>? = null
     private var volumeContentObserver: ContentObserver? = null
     private val volumeObserverHandler = Handler(Looper.getMainLooper())
     private var volumeObserverDebounceRunnable: Runnable? = null
@@ -115,6 +121,7 @@ class MainActivity: FlutterActivity() {
             Log.i("Flick", "Rust Android audio context initialized")
         }
 
+        handleExternalPlaybackIntent(intent)
         handleUsbAttachIntent(intent)
         maybeRequestPermissionForConnectedUsbAudioDevices(reason = "activity create")
     }
@@ -122,6 +129,7 @@ class MainActivity: FlutterActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        handleExternalPlaybackIntent(intent)
         handleUsbAttachIntent(intent)
         maybeRequestPermissionForConnectedUsbAudioDevices(reason = "new intent")
     }
@@ -506,6 +514,24 @@ class MainActivity: FlutterActivity() {
             }
         }
 
+        integrationChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            INTEGRATION_CHANNEL,
+        ).also { channel ->
+            channel.setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "consumePendingExternalPlayback" -> {
+                        result.success(pendingExternalPlaybackPayload)
+                        pendingExternalPlaybackPayload = null
+                    }
+                    "returnToLocker" -> {
+                        result.success(returnToLocker())
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+        }
+
         // UAC 2.0 USB Host API (Android): list devices and request permission
         uac2Channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, UAC2_CHANNEL)
         uac2Channel?.setMethodCallHandler { call, result ->
@@ -856,6 +882,87 @@ class MainActivity: FlutterActivity() {
         } catch (e: Exception) {
             resolver.delete(itemUri, null, null)
             throw e
+        }
+    }
+
+    private fun handleExternalPlaybackIntent(intent: Intent?) {
+        val payload = buildExternalPlaybackPayload(intent) ?: return
+        pendingExternalPlaybackPayload = payload
+        integrationChannel?.invokeMethod("externalPlaybackIntent", payload)
+    }
+
+    private fun buildExternalPlaybackPayload(intent: Intent?): Map<String, Any?>? {
+        if (intent?.action != Intent.ACTION_VIEW) {
+            return null
+        }
+
+        val dataUri = intent.data ?: return null
+        if (dataUri.scheme != ContentResolver.SCHEME_CONTENT) {
+            return null
+        }
+
+        if (!isReadableContentUri(dataUri)) {
+            Log.w("Flick", "Ignoring unreadable external playback URI: $dataUri")
+            return null
+        }
+
+        val sourcePackage = resolveSourcePackage(intent)
+        return mapOf(
+            "uri" to dataUri.toString(),
+            "mimeType" to (intent.type ?: contentResolver.getType(dataUri)),
+            "displayName" to getDocumentDisplayName(dataUri.toString()),
+            "sourcePackage" to sourcePackage,
+            "fromLocker" to (sourcePackage == LOCKER_PACKAGE),
+        )
+    }
+
+    private fun isReadableContentUri(uri: Uri): Boolean {
+        return try {
+            contentResolver.openAssetFileDescriptor(uri, "r")?.use { true } ?: false
+        } catch (e: Exception) {
+            Log.w("Flick", "Failed to open external playback URI: $uri", e)
+            false
+        }
+    }
+
+    private fun resolveSourcePackage(intent: Intent): String? {
+        val referrerUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_REFERRER, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_REFERRER)
+        }
+
+        packageNameFromReferrer(referrerUri)?.let { return it }
+
+        val referrerName = intent.getStringExtra(Intent.EXTRA_REFERRER_NAME)
+        packageNameFromReferrer(referrerName?.let(Uri::parse))?.let { return it }
+
+        packageNameFromReferrer(referrer)?.let { return it }
+
+        return null
+    }
+
+    private fun packageNameFromReferrer(uri: Uri?): String? {
+        if (uri == null) return null
+        if (uri.scheme == "android-app") {
+            return uri.host?.takeIf { it.isNotBlank() }
+        }
+        return uri.host?.takeIf { it.isNotBlank() }
+    }
+
+    private fun returnToLocker(): Boolean {
+        return try {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(LOCKER_RETURN_URI)).apply {
+                `package` = LOCKER_PACKAGE
+                addCategory(Intent.CATEGORY_BROWSABLE)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            }
+            startActivity(intent)
+            true
+        } catch (e: Exception) {
+            Log.w("Flick", "Failed to return to Locker", e)
+            false
         }
     }
 

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -113,8 +113,12 @@ class _MainShellState extends ConsumerState<MainShell>
       // player screen on every app launch.
       final songChanged =
           nextSong != null &&
-          _previousSong != null &&          // must have had a song before
-          _previousSong!.id != nextSong.id; // and it must have changed
+          _previousSong != null &&
+          _previousSong!.id != nextSong.id;
+
+      if (!songChanged && nextSong?.isExternal == true) {
+        _maybeOpenExternalPlayer(nextSong);
+      }
 
       if (songChanged && context.mounted) {
         final isPlaying = ref.read(isPlayingProvider);
@@ -177,6 +181,13 @@ class _MainShellState extends ConsumerState<MainShell>
         }
       },
     );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _maybeOpenExternalPlayer(ref.read(currentSongProvider));
+    });
   }
 
   @override
@@ -203,7 +214,7 @@ class _MainShellState extends ConsumerState<MainShell>
       // in the background, so treat this as a true "end" only when paused.
       final playerState = ref.read(playerProvider);
       final song = playerState.currentSong;
-      if (song != null && !playerState.isPlaying) {
+      if (song != null && !song.isExternal && !playerState.isPlaying) {
         final notifier = ref.read(playerProvider.notifier);
         ref
             .read(lastFmScrobbleProvider.notifier)
@@ -230,6 +241,25 @@ class _MainShellState extends ConsumerState<MainShell>
     } else {
       _navBarAnimationController.forward();
     }
+  }
+
+  void _maybeOpenExternalPlayer(Song? song) {
+    if (song?.isExternal != true) {
+      return;
+    }
+    if (!ref.read(isPlayingProvider) || NavigationHelper.isFullPlayerOpen) {
+      return;
+    }
+
+    Future.delayed(const Duration(milliseconds: 100), () {
+      if (!mounted || NavigationHelper.isFullPlayerOpen || song == null) {
+        return;
+      }
+      NavigationHelper.navigateToFullPlayer(
+        context,
+        heroTag: 'external_${song.id}',
+      );
+    });
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -14,6 +14,7 @@ import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart'
 import 'package:flick/models/player_screen_mode.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/external_playback_service.dart';
 import 'package:flick/services/favorites_service.dart';
 import 'package:flick/services/lyrics_service.dart';
 import 'package:flick/services/player_screen_mode_preference_service.dart';
@@ -35,6 +36,8 @@ class FullPlayerScreen extends StatefulWidget {
 class _FullPlayerScreenState extends State<FullPlayerScreen>
     with TickerProviderStateMixin {
   final PlayerService _playerService = PlayerService();
+  final ExternalPlaybackService _externalPlaybackService =
+      ExternalPlaybackService();
   final FavoritesService _favoritesService = FavoritesService();
   final LyricsService _lyricsService = LyricsService();
   final PlayerScreenModePreferenceService _playerScreenModePreferenceService =
@@ -1188,48 +1191,54 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
             ],
           ],
         ),
-        FutureBuilder<bool>(
-          future: _favoritesService.isFavorite(song.id),
-          builder: (context, snapshot) {
-            final isFavorite = snapshot.data ?? false;
-            return GestureDetector(
-              onTap: () async {
-                final newState = await _favoritesService.toggleFavorite(
-                  song.id,
-                );
-                setState(() {});
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        newState
-                            ? 'Added to favorites'
-                            : 'Removed from favorites',
-                      ),
-                      duration: const Duration(seconds: 1),
-                    ),
+        if (song.isExternal)
+          SizedBox(
+            width: favoriteIconSize + actionPadding.horizontal,
+            height: favoriteIconSize + actionPadding.vertical,
+          )
+        else
+          FutureBuilder<bool>(
+            future: _favoritesService.isFavorite(song.id),
+            builder: (context, snapshot) {
+              final isFavorite = snapshot.data ?? false;
+              return GestureDetector(
+                onTap: () async {
+                  final newState = await _favoritesService.toggleFavorite(
+                    song.id,
                   );
-                }
-              },
-              child: Container(
-                padding: actionPadding,
-                decoration: BoxDecoration(
-                  color: isFavorite
-                      ? Colors.red.withValues(alpha: 0.25)
-                      : Colors.white.withValues(alpha: 0.15),
-                  borderRadius: BorderRadius.circular(actionRadius),
+                  setState(() {});
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          newState
+                              ? 'Added to favorites'
+                              : 'Removed from favorites',
+                        ),
+                        duration: const Duration(seconds: 1),
+                      ),
+                    );
+                  }
+                },
+                child: Container(
+                  padding: actionPadding,
+                  decoration: BoxDecoration(
+                    color: isFavorite
+                        ? Colors.red.withValues(alpha: 0.25)
+                        : Colors.white.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(actionRadius),
+                  ),
+                  child: Icon(
+                    isFavorite ? Icons.favorite : Icons.favorite_border,
+                    color: isFavorite
+                        ? Colors.red
+                        : Colors.white.withValues(alpha: 0.9),
+                    size: favoriteIconSize,
+                  ),
                 ),
-                child: Icon(
-                  isFavorite ? Icons.favorite : Icons.favorite_border,
-                  color: isFavorite
-                      ? Colors.red
-                      : Colors.white.withValues(alpha: 0.9),
-                  size: favoriteIconSize,
-                ),
-              ),
-            );
-          },
-        ),
+              );
+            },
+          ),
       ],
     );
   }
@@ -1240,6 +1249,36 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
     required bool compact,
   }) {
     if (song.filePath == null) return const SizedBox.shrink();
+    if (song.isFromLocker) {
+      return Padding(
+        padding: EdgeInsets.only(
+          left: context.responsive(12.0, 16.0, 20.0),
+          right: context.responsive(12.0, 16.0, 20.0),
+          top: compact ? context.responsive(8.0, 10.0, 12.0) : 0,
+          bottom: compact ? 0 : context.responsive(16.0, 20.0, 24.0),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              LucideIcons.lock,
+              size: context.responsive(11.0, 12.0, 13.0),
+              color: Colors.white.withValues(alpha: 0.7),
+            ),
+            SizedBox(width: context.responsive(4.0, 5.0, 6.0)),
+            Text(
+              'Opened from Locker',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: context.responsive(10.0, 11.0, 12.0),
+                color: Colors.white.withValues(alpha: 0.74),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+    if (song.isExternal) return const SizedBox.shrink();
 
     String dirText = '';
     final filePath = song.filePath!;
@@ -1378,6 +1417,13 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
                     });
                   },
                   onQueueSwipe: () => _queueSong(context, song),
+                  onReturnToLocker: () async {
+                    final returned = await _externalPlaybackService
+                        .returnToLocker();
+                    if (!returned && context.mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  },
                   onShowSongActions: () =>
                       _showSongActionsBottomSheet(context, song),
                   onPrevious: _animateToPreviousSong,
@@ -1417,6 +1463,7 @@ class _AnimatedSongScene extends StatelessWidget {
   final VoidCallback onOpenQueue;
   final VoidCallback onToggleLyrics;
   final Future<void> Function() onQueueSwipe;
+  final Future<void> Function() onReturnToLocker;
   final VoidCallback onShowSongActions;
   final Future<void> Function() onPrevious;
   final Future<void> Function() onNext;
@@ -1441,6 +1488,7 @@ class _AnimatedSongScene extends StatelessWidget {
     required this.onOpenQueue,
     required this.onToggleLyrics,
     required this.onQueueSwipe,
+    required this.onReturnToLocker,
     required this.onShowSongActions,
     required this.onPrevious,
     required this.onNext,
@@ -1627,6 +1675,7 @@ class _AnimatedSongScene extends StatelessWidget {
                 valueListenable: playerService.queueNotifier,
                 builder: (context, queue, _) {
                   final hasQueue = queue.isNotEmpty;
+                  final fromLocker = song.isFromLocker;
                   final chip = AnimatedContainer(
                     duration: const Duration(milliseconds: 180),
                     padding: EdgeInsets.symmetric(
@@ -1645,21 +1694,27 @@ class _AnimatedSongScene extends StatelessWidget {
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              'Now Playing',
-                              style: TextStyle(
-                                fontFamily: 'ProductSans',
-                                fontSize: context.responsive(12.0, 13.0, 14.0),
-                                fontWeight: FontWeight.w600,
-                                color: Colors.white.withValues(alpha: 0.9),
-                                letterSpacing: 0.8,
-                              ),
-                            ),
-                          ],
+                        Text(
+                          'Now Playing',
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: context.responsive(12.0, 13.0, 14.0),
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white.withValues(alpha: 0.9),
+                            letterSpacing: 0.8,
+                          ),
                         ),
+                        if (fromLocker) ...[
+                          SizedBox(height: context.responsive(2.0, 3.0, 4.0)),
+                          Text(
+                            'Opened from Locker',
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              fontSize: context.responsive(10.0, 10.5, 11.0),
+                              color: Colors.white.withValues(alpha: 0.7),
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   );
@@ -1678,12 +1733,60 @@ class _AnimatedSongScene extends StatelessWidget {
             ),
           ),
           SizedBox(width: context.responsive(8.0, 10.0, 12.0)),
-          _buildChromeButton(
-            context,
-            icon: Icons.more_vert,
-            onTap: onShowSongActions,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (song.isFromLocker) ...[
+                _buildReturnToLockerButton(context),
+                SizedBox(width: context.responsive(8.0, 10.0, 12.0)),
+              ],
+              _buildChromeButton(
+                context,
+                icon: Icons.more_vert,
+                onTap: onShowSongActions,
+              ),
+            ],
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildReturnToLockerButton(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        unawaited(onReturnToLocker());
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: context.responsive(12.0, 14.0, 16.0),
+          vertical: context.responsive(10.0, 11.0, 12.0),
+        ),
+        decoration: BoxDecoration(
+          color: const Color(0xFF121212).withValues(alpha: 0.76),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              LucideIcons.undo2,
+              size: context.responsive(14.0, 15.0, 16.0),
+              color: Colors.white.withValues(alpha: 0.9),
+            ),
+            SizedBox(width: context.responsive(6.0, 7.0, 8.0)),
+            Text(
+              'Back to Locker',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: context.responsive(11.0, 12.0, 13.0),
+                fontWeight: FontWeight.w600,
+                color: Colors.white.withValues(alpha: 0.92),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/playlists/screens/playlists_screen.dart
+++ b/lib/features/playlists/screens/playlists_screen.dart
@@ -6,7 +6,10 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/models/playlist.dart';
+import 'package:flick/models/song.dart';
 import 'package:flick/providers/playlist_provider.dart';
+import 'package:flick/providers/songs_provider.dart';
+import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/features/playlists/screens/playlist_detail_screen.dart';
 
 class PlaylistsScreen extends ConsumerWidget {
@@ -511,20 +514,7 @@ class _PlaylistCard extends StatelessWidget {
             padding: const EdgeInsets.all(AppConstants.spacingMd),
             child: Row(
               children: [
-                Container(
-                  width: context.scaleSize(56),
-                  height: context.scaleSize(56),
-                  decoration: BoxDecoration(
-                    color: AppColors.surfaceLight,
-                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                    border: Border.all(color: AppColors.surfaceDark),
-                  ),
-                  child: Icon(
-                    LucideIcons.music,
-                    color: context.adaptiveTextSecondary,
-                    size: context.responsiveIcon(AppConstants.iconSizeLg),
-                  ),
-                ),
+                _PlaylistCover(playlist: playlist),
                 const SizedBox(width: AppConstants.spacingMd),
                 Expanded(
                   child: Column(
@@ -608,6 +598,116 @@ class _PlaylistCard extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _PlaylistCover extends ConsumerWidget {
+  final Playlist playlist;
+
+  const _PlaylistCover({required this.playlist});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final songsAsync = ref.watch(songsProvider);
+
+    return songsAsync.when(
+      loading: () => _buildCoverPlaceholder(context),
+      error: (_, __) => _buildCoverPlaceholder(context),
+      data: (songsState) {
+        final playlistSongs = songsState.songs
+            .where((song) => playlist.songIds.contains(song.id))
+            .toList();
+
+        if (playlistSongs.isEmpty) {
+          return _buildCoverPlaceholder(context);
+        }
+
+        final artworkPaths = playlistSongs
+            .map((s) => s.albumArt)
+            .where((art) => art != null && art.isNotEmpty)
+            .cast<String>()
+            .take(4)
+            .toList();
+
+        return _buildCoverGrid(context, artworkPaths);
+      },
+    );
+  }
+
+  Widget _buildCoverPlaceholder(BuildContext context) {
+    return Container(
+      width: context.scaleSize(56),
+      height: context.scaleSize(56),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.surfaceDark),
+      ),
+      child: Icon(
+        LucideIcons.music,
+        color: context.adaptiveTextSecondary,
+        size: context.responsiveIcon(AppConstants.iconSizeLg),
+      ),
+    );
+  }
+
+  Widget _buildCoverGrid(BuildContext context, List<String> artworkPaths) {
+    final size = context.scaleSize(56);
+
+    if (artworkPaths.isEmpty) {
+      return _buildCoverPlaceholder(context);
+    }
+
+    if (artworkPaths.length == 1) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        child: SizedBox(
+          width: size,
+          height: size,
+          child: CachedImageWidget(
+            imagePath: artworkPaths[0],
+            fit: BoxFit.cover,
+            placeholder: _buildPlaceholderIcon(context),
+            errorWidget: _buildPlaceholderIcon(context),
+          ),
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: _buildGridArt(context, artworkPaths, size),
+      ),
+    );
+  }
+
+  Widget _buildGridArt(BuildContext context, List<String> artworkPaths, double size) {
+    return GridView.count(
+      crossAxisCount: 2,
+      physics: const NeverScrollableScrollPhysics(),
+      children: artworkPaths.take(4).map((path) {
+        return CachedImageWidget(
+          imagePath: path,
+          fit: BoxFit.cover,
+          placeholder: Container(color: AppColors.surfaceLight),
+          errorWidget: Container(color: AppColors.surfaceLight),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildPlaceholderIcon(BuildContext context) {
+    return Container(
+      color: AppColors.surfaceLight,
+      child: Icon(
+        LucideIcons.music,
+        color: context.adaptiveTextSecondary,
+        size: context.responsiveIcon(AppConstants.iconSizeLg),
       ),
     );
   }

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -125,6 +125,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                         setState(() {
                           _searchQuery = value.toLowerCase();
                           _selectedIndex = 0;
+                          _lastSyncedSong = null;
                         });
                       },
                     ),
@@ -141,7 +142,10 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                       final isFolderMode = songsState.sortOption == SongSortOption.folder;
                       final allSongs = songsState.sortedSongs;
                       var songs = allSongs;
-                      _cachedSongs = songsState.songs;
+                      if (_cachedSongs != songsState.songs) {
+                        _cachedSongs = songsState.songs;
+                        _lastSyncedSong = null;
+                      }
 
                       if (_searchQuery.isNotEmpty) {
                         songs = songs.where((song) {
@@ -614,10 +618,17 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
     }).toList();
   }
 
+  Song? _lastSyncedSong;
+
   void _syncInterfaceToCurrentSong(Song? song, {bool animate = true}) {
     if (!mounted || song == null || _cachedSongs.isEmpty) {
       return;
     }
+
+    if (_lastSyncedSong != null && _lastSyncedSong!.id == song.id) {
+      return;
+    }
+    _lastSyncedSong = song;
 
     final visibleSongs = _visibleSongsFromCache();
     final targetIndex = visibleSongs.indexWhere((candidate) {
@@ -904,6 +915,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                       ref.read(songsProvider.notifier).setSortOption(result);
                       setState(() {
                         _selectedIndex = 0;
+                        _lastSyncedSong = null;
                       });
                     } else if (result is SongFileTypeFilter) {
                       ref
@@ -911,6 +923,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                           .setFileTypeFilter(result);
                       setState(() {
                         _selectedIndex = 0;
+                        _lastSyncedSong = null;
                       });
                     }
                   },

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -39,6 +39,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   final OrbitScrollController _orbitScrollController = OrbitScrollController();
   String _searchQuery = '';
   List<Song> _cachedSongs = [];
+  List<Song> _cachedDisplaySongs = [];
   String _selectedFastToken = 'A';
   late final ProviderSubscription<Song?> _currentSongSubscription;
   bool _alignedCurrentSongAfterLoad = false;
@@ -155,6 +156,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                               song.artist.toLowerCase().contains(_searchQuery);
                         }).toList();
                       }
+                      _cachedDisplaySongs = songs;
 
                       if (songs.isEmpty && _searchQuery.isEmpty) {
                         return _buildEmptyState();
@@ -608,20 +610,13 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   }
 
   List<Song> _visibleSongsFromCache() {
-    if (_searchQuery.isEmpty) {
-      return _cachedSongs;
-    }
-
-    return _cachedSongs.where((song) {
-      return song.title.toLowerCase().contains(_searchQuery) ||
-          song.artist.toLowerCase().contains(_searchQuery);
-    }).toList();
+    return _cachedDisplaySongs;
   }
 
   Song? _lastSyncedSong;
 
   void _syncInterfaceToCurrentSong(Song? song, {bool animate = true}) {
-    if (!mounted || song == null || _cachedSongs.isEmpty) {
+    if (!mounted || song == null || _cachedDisplaySongs.isEmpty) {
       return;
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/src/rust/frb_generated.dart';
 import 'package:flick/app/app.dart';
 import 'package:flick/data/database.dart';
+import 'package:flick/services/external_playback_service.dart';
 import 'package:flick/services/permission_service.dart';
 import 'package:flick/services/player_service.dart';
 
@@ -16,7 +17,10 @@ Future<void> main() async {
 
   await Database.init();
 
-  await _restoreLastPlayedSong();
+  final externalPlaybackHandled = await ExternalPlaybackService().initialize();
+  if (!externalPlaybackHandled) {
+    await _restoreLastPlayedSong();
+  }
 
   runApp(const ProviderScope(child: FlickPlayerApp()));
 

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -48,6 +48,12 @@ class Song {
   /// Date the song was added to the library
   final DateTime? dateAdded;
 
+  /// True when the song came from an external app handoff.
+  final bool isExternal;
+
+  /// Package name of the app that handed this song to Flick.
+  final String? sourcePackage;
+
   const Song({
     required this.id,
     required this.title,
@@ -65,7 +71,11 @@ class Song {
     this.filePath,
     this.folderUri,
     this.dateAdded,
+    this.isExternal = false,
+    this.sourcePackage,
   });
+
+  bool get isFromLocker => sourcePackage == 'com.ultraelectronica.locker';
 
   /// Format duration as mm:ss or hh:mm:ss
   String get formattedDuration {
@@ -97,6 +107,8 @@ class Song {
     String? filePath,
     String? folderUri,
     DateTime? dateAdded,
+    bool? isExternal,
+    String? sourcePackage,
   }) {
     return Song(
       id: id ?? this.id,
@@ -115,6 +127,8 @@ class Song {
       filePath: filePath ?? this.filePath,
       folderUri: folderUri ?? this.folderUri,
       dateAdded: dateAdded ?? this.dateAdded,
+      isExternal: isExternal ?? this.isExternal,
+      sourcePackage: sourcePackage ?? this.sourcePackage,
     );
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -197,7 +197,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
 
         final positionAdvanced =
             latestPositionSeconds > _lastTrackedPositionSeconds;
-        if (positionAdvanced) {
+        if (positionAdvanced && !latestSong.isExternal) {
           unawaited(
             ref
                 .read(lastFmScrobbleProvider.notifier)
@@ -257,6 +257,9 @@ class PlayerNotifier extends Notifier<PlayerState> {
   }
 
   void _handleTrackStarted(Song song) {
+    if (song.isExternal) {
+      return;
+    }
     unawaited(
       ref
           .read(lastFmScrobbleProvider.notifier)
@@ -276,6 +279,9 @@ class PlayerNotifier extends Notifier<PlayerState> {
     required int listenedSeconds,
     required int trackDurationSeconds,
   }) {
+    if (endedSong.isExternal) {
+      return;
+    }
     unawaited(
       ref
           .read(lastFmScrobbleProvider.notifier)

--- a/lib/services/external_playback_service.dart
+++ b/lib/services/external_playback_service.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flick/core/utils/audio_metadata_utils.dart';
+import 'package:flick/models/song.dart';
+import 'package:flick/services/music_folder_service.dart';
+import 'package:flick/services/player_service.dart';
+
+class ExternalPlaybackService {
+  ExternalPlaybackService._();
+
+  static final ExternalPlaybackService _instance = ExternalPlaybackService._();
+  static const _channel = MethodChannel(
+    'com.ultraelectronica.flick/integration',
+  );
+  static const _lockerPackage = 'com.ultraelectronica.locker';
+
+  factory ExternalPlaybackService() => _instance;
+
+  final MusicFolderService _musicFolderService = MusicFolderService();
+  bool _initialized = false;
+
+  Future<bool> initialize() async {
+    if (!_initialized) {
+      _channel.setMethodCallHandler(_handleMethodCall);
+      _initialized = true;
+    }
+
+    return _consumePendingExternalPlayback();
+  }
+
+  Future<bool> returnToLocker() async {
+    try {
+      return await _channel.invokeMethod<bool>('returnToLocker') ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('Failed to return to Locker: ${e.message}');
+      return false;
+    }
+  }
+
+  Future<bool> _consumePendingExternalPlayback() async {
+    try {
+      final payload = await _channel.invokeMapMethod<dynamic, dynamic>(
+        'consumePendingExternalPlayback',
+      );
+      if (payload == null) {
+        return false;
+      }
+      return _playExternalPayload(payload.cast<String, dynamic>());
+    } on PlatformException catch (e) {
+      debugPrint('Failed to consume pending external playback: ${e.message}');
+      return false;
+    }
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    if (call.method != 'externalPlaybackIntent') {
+      throw MissingPluginException(
+        'Unhandled integration method: ${call.method}',
+      );
+    }
+
+    final arguments = call.arguments;
+    if (arguments is! Map) {
+      return false;
+    }
+
+    return _playExternalPayload(arguments.cast<String, dynamic>());
+  }
+
+  Future<bool> _playExternalPayload(Map<String, dynamic> payload) async {
+    final uri = payload['uri'] as String?;
+    if (uri == null || uri.isEmpty) {
+      return false;
+    }
+
+    try {
+      final metadataList = await _musicFolderService.fetchMetadata([uri]);
+      final metadata = metadataList.isNotEmpty ? metadataList.first : null;
+      final displayName = payload['displayName'] as String?;
+      final mimeType = payload['mimeType'] as String?;
+      final sourcePackage =
+          (payload['sourcePackage'] as String?) ??
+          ((payload['fromLocker'] == true) ? _lockerPackage : null);
+      final song = Song(
+        id: 'external:${DateTime.now().microsecondsSinceEpoch}:$uri',
+        title: _resolveTitle(metadata?.title, displayName, uri),
+        artist: metadata?.artist?.trim().isNotEmpty == true
+            ? metadata!.artist!.trim()
+            : 'Unknown artist',
+        albumArt: metadata?.albumArtPath,
+        duration: Duration(milliseconds: metadata?.duration ?? 0),
+        fileType: _resolveFileType(metadata?.extension, mimeType, uri),
+        resolution: _resolveResolution(
+          bitrate: metadata?.bitrate,
+          sampleRate: metadata?.sampleRate,
+          bitDepth: metadata?.bitDepth,
+        ),
+        sampleRate: metadata?.sampleRate,
+        bitDepth: metadata?.bitDepth,
+        album: metadata?.album,
+        albumArtist: metadata?.albumArtist,
+        trackNumber: metadata?.trackNumber,
+        discNumber: metadata?.discNumber,
+        filePath: uri,
+        isExternal: true,
+        sourcePackage: sourcePackage,
+      );
+
+      await PlayerService().play(song, playlist: [song]);
+      return true;
+    } catch (e, stackTrace) {
+      debugPrint('Failed to start external playback for $uri: $e');
+      debugPrintStack(stackTrace: stackTrace);
+      return false;
+    }
+  }
+
+  String _resolveTitle(String? title, String? displayName, String uri) {
+    final trimmedTitle = title?.trim();
+    if (trimmedTitle != null && trimmedTitle.isNotEmpty) {
+      return trimmedTitle;
+    }
+
+    final trimmedDisplayName = displayName?.trim();
+    if (trimmedDisplayName != null && trimmedDisplayName.isNotEmpty) {
+      return trimmedDisplayName;
+    }
+
+    final pathSegments = Uri.tryParse(uri)?.pathSegments ?? const <String>[];
+    final fallback = pathSegments.isNotEmpty ? pathSegments.last : null;
+    return fallback == null || fallback.isEmpty ? 'Unknown track' : fallback;
+  }
+
+  String _resolveFileType(String? extension, String? mimeType, String uri) {
+    final normalized = _canonicalPlaybackFileType(
+      fileType: extension ?? mimeType ?? '',
+      filePath: uri,
+    );
+    if (normalized.isNotEmpty) {
+      return normalized.toUpperCase();
+    }
+
+    return 'AUDIO';
+  }
+
+  String? _resolveResolution({
+    String? bitrate,
+    int? sampleRate,
+    int? bitDepth,
+  }) {
+    if (sampleRate != null &&
+        sampleRate > 0 &&
+        bitDepth != null &&
+        bitDepth > 0) {
+      final sampleRateLabel = sampleRate % 1000 == 0
+          ? '${sampleRate ~/ 1000}kHz'
+          : '${(sampleRate / 1000).toStringAsFixed(1)}kHz';
+      return '$bitDepth-bit/$sampleRateLabel';
+    }
+
+    final bitrateValue = int.tryParse(bitrate ?? '');
+    return AudioMetadataUtils.formatBitrateLabel(
+      bitrateValue,
+      sampleRate: sampleRate,
+      bitDepth: bitDepth,
+    );
+  }
+
+  bool isLockerSession(Song? song) {
+    return song?.isExternal == true && song?.sourcePackage == _lockerPackage;
+  }
+}
+
+String _canonicalPlaybackFileType({
+  required String fileType,
+  String? filePath,
+}) {
+  final pathExtension = _extractPlaybackPathExtension(filePath);
+  final candidates = <String>[
+    if (pathExtension.isNotEmpty) pathExtension,
+    if (fileType.trim().isNotEmpty) fileType,
+  ];
+
+  for (final candidate in candidates) {
+    final normalized = _normalizePlaybackFileTypeCandidate(candidate);
+    if (normalized.isNotEmpty) {
+      return normalized;
+    }
+  }
+
+  return '';
+}
+
+String _extractPlaybackPathExtension(String? path) {
+  if (path == null || path.isEmpty) return '';
+
+  final withoutQuery = path.split('?').first.split('#').first;
+  final dotIndex = withoutQuery.lastIndexOf('.');
+  if (dotIndex < 0 || dotIndex >= withoutQuery.length - 1) return '';
+  return withoutQuery.substring(dotIndex + 1).toLowerCase();
+}
+
+String _normalizePlaybackFileTypeCandidate(String rawValue) {
+  var token = rawValue.trim().toLowerCase();
+  if (token.isEmpty) return '';
+
+  final separatorIndex = token.indexOf(';');
+  if (separatorIndex >= 0) {
+    token = token.substring(0, separatorIndex);
+  }
+
+  final slashIndex = token.lastIndexOf('/');
+  if (slashIndex >= 0 && slashIndex < token.length - 1) {
+    token = token.substring(slashIndex + 1);
+  }
+
+  token = token.replaceFirst(RegExp(r'^\.+'), '');
+  token = token.trim();
+
+  switch (token) {
+    case 'aif':
+    case 'aiff':
+    case 'x-aiff':
+      return 'aiff';
+    case 'alac':
+    case 'm4a':
+    case 'mp4':
+    case 'x-m4a':
+      return 'm4a';
+    case 'ogg':
+    case 'oga':
+    case 'vorbis':
+      return 'ogg';
+    case 'ogx':
+      return 'ogx';
+    case 'opus':
+      return 'opus';
+    case 'wave':
+      return 'wav';
+    default:
+      return token;
+  }
+}

--- a/lib/services/music_folder_service.dart
+++ b/lib/services/music_folder_service.dart
@@ -369,6 +369,10 @@ class MusicFolderService {
     }
   }
 
+  Future<String?> getDocumentDisplayName(String uri) {
+    return _getDisplayName(uri);
+  }
+
   Future<String?> resolveFilesystemPath(String uri) async {
     try {
       if (!uri.startsWith('content://')) {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1337,6 +1337,14 @@ class PlayerService {
     _replayPlayTracker.startTrack(song.id, initialPosition: initialPosition);
   }
 
+  bool _shouldPersistSong(Song? song) {
+    return song != null && !song.isExternal;
+  }
+
+  bool _allowsFavoriteActions(Song? song) {
+    return song != null && !song.isExternal;
+  }
+
   void _clearReplayTracking() {
     _replayPlayTracker.clear();
   }
@@ -1357,7 +1365,7 @@ class PlayerService {
       songId: song.id,
       position: position,
     );
-    if (counted) {
+    if (counted && _shouldPersistSong(song)) {
       unawaited(_recentlyPlayedRepository.recordPlay(song.id));
     }
   }
@@ -1555,8 +1563,8 @@ class PlayerService {
 
   Future<void> _toggleFavoriteFromNotification() async {
     final song = currentSongNotifier.value;
-    if (song != null) {
-      await _favoritesService.toggleFavorite(song.id);
+    if (_allowsFavoriteActions(song)) {
+      await _favoritesService.toggleFavorite(song!.id);
       _updateNotificationState();
     }
   }
@@ -1566,10 +1574,12 @@ class PlayerService {
     if (song == null) return;
 
     var isFav = false;
-    try {
-      isFav = await _favoritesService.isFavorite(song.id);
-    } catch (e) {
-      debugPrint('Failed to load favorite state: $e');
+    if (_allowsFavoriteActions(song)) {
+      try {
+        isFav = await _favoritesService.isFavorite(song.id);
+      } catch (e) {
+        debugPrint('Failed to load favorite state: $e');
+      }
     }
 
     await _notificationService.updateNotification(
@@ -2620,11 +2630,12 @@ class PlayerService {
 
   Future<void> _savePosition({Song? song, Duration? position}) async {
     final resolvedSong = song ?? currentSongNotifier.value;
-    if (resolvedSong == null) return;
+    if (!_shouldPersistSong(resolvedSong)) return;
+    final persistedSong = resolvedSong!;
 
     try {
       await _lastPlayedService.saveLastPlayed(
-        resolvedSong.id,
+        persistedSong.id,
         position ?? positionNotifier.value,
         playlistSongIds: _playlist.map((s) => s.id).toList(),
         currentIndex: _currentIndex,

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1689,7 +1689,7 @@ class PlayerService {
 
     // SAF-backed URIs for ALAC/AIFF/M4A can fail format detection in some
     // decoder paths. Stage them to a local temp file with a stable extension.
-    if (isAndroidContentUri && _shouldStageForPlayback(song)) {
+    if (isAndroidContentUri && _shouldStageContentUriForPlayback(song)) {
       final stagedPath = await _stageContentUriForPlayback(
         filePath,
         extensionHint: _preferredExtension(song),
@@ -1715,6 +1715,10 @@ class PlayerService {
   bool _shouldStageForPlayback(Song song) {
     final normalized = _playbackFileType(song);
     return normalized == 'm4a' || normalized == 'aiff';
+  }
+
+  bool _shouldStageContentUriForPlayback(Song song) {
+    return song.isExternal || _shouldStageForPlayback(song);
   }
 
   Future<String?> _stageContentUriForPlayback(
@@ -1847,7 +1851,8 @@ class PlayerService {
   }
 
   Future<void> _prepareImmediatePlaybackAsset(Song song) async {
-    if (!_shouldStageForPlayback(song) && !_shouldConvertToWav(song)) {
+    if (!_shouldStageContentUriForPlayback(song) &&
+        !_shouldConvertToWav(song)) {
       return;
     }
 
@@ -3373,6 +3378,9 @@ class PlayerService {
     playbackSpeedNotifier.dispose();
     sleepTimerRemainingNotifier.dispose();
 
+    for (final stagedPath in _stagedPlaybackPathCache.values) {
+      unawaited(_deleteTemporaryPlaybackFile(stagedPath));
+    }
     for (final convertedPath in _convertedPlaybackPathCache.values) {
       unawaited(_deleteTemporaryPlaybackFile(convertedPath));
     }


### PR DESCRIPTION
# Summary

- Add external playback service for processing intents from Locker and third-party apps
- Add content intent handling for `audio/*` URIs
- Add external songs support with "Back to Locker" button
- Add playlist cover component to `PlaylistsScreen`
- Enhance song display logic and synchronization in `SongsScreen`

# Changes

## External Playback

- Add `ExternalPlaybackService` to process external intents
- Implement `ACTION_VIEW` intent filter for `audio/*` content URIs
- Add `isExternal` flag and `sourcePackage` to Song model
- Add `isFromLocker` getter for locker app detection
- Auto-open full player for external songs

## UI Features

- Add playlist cover component with dynamic artwork based on songs
- Add "Back to Locker" button and status indicators
- Hide favorites toggle for external/locker songs
- Skip Last.fm scrobbling for external songs to avoid incorrect scrobbles

## Song Display

- Refactor song synchronization with `_lastSyncedSong` to prevent redundant updates
- Add `_cachedDisplaySongs` for search functionality

# Files Changed

- `lib/services/external_playback_service.dart` — New external playback service
- `android/app/src/main/kotlin/.../MainActivity.kt` — Content intent handling
- `lib/app/app.dart` — External auto-open logic
- `lib/features/player/screens/full_player_screen.dart` — Locker integration UI
- `lib/features/playlists/screens/playlists_screen.dart` — Playlist covers
- `lib/features/songs/screens/songs_screen.dart` — Song sync improvements
- `lib/models/song.dart` — External song tracking
- `lib/providers/player_provider.dart` — External scrobbling prevention