### PR TITLE
Add audio visualizer with real-time FFT capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Flick Player is a high-performance music player application built with Flutter a
 
 ### Audio Engine
 - **Primary**: Custom Rust audio engine with UAC 2.0 support for bit-perfect playback through USB DACs/AMPs
+- **DAP Bit-Perfect**: High-resolution playback through device's internal DAC via Oboe/AAudio exclusive mode, with device qualification for confirmed bit-perfect DAPs
 - **Fallback**: `just_audio` for standard audio playback on devices without USB audio support
 - **Audio Processing**: Advanced EQ, dynamics, and spatial/time effects via JustAudioProcessingController on Android
 - **EQ Preset Management**: Import/export functionality for EQ presets in JSON and TXT formats with parametric band support
@@ -20,7 +21,7 @@ Flick Player is a high-performance music player application built with Flutter a
 - Bit-perfect audio transmission to external USB audio devices
 
 ### Advanced Equalizer & Audio Effects
-- 10-band graphic equalizer with parametric controls
+- 10-band graphic equalizer with preamp and parametric controls
 - Real-time audio processing with EQ, dynamics, and spatial effects
 - Preset management with import/export functionality (JSON/TXT formats)
 - Spatial and time effects including balance, tempo, damp, filter, delay, size, mix, feedback, and width

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Visualizer API requires RECORD_AUDIO to read the output mix -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application
         android:label="Flick"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt
@@ -20,6 +20,7 @@ import android.media.AudioAttributes
 import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.MediaMetadataRetriever
+import android.media.audiofx.Visualizer
 import android.database.ContentObserver
 import android.os.Handler
 import android.os.Looper
@@ -38,6 +39,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugins.GeneratedPluginRegistrant
 import kotlinx.coroutines.CoroutineScope
@@ -60,6 +62,8 @@ class MainActivity: FlutterActivity() {
     private val UAC2_CHANNEL = "com.ultraelectronica.flick/uac2"
     private val AUDIO_DEVICE_CHANNEL = "com.ultraelectronica.flick/audio_device"
     private val EQUALIZER_CHANNEL = "com.ultraelectronica.flick/equalizer"
+    private val VISUALIZER_METHOD_CHANNEL = "com.ultraelectronica.flick/visualizer"
+    private val VISUALIZER_EVENT_CHANNEL = "com.ultraelectronica.flick/visualizer_events"
     private val LOCKER_PACKAGE = "com.ultraelectronica.locker"
     private val LOCKER_RETURN_URI = "locker://return?source=flick"
     // private val CONVERTER_CHANNEL = "com.ultraelectronica.flick/converter"
@@ -109,6 +113,8 @@ class MainActivity: FlutterActivity() {
     // private var audioConverter: AudioConverter? = null
     // Coroutine scope for background tasks
     private val mainScope = CoroutineScope(Dispatchers.Main)
+    private var visualizer: Visualizer? = null
+    private var visualizerEventSink: EventChannel.EventSink? = null
 
     // Load the Rust shared library before calling into native startup hooks.
     init {
@@ -698,6 +704,31 @@ class MainActivity: FlutterActivity() {
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, EQUALIZER_CHANNEL).setMethodCallHandler { call, result ->
             if (!justAudioProcessingController.handle(call, result)) {
                 result.notImplemented()
+            }
+        }
+
+        // Audio visualizer: attach to just_audio session for real FFT data
+        EventChannel(flutterEngine.dartExecutor.binaryMessenger, VISUALIZER_EVENT_CHANNEL).setStreamHandler(
+            object : EventChannel.StreamHandler {
+                override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+                    visualizerEventSink = events
+                }
+                override fun onCancel(arguments: Any?) {
+                    visualizerEventSink = null
+                }
+            }
+        )
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, VISUALIZER_METHOD_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "attachVisualizer" -> {
+                    val sessionId = call.argument<Int>("sessionId") ?: 0
+                    result.success(attachVisualizer(sessionId))
+                }
+                "detachVisualizer" -> {
+                    detachVisualizer()
+                    result.success(null)
+                }
+                else -> result.notImplemented()
             }
         }
 
@@ -3227,12 +3258,61 @@ class MainActivity: FlutterActivity() {
         }
     }
     
