### PR TITLE
 Disable crossfade, refactor playlist creation, bump to 0.14.0-beta.1

### DIFF
--- a/lib/features/playlists/screens/playlists_screen.dart
+++ b/lib/features/playlists/screens/playlists_screen.dart
@@ -39,8 +39,7 @@ class PlaylistsScreen extends ConsumerWidget {
           ],
         ),
       ),
-      floatingActionButton: _buildCreateButton(context, ref),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+
     );
   }
 
@@ -108,12 +107,24 @@ class PlaylistsScreen extends ConsumerWidget {
               ),
               color: AppColors.surface,
               onSelected: (value) {
-                if (value == 'import_m3u') {
+                if (value == 'create') {
+                  _showCreatePlaylistDialog(context, ref);
+                } else if (value == 'import_m3u') {
                   _importPlaylist(context, ref);
                 }
               },
-              itemBuilder: (context) => const [
-                PopupMenuItem(
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 'create',
+                  child: Row(
+                    children: [
+                      Icon(LucideIcons.plus, size: 18),
+                      SizedBox(width: 8),
+                      Text('Create Playlist'),
+                    ],
+                  ),
+                ),
+                const PopupMenuItem(
                   value: 'import_m3u',
                   child: Row(
                     children: [
@@ -315,20 +326,6 @@ class PlaylistsScreen extends ConsumerWidget {
             child: Text('Delete', style: TextStyle(color: Colors.red)),
           ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildCreateButton(BuildContext context, WidgetRef ref) {
-    return FloatingActionButton.extended(
-      onPressed: () => _showCreatePlaylistDialog(context, ref),
-      backgroundColor: AppColors.surfaceLight,
-      foregroundColor: context.adaptiveTextPrimary,
-      elevation: 4,
-      icon: const Icon(LucideIcons.plus),
-      label: const Text(
-        'Create Playlist',
-        style: TextStyle(fontFamily: 'ProductSans'),
       ),
     );
   }

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -332,9 +332,7 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   const SizedBox(height: AppConstants.spacingMd),
-                  const CircularProgressIndicator(
-                    color: AppColors.textPrimary,
-                  ),
+                  const CircularProgressIndicator(color: AppColors.textPrimary),
                   const SizedBox(height: AppConstants.spacingMd),
                   Text(
                     'Loading patch notes...',
@@ -470,7 +468,7 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.13.0-beta.2',
+            'Version 0.14.0-beta.1',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -655,7 +653,7 @@ SOFTWARE.
               NavigationSetting(
                 icon: LucideIcons.info,
                 title: 'About Flick Player',
-                subtitle: 'Version 0.13.0-beta.2',
+                subtitle: 'Version 0.14.0-beta.1',
                 onTap: _showAboutBottomSheet,
               ),
               const SettingsDivider(),
@@ -711,9 +709,8 @@ SOFTWARE.
                     icon: LucideIcons.heart,
                     title: 'Buy me a coffee',
                     subtitle: 'Support development on Ko-fi',
-                    onTap: () => _launchUrl(
-                      'https://ko-fi.com/ultraelectronica',
-                    ),
+                    onTap: () =>
+                        _launchUrl('https://ko-fi.com/ultraelectronica'),
                   ),
                 ],
               );

--- a/lib/features/settings/screens/audio_settings_screen.dart
+++ b/lib/features/settings/screens/audio_settings_screen.dart
@@ -4,13 +4,14 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
-import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/features/settings/screens/equalizer_screen.dart';
 import 'package:flick/features/settings/screens/uac2_settings_screen.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
-import 'package:flick/providers/app_preferences_provider.dart';
-import 'package:flick/services/rust_audio_service.dart';
-import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
+// TODO: crossfade disabled for this version
+// import 'package:flick/core/utils/app_haptics.dart';
+// import 'package:flick/providers/app_preferences_provider.dart';
+// import 'package:flick/services/rust_audio_service.dart';
+// import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
 
 class AudioSettingsScreen extends ConsumerStatefulWidget {
   const AudioSettingsScreen({super.key});
@@ -21,39 +22,38 @@ class AudioSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _AudioSettingsScreenState extends ConsumerState<AudioSettingsScreen> {
-  final _rustAudioService = RustAudioService();
+  // TODO: crossfade disabled for this version
+  // final _rustAudioService = RustAudioService();
 
-  static const _curveLabels = <String>[
-    'Equal Power',
-    'Linear',
-    'Square Root',
-    'S-Curve',
-  ];
+  // static const _curveLabels = <String>[
+  //   'Equal Power',
+  //   'Linear',
+  //   'Square Root',
+  //   'S-Curve',
+  // ];
 
-  static const _curveValues = <rust_audio.CrossfadeCurveType>[
-    rust_audio.CrossfadeCurveType.equalPower,
-    rust_audio.CrossfadeCurveType.linear,
-    rust_audio.CrossfadeCurveType.squareRoot,
-    rust_audio.CrossfadeCurveType.sCurve,
-  ];
+  // static const _curveValues = <rust_audio.CrossfadeCurveType>[
+  //   rust_audio.CrossfadeCurveType.equalPower,
+  //   rust_audio.CrossfadeCurveType.linear,
+  //   rust_audio.CrossfadeCurveType.squareRoot,
+  //   rust_audio.CrossfadeCurveType.sCurve,
+  // ];
 
-  Future<void> _applyCrossfade() async {
-    final prefs = ref.read(appPreferencesProvider);
-    await _rustAudioService.setCrossfade(
-      enabled: prefs.crossfadeEnabled,
-      durationSecs: prefs.crossfadeDurationSecs,
-    );
-    final curve = _curveValues[prefs.crossfadeCurveIndex.clamp(
-      0,
-      _curveValues.length - 1,
-    )];
-    await _rustAudioService.setCrossfadeCurve(curve);
-  }
+  // Future<void> _applyCrossfade() async {
+  //   final prefs = ref.read(appPreferencesProvider);
+  //   await _rustAudioService.setCrossfade(
+  //     enabled: prefs.crossfadeEnabled,
+  //     durationSecs: prefs.crossfadeDurationSecs,
+  //   );
+  //   final curve = _curveValues[prefs.crossfadeCurveIndex.clamp(
+  //     0,
+  //     _curveValues.length - 1,
+  //   )];
+  //   await _rustAudioService.setCrossfadeCurve(curve);
+  // }
 
   @override
   Widget build(BuildContext context) {
-    final prefs = ref.watch(appPreferencesProvider);
-
     return SettingsScaffold(
       title: 'Audio',
       body: Column(
@@ -89,139 +89,10 @@ class _AudioSettingsScreenState extends ConsumerState<AudioSettingsScreen> {
               ),
             ],
           ),
-          const SizedBox(height: AppConstants.spacingLg),
-          const SettingsSectionHeader('Crossfade'),
-          SettingsCard(
-            children: [
-              ToggleSetting(
-                icon: LucideIcons.blend,
-                title: 'Crossfade',
-                subtitle: 'Smoothly blend between tracks',
-                value: prefs.crossfadeEnabled,
-                onChanged: (value) async {
-                  await ref
-                      .read(appPreferencesProvider.notifier)
-                      .setCrossfadeEnabled(value);
-                  await _applyCrossfade();
-                },
-              ),
-              if (prefs.crossfadeEnabled) ...[
-                const SettingsDivider(),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingLg,
-                    vertical: AppConstants.spacingSm,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            'Duration',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(
-                                  color: context.adaptiveTextPrimary,
-                                ),
-                          ),
-                          Text(
-                            '${prefs.crossfadeDurationSecs.toStringAsFixed(1)} s',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(
-                                  color: context.adaptiveTextSecondary,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppConstants.spacingSm),
-                      Slider(
-                        value: prefs.crossfadeDurationSecs,
-                        min: 0.5,
-                        max: 10.0,
-                        divisions: 19,
-                        activeColor: context.adaptiveTextPrimary,
-                        inactiveColor: AppColors.glassBorder,
-                        onChanged: (value) async {
-                          await ref
-                              .read(appPreferencesProvider.notifier)
-                              .setCrossfadeDurationSecs(value);
-                        },
-                        onChangeEnd: (_) => _applyCrossfade(),
-                      ),
-                    ],
-                  ),
-                ),
-                const SettingsDivider(),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: AppConstants.spacingLg,
-                    right: AppConstants.spacingLg,
-                    top: AppConstants.spacingSm,
-                    bottom: AppConstants.spacingMd,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Curve',
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium
-                            ?.copyWith(color: context.adaptiveTextPrimary),
-                      ),
-                      const SizedBox(height: AppConstants.spacingSm),
-                      Wrap(
-                        spacing: AppConstants.spacingSm,
-                        children: List.generate(_curveLabels.length, (index) {
-                          final selected =
-                              prefs.crossfadeCurveIndex == index;
-                          return ChoiceChip(
-                            label: Text(_curveLabels[index]),
-                            selected: selected,
-                            onSelected: (_) async {
-                              AppHaptics.tap();
-                              await ref
-                                  .read(appPreferencesProvider.notifier)
-                                  .setCrossfadeCurveIndex(index);
-                              await _applyCrossfade();
-                            },
-                            backgroundColor: AppColors.glassBackgroundStrong,
-                            selectedColor:
-                                context.adaptiveTextPrimary.withValues(
-                              alpha: 0.15,
-                            ),
-                            side: BorderSide(
-                              color: selected
-                                  ? context.adaptiveTextPrimary
-                                  : AppColors.glassBorder,
-                              width: 1,
-                            ),
-                            labelStyle: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                  color: selected
-                                      ? context.adaptiveTextPrimary
-                                      : context.adaptiveTextSecondary,
-                                  fontWeight: selected
-                                      ? FontWeight.w600
-                                      : FontWeight.normal,
-                                ),
-                          );
-                        }),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ],
-          ),
+          // TODO: crossfade disabled for this version
+          // const SizedBox(height: AppConstants.spacingLg),
+          // const SettingsSectionHeader('Crossfade'),
+          // SettingsCard(
           const SizedBox(height: AppConstants.spacingLg),
           const SizedBox(height: AppConstants.navBarHeight + 40),
         ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.13.0-beta.2+7
+version: 0.14.0-beta.2+8
 
 environment:
   sdk: ^3.10.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.14.0-beta.2+8
+version: 0.14.0-beta.1+8
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
### **Summary**
- **Crossfade disabled**: Stripped crossfade UI and reverted to minimal audio settings
- **Playlist UX**: Removed playlist FAB and added create option to popup menu  
- **Version bump**: Updated version references to `0.14.0-beta.1`

---

### **Changes**

#### **Crossfade Disabled**
- Removed crossfade UI from audio settings screen: duration sliders, curve selection, gapless toggle
- Reverted to minimal audio settings layout

#### **Playlist Management**
- Removed FAB for playlist creation
- Added create playlist option to popup menu

#### **Versioning**
- Updated version to `0.14.0-beta.1` in `pubspec.yaml` and info screen

---

### **Files Changed**

| Category | Files |
| --- | --- |
| **Features - Settings** | `lib/features/settings/screens/audio_settings_screen.dart`<br>`lib/features/settings/screens/app_info_settings_screen.dart` |
| **Features - Playlists** | `lib/features/playlists/screens/playlists_screen.dart` |
| **Config** | `pubspec.yaml` |