+    private fun attachVisualizer(sessionId: Int): Boolean {
+        return try {
+            detachVisualizer()
+            if (sessionId <= 0) {
+                Log.w("Visualizer", "Invalid audio session ID: $sessionId")
+                return false
+            }
+            val viz = Visualizer(sessionId).apply {
+                val captureSizeRange = Visualizer.getCaptureSizeRange()
+                val targetSize = captureSizeRange[1].coerceAtMost(512)
+                captureSize = targetSize
+                setDataCaptureListener(
+                    object : Visualizer.OnDataCaptureListener {
+                        override fun onWaveFormDataCapture(
+                            v: Visualizer?,
+                            waveform: ByteArray?,
+                            samplingRate: Int
+                        ) {}
+                        override fun onFftDataCapture(
+                            v: Visualizer?,
+                            fft: ByteArray?,
+                            samplingRate: Int
+                        ) {
+                            fft?.let { visualizerEventSink?.success(it) }
+                        }
+                    },
+                    30, // ~33 fps
+                    false,
+                    true
+                )
+                enabled = true
+            }
+            visualizer = viz
+            Log.i("Visualizer", "Attached to session $sessionId with capture size ${viz.captureSize}")
+            true
+        } catch (e: Exception) {
+            Log.e("Visualizer", "Failed to attach visualizer: ${e.message}", e)
+            false
+        }
+    }
+
+    private fun detachVisualizer() {
+        visualizer?.enabled = false
+        visualizer?.release()
+        visualizer = null
+        visualizerEventSink = null
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         unregisterReceiverSafely(usbHotplugReceiver)
         unregisterReceiverSafely(usbPermissionReceiver)
         unregisterVolumeContentObserver()
         justAudioProcessingController.release()
+        detachVisualizer()
         usbHotplugReceiver = null
         usbPermissionReceiver = null
         if (killIsochronousUsbOnQuit) {

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -41,8 +41,8 @@ The core audio engine in `rust/src/audio/engine.rs` features a sophisticated arc
 
 - **Lock-Free Design**: Uses atomic operations and lock-free data structures in the audio callback to prevent audio glitches
 - **Multiple Output Strategies**: Dynamically selects between USB Direct, DAP Native, Mixer Bit-Perfect, Mixer Matched, and Resampled Fallback based on device capabilities
-- **Real-Time Processing Chain**: Implements a complete DSP chain including volume control, 10-band graphic equalizer, spatial/time FX, dynamics processing (compressor/limiter), playback speed control, and crossfading
-- **Bit-Perfect Mode**: Includes a bit-perfect bypass that routes decoded audio directly to output when requested, skipping all DSP processing
+- **Real-Time Processing Chain**: Implements a complete DSP chain including volume control, 10-band graphic equalizer with preamp, spatial/time FX, dynamics processing (compressor/limiter), playback speed control, and crossfading
+- **Runtime Pipeline Mode**: Dynamically selects between `Passthrough` (bit-perfect, skips all DSP) and `Dsp` (full processing chain) at runtime, based on output strategy and device capabilities
 - **Continuous Verification**: Constantly monitors and verifies that the actual output matches the requested format for quality assurance
 - **Thread Safety**: Properly separates real-time audio processing (lock-free) from control operations (thread-safe)
 
@@ -93,11 +93,11 @@ Located in `rust/src/audio`, this is the heart of the application. It bypasses s
   - **Android Managed**: Standard audio playback through Oboe/AAudio or the Android mixer
   - **DAP Internal High-Res**: High-resolution audio through the device's internal DAC using Oboe/AAudio in exclusive mode
 
-- **Decoder (`decoder.rs`)**: Uses `symphonia` to read various audio formats (MP3, FLAC, WAV, OGG) and decode them into raw sound waves (PCM).
-  - **TODO**: ALAC and M4A files are not yet supported. These formats will not play any sound.
+- **Decoder (`decoder.rs`)**: Uses `symphonia` to read various audio formats (MP3, FLAC, WAV, OGG, M4A, ALAC, AIFF) and decode them into raw sound waves (PCM).
+- **ALAC Converter (`alac_converter.rs`)**: Lossless real-time conversion of ALAC/M4A/AIFF files to WAV/PCM, preserving original bit depth (16/24/32-bit). Session-based streaming conversion for memory efficiency.
 - **Resampler (`resampler.rs`)**: Uses `rubato` to change the audio quality on-the-fly. If a song is 44.1kHz but your speakers are 48kHz, this module smooths out the difference without losing quality.
 - **Crossfader (`crossfader.rs`)**: Handles the smooth blending between songs, so there is no silence when one track ends and the next begins.
-- **Equalizer (`equalizer.rs`)**: Implements a 10-band graphic equalizer for precise tonal control with parametric band support.
+- **Equalizer (`equalizer.rs`)**: Implements a 10-band graphic equalizer with preamp control and parametric band support for precise tonal control.
 - **FX Processing (`fx.rs`)**: Implements spatial and time effects including balance, tempo, damp, filter, delay, size, mix, feedback, and width for creative audio processing.
 - **Android Audio Processing (`android_audio_processing_service.dart`)**: On Android, uses JustAudioProcessingController for enhanced EQ and effects management with real-time processing capabilities.
 - **Source Provider (`source.rs`)**: Manages the queue for **Gapless Playback**, ensuring there are no awkward pauses between tracks by pre-loading the next song before the current one finishes.

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -19,6 +19,7 @@ import 'package:flick/services/favorites_service.dart';
 import 'package:flick/services/lyrics_service.dart';
 import 'package:flick/services/player_screen_mode_preference_service.dart';
 import 'package:flick/providers/playlist_provider.dart';
+import 'package:flick/features/player/widgets/audio_visualizer.dart';
 import 'package:flick/features/player/widgets/waveform_seek_bar.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
@@ -62,6 +63,7 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
   double? _cachedTopBarFontSize;
   double _cachedTopBarTextWidth = 0;
   bool _isLyricsMode = false;
+  bool _isVisualizationMode = false;
   int _songTransitionDirection = 1;
   PlayerScreenMode _playerScreenMode = PlayerScreenMode.immersive;
 
@@ -824,6 +826,19 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
               ),
               _buildSongActionTile(
                 context: sheetContext,
+                icon: Icons.graphic_eq_rounded,
+                label: _isVisualizationMode ? 'Hide Visualizer' : 'Visualizer',
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  if (mounted) {
+                    setState(() {
+                      _isVisualizationMode = !_isVisualizationMode;
+                    });
+                  }
+                },
+              ),
+              _buildSongActionTile(
+                context: sheetContext,
                 icon: LucideIcons.user,
                 label: 'Go to Artist',
                 onTap: () {
@@ -1461,6 +1476,7 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
                   key: ValueKey(song.id),
                   song: song,
                   lyricsMode: _isLyricsMode,
+                  visualizationMode: _isVisualizationMode,
                   playerScreenMode: _playerScreenMode,
                   transitionDirection: _songTransitionDirection,
                   topBarTextFontFamily: _topBarTextFontFamily,
@@ -1511,6 +1527,7 @@ class _FullPlayerScreenState extends State<FullPlayerScreen>
 class _AnimatedSongScene extends StatelessWidget {
   final Song song;
   final bool lyricsMode;
+  final bool visualizationMode;
   final PlayerScreenMode playerScreenMode;
   final int transitionDirection;
   final String topBarTextFontFamily;
@@ -1536,6 +1553,7 @@ class _AnimatedSongScene extends StatelessWidget {
     super.key,
     required this.song,
     required this.lyricsMode,
+    required this.visualizationMode,
     required this.playerScreenMode,
     required this.transitionDirection,
     required this.topBarTextFontFamily,
@@ -1620,6 +1638,35 @@ class _AnimatedSongScene extends StatelessWidget {
   }
 
   Widget _buildBackground(BuildContext context) {
+    if (visualizationMode && playerScreenMode != PlayerScreenMode.artworkCard) {
+      return Stack(
+        children: [
+          Positioned.fill(
+            child: AudioVisualizer(playerService: playerService),
+          ),
+          Positioned.fill(
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    const Color(0xFF0A0A0A).withValues(alpha: 0.7),
+                    const Color(0xFF0A0A0A).withValues(alpha: 0.35),
+                    Colors.transparent,
+                    Colors.transparent,
+                    const Color(0xFF0A0A0A).withValues(alpha: 0.3),
+                    const Color(0xFF0A0A0A).withValues(alpha: 0.75),
+                  ],
+                  stops: const [0.0, 0.12, 0.28, 0.62, 0.82, 1.0],
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
     if (playerScreenMode == PlayerScreenMode.artworkCard) {
       return Stack(
         children: [
@@ -1648,11 +1695,11 @@ class _AnimatedSongScene extends StatelessWidget {
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
                   colors: [
-                    const Color(0xFF080808).withValues(alpha: 0.62),
-                    const Color(0xFF101010).withValues(alpha: 0.42),
-                    const Color(0xFF0A0A0A).withValues(alpha: 0.9),
+                    const Color(0xFF080808).withValues(alpha: 0.5),
+                    const Color(0xFF0E0E0E).withValues(alpha: 0.32),
+                    const Color(0xFF0A0A0A).withValues(alpha: 0.94),
                   ],
-                  stops: const [0.0, 0.45, 1.0],
+                  stops: const [0.0, 0.5, 1.0],
                 ),
               ),
             ),
@@ -2100,23 +2147,23 @@ class _AnimatedSongScene extends StatelessWidget {
             .min(
               constraints.maxWidth - (horizontalPadding * 2),
               isVeryShortHeight
-                  ? constraints.maxHeight * 0.34
+                  ? constraints.maxHeight * 0.32
                   : isShortHeight
-                  ? constraints.maxHeight * 0.38
-                  : constraints.maxHeight * 0.44,
+                  ? constraints.maxHeight * 0.36
+                  : constraints.maxHeight * 0.42,
             )
-            .clamp(isVeryShortHeight ? 180.0 : 200.0, maxArtworkSize)
+            .clamp(isVeryShortHeight ? 160.0 : 180.0, maxArtworkSize)
             .toDouble();
         final artworkSpacing = isVeryShortHeight
-            ? 14.0
+            ? 12.0
             : isShortHeight
-            ? 18.0
-            : context.responsive(24.0, 28.0, 32.0);
+            ? 16.0
+            : context.responsive(22.0, 26.0, 30.0);
         final identitySpacing = isVeryShortHeight
-            ? 10.0
+            ? 8.0
             : isShortHeight
-            ? 14.0
-            : context.responsive(20.0, 22.0, 24.0);
+            ? 12.0
+            : context.responsive(18.0, 20.0, 22.0);
         final lyricsSpacing = isVeryShortHeight
             ? 12.0
             : context.responsive(16.0, 18.0, 20.0);
@@ -2124,10 +2171,10 @@ class _AnimatedSongScene extends StatelessWidget {
             ? 10.0
             : context.responsive(14.0, 16.0, 18.0);
         final directorySpacing = isVeryShortHeight
-            ? 8.0
+            ? 6.0
             : isShortHeight
-            ? 12.0
-            : context.responsive(14.0, 18.0, 22.0);
+            ? 10.0
+            : context.responsive(12.0, 16.0, 20.0);
 
         return Padding(
           padding: EdgeInsets.fromLTRB(
@@ -2157,7 +2204,12 @@ class _AnimatedSongScene extends StatelessWidget {
                       Flexible(
                         flex: isVeryShortHeight ? 5 : 7,
                         child: Center(
-                          child: _AlbumArtBox(song: song, size: artworkSize),
+                          child: visualizationMode
+                              ? _VisualizerArtBox(
+                                  playerService: playerService,
+                                  size: artworkSize,
+                                )
+                              : _AlbumArtBox(song: song, size: artworkSize),
                         ),
                       ),
                       SizedBox(height: artworkSpacing),
@@ -2193,18 +2245,18 @@ class _AnimatedSongScene extends StatelessWidget {
     bool veryCompact = false,
   }) {
     final titleSize = veryCompact
-        ? context.responsive(19.0, 21.0, 24.0)
+        ? context.responsive(20.0, 22.0, 25.0)
         : compact
-        ? context.responsive(21.0, 24.0, 27.0)
-        : context.responsive(24.0, 26.0, 29.0);
+        ? context.responsive(22.0, 25.0, 28.0)
+        : context.responsive(25.0, 27.0, 30.0);
     final artistSize = veryCompact
-        ? context.responsive(12.0, 13.0, 14.0)
-        : compact
         ? context.responsive(13.0, 14.0, 15.0)
-        : context.responsive(14.0, 15.0, 16.0);
+        : compact
+        ? context.responsive(14.0, 15.0, 16.0)
+        : context.responsive(15.0, 16.0, 17.0);
     final titleToArtistSpacing = veryCompact
         ? 6.0
-        : context.responsive(8.0, 9.0, 10.0);
+        : context.responsive(8.0, 10.0, 12.0);
     final artistToAlbumSpacing = veryCompact
         ? 8.0
         : compact
@@ -2245,7 +2297,7 @@ class _AnimatedSongScene extends StatelessWidget {
             fontFamily: 'ProductSans',
             fontSize: context.responsiveText(artistSize),
             fontWeight: FontWeight.w500,
-            color: Colors.white.withValues(alpha: 0.82),
+            color: Colors.white.withValues(alpha: 0.78),
           ),
         ),
         if (song.album != null && song.album!.trim().isNotEmpty) ...[
@@ -2256,9 +2308,9 @@ class _AnimatedSongScene extends StatelessWidget {
               vertical: albumVerticalPadding,
             ),
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: Colors.white.withValues(alpha: 0.06),
               borderRadius: BorderRadius.circular(999),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
             ),
             child: Text(
               song.album!,
@@ -2267,7 +2319,7 @@ class _AnimatedSongScene extends StatelessWidget {
               style: TextStyle(
                 fontFamily: 'ProductSans',
                 fontSize: context.responsiveText(albumFontSize),
-                color: Colors.white.withValues(alpha: 0.74),
+                color: Colors.white.withValues(alpha: 0.68),
               ),
             ),
           ),
@@ -2317,12 +2369,12 @@ class _AlbumArtBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double resolvedSize = size ?? context.responsive(280.0, 320.0, 360.0);
-    final framePadding = resolvedSize < 220 ? 4.0 : 6.0;
-    final outerRadius = resolvedSize < 220 ? 26.0 : 32.0;
-    final innerRadius = math.max(outerRadius - 6.0, 18.0);
+    final framePadding = resolvedSize < 220 ? 5.0 : 7.0;
+    final outerRadius = resolvedSize < 220 ? 28.0 : 34.0;
+    final innerRadius = math.max(outerRadius - 7.0, 20.0);
     final iconSize = math.max(52.0, resolvedSize * 0.24);
-    final shadowBlur = resolvedSize < 220 ? 24.0 : 30.0;
-    final shadowOffsetY = resolvedSize < 220 ? 12.0 : 16.0;
+    final shadowBlur = resolvedSize < 220 ? 28.0 : 36.0;
+    final shadowOffsetY = resolvedSize < 220 ? 14.0 : 20.0;
 
     return Center(
       child: Container(
@@ -2335,16 +2387,23 @@ class _AlbumArtBox extends StatelessWidget {
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
             colors: [
-              Colors.white.withValues(alpha: 0.2),
-              Colors.white.withValues(alpha: 0.04),
+              Colors.white.withValues(alpha: 0.16),
+              Colors.white.withValues(alpha: 0.06),
+              Colors.white.withValues(alpha: 0.02),
             ],
+            stops: const [0.0, 0.4, 1.0],
           ),
-          border: Border.all(color: Colors.white.withValues(alpha: 0.16)),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.28),
+              color: Colors.black.withValues(alpha: 0.32),
               blurRadius: shadowBlur,
               offset: Offset(0, shadowOffsetY),
+            ),
+            BoxShadow(
+              color: Colors.white.withValues(alpha: 0.06),
+              blurRadius: 1,
+              offset: const Offset(0, 1),
             ),
           ],
         ),
@@ -2355,21 +2414,79 @@ class _AlbumArtBox extends StatelessWidget {
             audioSourcePath: song.filePath,
             fit: BoxFit.cover,
             placeholder: Container(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: Colors.white.withValues(alpha: 0.05),
               child: Icon(
                 LucideIcons.music,
                 size: iconSize,
-                color: Colors.white.withValues(alpha: 0.68),
+                color: Colors.white.withValues(alpha: 0.48),
               ),
             ),
             errorWidget: Container(
-              color: Colors.white.withValues(alpha: 0.08),
+              color: Colors.white.withValues(alpha: 0.05),
               child: Icon(
                 LucideIcons.music,
                 size: iconSize,
-                color: Colors.white.withValues(alpha: 0.68),
+                color: Colors.white.withValues(alpha: 0.48),
               ),
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _VisualizerArtBox extends StatelessWidget {
+  final PlayerService playerService;
+  final double? size;
+
+  const _VisualizerArtBox({required this.playerService, this.size});
+
+  @override
+  Widget build(BuildContext context) {
+    final double resolvedSize = size ?? context.responsive(280.0, 320.0, 360.0);
+    final framePadding = resolvedSize < 220 ? 5.0 : 7.0;
+    final outerRadius = resolvedSize < 220 ? 28.0 : 34.0;
+    final innerRadius = math.max(outerRadius - 7.0, 20.0);
+    final shadowBlur = resolvedSize < 220 ? 28.0 : 36.0;
+    final shadowOffsetY = resolvedSize < 220 ? 14.0 : 20.0;
+
+    return Center(
+      child: Container(
+        width: resolvedSize,
+        height: resolvedSize,
+        padding: EdgeInsets.all(framePadding),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(outerRadius),
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Colors.white.withValues(alpha: 0.16),
+              Colors.white.withValues(alpha: 0.06),
+              Colors.white.withValues(alpha: 0.02),
+            ],
+            stops: const [0.0, 0.4, 1.0],
+          ),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.32),
+              blurRadius: shadowBlur,
+              offset: Offset(0, shadowOffsetY),
+            ),
+            BoxShadow(
+              color: Colors.white.withValues(alpha: 0.06),
+              blurRadius: 1,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(innerRadius),
+          child: Container(
+            color: const Color(0xFF0A0A0A),
+            child: AudioVisualizer(playerService: playerService),
           ),
         ),
       ),

--- a/lib/features/player/widgets/audio_visualizer.dart
+++ b/lib/features/player/widgets/audio_visualizer.dart
@@ -1,0 +1,393 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flick/services/player_service.dart';
+import 'package:flick/services/visualizer_service.dart';
+
+class AudioVisualizer extends StatefulWidget {
+  final PlayerService playerService;
+
+  const AudioVisualizer({super.key, required this.playerService});
+
+  @override
+  State<AudioVisualizer> createState() => _AudioVisualizerState();
+}
+
+class _AudioVisualizerState extends State<AudioVisualizer>
+    with TickerProviderStateMixin {
+  static const int _barCount = 48;
+  static const double _minHeight = 0.04;
+  static const double _spring = 0.28;
+  static const double _damping = 0.72;
+
+  late AnimationController _controller;
+  late VisualizerService _visualizerService;
+
+  // Simulated fallback state
+  final List<double> _currentHeights = List.filled(_barCount, _minHeight);
+  final List<double> _targetHeights = List.filled(_barCount, _minHeight);
+  final List<double> _velocities = List.filled(_barCount, 0.0);
+
+  bool _isPlaying = false;
+  bool _useRealData = false;
+  int _frameCount = 0;
+  int _songSeed = 0;
+  double _songDurationSec = 180.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _visualizerService = VisualizerService();
+    _visualizerService.barHeightsNotifier.addListener(_onRealDataChanged);
+
+    _isPlaying = widget.playerService.isPlayingNotifier.value;
+    _updateSongSeed();
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    );
+    _controller.addListener(_onFrame);
+    _controller.repeat();
+
+    widget.playerService.isPlayingNotifier.addListener(_onPlayingChanged);
+    widget.playerService.positionNotifier.addListener(_onPositionChanged);
+    widget.playerService.currentSongNotifier.addListener(_onSongChanged);
+    widget.playerService.usingRustBackendNotifier.addListener(
+      _onBackendChanged,
+    );
+
+    _syncVisualizerAttachment();
+  }
+
+  @override
+  void didUpdateWidget(AudioVisualizer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.playerService != widget.playerService) {
+      oldWidget.playerService.isPlayingNotifier.removeListener(
+        _onPlayingChanged,
+      );
+      oldWidget.playerService.positionNotifier.removeListener(
+        _onPositionChanged,
+      );
+      oldWidget.playerService.currentSongNotifier.removeListener(
+        _onSongChanged,
+      );
+      oldWidget.playerService.usingRustBackendNotifier.removeListener(
+        _onBackendChanged,
+      );
+      widget.playerService.isPlayingNotifier.addListener(_onPlayingChanged);
+      widget.playerService.positionNotifier.addListener(_onPositionChanged);
+      widget.playerService.currentSongNotifier.addListener(_onSongChanged);
+      widget.playerService.usingRustBackendNotifier.addListener(
+        _onBackendChanged,
+      );
+      _isPlaying = widget.playerService.isPlayingNotifier.value;
+      _updateSongSeed();
+      _syncVisualizerAttachment();
+    }
+  }
+
+  void _onRealDataChanged() {
+    final real = _visualizerService.barHeightsNotifier.value;
+    if (mounted) {
+      setState(() {
+        _useRealData = real != null && real.length == _barCount;
+      });
+    }
+  }
+
+  void _onBackendChanged() => _syncVisualizerAttachment();
+
+  void _syncVisualizerAttachment() {
+    final usingRust = widget.playerService.usingRustBackendNotifier.value;
+    final sessionId = widget.playerService.androidAudioSessionId;
+
+    if (!Platform.isAndroid || usingRust || sessionId == null || sessionId <= 0) {
+      _visualizerService.detach();
+      return;
+    }
+
+    if (_isPlaying) {
+      _visualizerService.attach(sessionId);
+    } else {
+      _visualizerService.detach();
+    }
+  }
+
+  void _onSongChanged() {
+    _updateSongSeed();
+  }
+
+  void _updateSongSeed() {
+    final song = widget.playerService.currentSongNotifier.value;
+    if (song == null) return;
+    final path = song.filePath ?? song.id;
+    var hash = 0x811c9dc5;
+    for (var i = 0; i < path.length; i++) {
+      hash ^= path.codeUnitAt(i);
+      hash = _imul(hash, 0x01000193);
+    }
+    hash ^= song.duration.inMilliseconds;
+    hash = _imul(hash, 0x01000193);
+    _songSeed = hash;
+    _songDurationSec = math.max(10.0, song.duration.inMilliseconds / 1000.0);
+  }
+
+  static int _imul(int a, int b) {
+    final ah = (a >> 16) & 0xffff;
+    final al = a & 0xffff;
+    final bh = (b >> 16) & 0xffff;
+    final bl = b & 0xffff;
+    return ((al * bl) + (((ah * bl + al * bh) << 16) >> 0)) | 0;
+  }
+
+  double _frand(int n) {
+    var x = _songSeed ^ n;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    return (x & 0x7fffffff) / 0x7fffffff;
+  }
+
+  double _noise2D(double x, double y) {
+    final ix = x.floor();
+    final iy = y.floor();
+    final fx = x - ix;
+    final fy = y - iy;
+
+    final n00 = _frand(ix * 73856093 ^ iy * 19349663);
+    final n10 = _frand((ix + 1) * 73856093 ^ iy * 19349663);
+    final n01 = _frand(ix * 73856093 ^ (iy + 1) * 19349663);
+    final n11 = _frand((ix + 1) * 73856093 ^ (iy + 1) * 19349663);
+
+    final u = fx * fx * (3.0 - 2.0 * fx);
+    final v = fy * fy * (3.0 - 2.0 * fy);
+
+    return n00 * (1 - u) * (1 - v) +
+        n10 * u * (1 - v) +
+        n01 * (1 - u) * v +
+        n11 * u * v;
+  }
+
+  double _fbm(double x, double y, int octaves) {
+    var value = 0.0;
+    var amplitude = 0.5;
+    var frequency = 1.0;
+    for (var i = 0; i < octaves; i++) {
+      value += amplitude * _noise2D(x * frequency, y * frequency);
+      amplitude *= 0.5;
+      frequency *= 2.0;
+    }
+    return value;
+  }
+
+  double _songEnergy(double t) {
+    final progress = t / _songDurationSec;
+    final sectionNoise = _fbm(progress * 8.0, _songSeed * 0.1, 3);
+
+    double energy;
+    if (progress < 0.08) {
+      energy = 0.2 + progress * 3.75;
+    } else if (progress < 0.35) {
+      energy = 0.5 + sectionNoise * 0.2;
+    } else if (progress < 0.55) {
+      energy = 0.75 + sectionNoise * 0.2;
+    } else if (progress < 0.72) {
+      energy = 0.55 + sectionNoise * 0.15;
+    } else if (progress < 0.88) {
+      energy = 0.85 + sectionNoise * 0.15;
+    } else {
+      energy = 0.6 * (1.0 - (progress - 0.88) / 0.12);
+    }
+
+    final swell = math.sin(progress * math.pi * 6.0 + _songSeed) * 0.08 +
+        math.sin(progress * math.pi * 14.0 + _songSeed * 2.0) * 0.04;
+
+    return (energy + swell).clamp(0.1, 1.0);
+  }
+
+  void _computeSimulatedTargets(int positionMs) {
+    final t = positionMs / 1000.0;
+    final energy = _songEnergy(t);
+
+    final beatPhase = (t * (_frand(1) * 2.0 + 1.8)) % 1.0;
+    final isBeat = beatPhase < 0.12;
+    final beatStrength = isBeat ? (1.0 - beatPhase / 0.12) : 0.0;
+
+    final fastBeatPhase = (t * (_frand(2) * 4.0 + 4.0)) % 1.0;
+    final isFastBeat = fastBeatPhase < 0.08;
+    final fastBeatStrength = isFastBeat ? (1.0 - fastBeatPhase / 0.08) * 0.4 : 0.0;
+
+    for (int i = 0; i < _barCount; i++) {
+      final x = i / (_barCount - 1);
+
+      final freqFactor = x < 0.25
+          ? 0.4
+          : x < 0.5
+              ? 0.8
+              : x < 0.75
+                  ? 1.3
+                  : 1.8;
+
+      final barSeed = i * 7919 + _songSeed;
+      final charOffset = _frand(barSeed) * 2.0 - 1.0;
+
+      final noiseTime = t * freqFactor * (0.8 + _frand(barSeed + 1) * 0.6);
+      final noiseFreq = x * 12.0 + charOffset * 3.0;
+      final organic = _fbm(noiseTime, noiseFreq, 4);
+
+      final bassEnv = math.exp(-x * 5.0);
+      final midEnv = math.exp(-((x - 0.35) * 6.0).abs());
+      final trebleEnv = math.exp(-((x - 0.75) * 8.0).abs());
+
+      final bassMovement = organic * bassEnv * 0.9;
+      final midMovement = organic * midEnv * 0.7;
+      final trebleMovement = organic * trebleEnv * 0.5;
+
+      final bassBeat = beatStrength * bassEnv * 0.5;
+      final midBeat = beatStrength * midEnv * 0.3;
+      final trebleFastBeat = fastBeatStrength * trebleEnv * 0.4;
+
+      var height = (bassMovement + midMovement + trebleMovement + bassBeat + midBeat + trebleFastBeat) * energy;
+
+      final transientChance = _frand((t * 30.0).floor() * 97 + barSeed);
+      if (transientChance > 0.985) {
+        height += _frand((t * 30.0).floor() * 53 + barSeed) * 0.35 * energy;
+      }
+
+      height = (height * 1.1 + 0.05).clamp(_minHeight, 1.0);
+      _targetHeights[i] = height;
+    }
+  }
+
+  void _onPositionChanged() {
+    if (!_isPlaying || _useRealData) return;
+    final ms = widget.playerService.positionNotifier.value.inMilliseconds;
+    _computeSimulatedTargets(ms);
+  }
+
+  void _onPlayingChanged() {
+    final playing = widget.playerService.isPlayingNotifier.value;
+    if (playing == _isPlaying) return;
+    _isPlaying = playing;
+    _syncVisualizerAttachment();
+    if (!_isPlaying && !_useRealData) {
+      for (int i = 0; i < _barCount; i++) {
+        _targetHeights[i] = _minHeight + _frand(i * 97) * 0.06;
+      }
+    }
+  }
+
+  void _onFrame() {
+    if (!mounted) return;
+    _frameCount++;
+
+    if (_useRealData) {
+      // Real data drives the display directly; no spring physics needed
+      // because the native capture already runs at ~33fps.
+      return;
+    }
+
+    for (int i = 0; i < _barCount; i++) {
+      final diff = _targetHeights[i] - _currentHeights[i];
+      _velocities[i] = _velocities[i] * _damping + diff * _spring;
+      _currentHeights[i] =
+          (_currentHeights[i] + _velocities[i]).clamp(_minHeight, 1.0);
+    }
+
+    if (_isPlaying && _frameCount % 2 == 0) {
+      final ms = widget.playerService.positionNotifier.value.inMilliseconds;
+      _computeSimulatedTargets(ms);
+    }
+  }
+
+  List<double> get _displayHeights {
+    if (_useRealData) {
+      return _visualizerService.barHeightsNotifier.value ?? _currentHeights;
+    }
+    return _currentHeights;
+  }
+
+  @override
+  void dispose() {
+    widget.playerService.isPlayingNotifier.removeListener(_onPlayingChanged);
+    widget.playerService.positionNotifier.removeListener(_onPositionChanged);
+    widget.playerService.currentSongNotifier.removeListener(_onSongChanged);
+    widget.playerService.usingRustBackendNotifier.removeListener(
+      _onBackendChanged,
+    );
+    _visualizerService.barHeightsNotifier.removeListener(_onRealDataChanged);
+    _visualizerService.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          return CustomPaint(
+            painter: _VisualizerBarPainter(
+              barHeights: _displayHeights,
+              repaint: _controller,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _VisualizerBarPainter extends CustomPainter {
+  final List<double> barHeights;
+
+  _VisualizerBarPainter({
+    required this.barHeights,
+    required Listenable repaint,
+  }) : super(repaint: repaint);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+
+    final barCount = barHeights.length;
+    const spacing = 2.5;
+    final totalSpacing = (barCount - 1) * spacing;
+    final barWidth = (size.width - totalSpacing) / barCount;
+    final maxBarHeight = size.height * 0.88;
+
+    for (int i = 0; i < barCount; i++) {
+      final height = barHeights[i] * maxBarHeight;
+      final t = barCount > 1 ? i / (barCount - 1) : 0.0;
+
+      final brightness = 1.0 - t * 0.55;
+      final color = Color.fromRGBO(
+        (255 * brightness).round(),
+        (255 * brightness).round(),
+        (255 * brightness).round(),
+        1.0,
+      );
+
+      final x = i * (barWidth + spacing);
+      final rect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(x, size.height - height, barWidth, height),
+        const Radius.circular(2.0),
+      );
+
+      final glowPaint = Paint()
+        ..color = color.withValues(alpha: 0.18)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4);
+      canvas.drawRRect(rect, glowPaint);
+
+      final barPaint = Paint()..color = color.withValues(alpha: 0.82);
+      canvas.drawRRect(rect, barPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_VisualizerBarPainter oldDelegate) => true;
+}

--- a/lib/services/visualizer_service.dart
+++ b/lib/services/visualizer_service.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Service that bridges Android's [Visualizer] API to Flutter FFT bar data.
+///
+/// Falls back to null data when the native visualizer is unavailable
+/// (Rust backend, non-Android, or no audio session).
+class VisualizerService {
+  static const MethodChannel _methodChannel = MethodChannel(
+    'com.ultraelectronica.flick/visualizer',
+  );
+  static const EventChannel _eventChannel = EventChannel(
+    'com.ultraelectronica.flick/visualizer_events',
+  );
+
+  static const int _barCount = 48;
+
+  final ValueNotifier<List<double>?> barHeightsNotifier = ValueNotifier(null);
+
+  StreamSubscription<dynamic>? _eventSubscription;
+  bool _attached = false;
+  int _lastSessionId = -1;
+
+  /// Whether we have a live native visualizer feeding data.
+  bool get hasRealData => barHeightsNotifier.value != null;
+
+  /// Attach the native visualizer to an Android audio session.
+  Future<bool> attach(int sessionId) async {
+    if (sessionId <= 0 || sessionId == _lastSessionId) {
+      return _attached;
+    }
+    _lastSessionId = sessionId;
+
+    try {
+      final success = await _methodChannel.invokeMethod<bool>(
+        'attachVisualizer',
+        {'sessionId': sessionId},
+      );
+      if (success == true) {
+        _attached = true;
+        _startListening();
+        return true;
+      }
+    } catch (e) {
+      debugPrint('[VisualizerService] attach failed: $e');
+    }
+    _attached = false;
+    return false;
+  }
+
+  /// Detach and clear any live data.
+  Future<void> detach() async {
+    _lastSessionId = -1;
+    if (!_attached) {
+      barHeightsNotifier.value = null;
+      return;
+    }
+    _attached = false;
+    await _eventSubscription?.cancel();
+    _eventSubscription = null;
+    barHeightsNotifier.value = null;
+    try {
+      await _methodChannel.invokeMethod('detachVisualizer');
+    } catch (e) {
+      debugPrint('[VisualizerService] detach failed: $e');
+    }
+  }
+
+  void _startListening() {
+    _eventSubscription?.cancel();
+    _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
+      _onFftData,
+      onError: (Object e) {
+        debugPrint('[VisualizerService] event error: $e');
+        barHeightsNotifier.value = null;
+      },
+    );
+  }
+
+  void _onFftData(dynamic data) {
+    if (data is! Uint8List) return;
+    barHeightsNotifier.value = _fftToBars(data, _barCount);
+  }
+
+  /// Convert Android Visualizer FFT bytes to normalized bar magnitudes.
+  ///
+  /// Android returns signed 8-bit bytes:
+  ///   [0]     = DC component (ignored)
+  ///   [1]     = unused padding
+  ///   [2..n]  = pairs of (real, imag) for each frequency bin
+  static List<double> _fftToBars(Uint8List fft, int barCount) {
+    final binCount = (fft.length ~/ 2) - 1;
+    if (binCount <= 0) {
+      return List<double>.filled(barCount, 0.04);
+    }
+
+    // Extract magnitudes from complex FFT pairs
+    final magnitudes = Float64List(binCount);
+    for (var i = 0; i < binCount; i++) {
+      final realIdx = 2 + i * 2;
+      final imagIdx = realIdx + 1;
+      if (imagIdx >= fft.length) break;
+
+      // Convert unsigned bytes to signed
+      final r = fft[realIdx] <= 127 ? fft[realIdx] : fft[realIdx] - 256;
+      final im = fft[imagIdx] <= 127 ? fft[imagIdx] : fft[imagIdx] - 256;
+
+      // Magnitude in dB-ish scale
+      final mag = math.sqrt(r * r + im * im).toDouble();
+      // Apply a perceptual weighting: boost highs slightly since visualizer
+      // capture tends to be bass-heavy
+      final weight = 1.0 + (i / binCount) * 0.4;
+      magnitudes[i] = mag * weight;
+    }
+
+    // Map bins to bars logarithmically (human hearing is log-scale)
+    final bars = List<double>.filled(barCount, 0.0);
+    for (var i = 0; i < barCount; i++) {
+      final t0 = i / barCount;
+      final t1 = (i + 1) / barCount;
+      // Logarithmic distribution: more resolution in lower frequencies
+      final start = (math.pow(t0, 1.6) * binCount).floor();
+      final end = (math.pow(t1, 1.6) * binCount).ceil();
+
+      var peak = 0.0;
+      for (var j = start; j < end && j < binCount; j++) {
+        if (magnitudes[j] > peak) peak = magnitudes[j];
+      }
+      bars[i] = peak;
+    }
+
+    // Normalize to 0..1 with a noise floor
+    var maxMag = 0.0;
+    for (final v in bars) {
+      if (v > maxMag) maxMag = v;
+    }
+
+    if (maxMag > 1.0) {
+      final scale = 1.0 / maxMag;
+      for (var i = 0; i < barCount; i++) {
+        bars[i] = (bars[i] * scale * 0.92 + 0.06).clamp(0.04, 1.0);
+      }
+    } else {
+      for (var i = 0; i < barCount; i++) {
+        bars[i] = (bars[i] * 0.92 + 0.06).clamp(0.04, 1.0);
+      }
+    }
+
+    return bars;
+  }
+
+  void dispose() {
+    detach();
+    barHeightsNotifier.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- Add audio visualizer support with real-time FFT capture from Android Visualizer API
- Add `VisualizerService` to bridge Android Visualizer FFT data to Flutter
- Add audio visualizer widget with real-time and simulated fallback modes
- Add visualizer mode toggle to full player screen

## Changes

### Visualizer Integration
- Add `VisualizerService` with `MethodChannel` for Android Visualizer FFT data
- Add audio visualizer widget with real-time and simulated modes
- Add visualizer mode toggle to full player screen

## Files Changed
| File | Changes |
| --- | --- |
| `lib/features/player/screens/full_player_screen.dart` | Visualizer mode toggle |
| `lib/features/player/widgets/audio_visualizer.dart` | New visualizer widget |
| `lib/services/visualizer_service.dart` | New FFT bridge service |
| `android/app/src/main/kotlin/.../MainActivity.kt` | Visualizer integration |