### PR TITLE
Add lyrics editor, multi-select mode, queue refactor, and just_audio API migrationVersion f

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -78,6 +78,8 @@ class _MainShellState extends ConsumerState<MainShell>
   Song? _previousSong;
   late final PlayerService _playerService;
 
+  DateTime? _lastBackPressTime;
+
   @override
   void initState() {
     super.initState();
@@ -144,27 +146,6 @@ class _MainShellState extends ConsumerState<MainShell>
         _maybeOpenExternalPlayer(nextSong);
       }
 
-      if (songChanged && context.mounted) {
-        final isPlaying = ref.read(isPlayingProvider);
-        if (!isPlaying) {
-          // Song changed but not playing yet — don't auto-navigate.
-          _previousSong = nextSong;
-          return;
-        }
-        if (NavigationHelper.isFullPlayerOpen) {
-          _previousSong = nextSong;
-          return;
-        }
-        final song = nextSong;
-        Future.delayed(const Duration(milliseconds: 100), () {
-          if (context.mounted) {
-            NavigationHelper.navigateToFullPlayer(
-              context,
-              heroTag: 'auto_nav_${song.id}',
-            );
-          }
-        });
-      }
       _previousSong = nextSong;
     });
 
@@ -396,6 +377,26 @@ class _MainShellState extends ConsumerState<MainShell>
     return false;
   }
 
+  void _handleBackPress(bool didPop, dynamic result) {
+    if (didPop) return;
+
+    final now = DateTime.now();
+    if (_lastBackPressTime == null ||
+        now.difference(_lastBackPressTime!) > const Duration(seconds: 2)) {
+      _lastBackPressTime = now;
+      ScaffoldMessenger.of(context)
+        ..clearSnackBars()
+        ..showSnackBar(
+          const SnackBar(
+            content: Text('Press back again to exit'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+    } else {
+      SystemNavigator.pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final currentIndex = ref.watch(navigationIndexProvider);
@@ -403,9 +404,12 @@ class _MainShellState extends ConsumerState<MainShell>
     final navBarConfig = ref.watch(navBarConfigProvider);
     final pageOrder = _getPageOrder(navBarConfig);
 
-    return AdaptiveColorProvider(
-      backgroundColor: backgroundColor,
-      child: Scaffold(
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: _handleBackPress,
+      child: AdaptiveColorProvider(
+        backgroundColor: backgroundColor,
+        child: Scaffold(
         backgroundColor: AppColors.background,
         extendBody: true,
         body: NotificationListener<ScrollNotification>(
@@ -479,7 +483,8 @@ class _MainShellState extends ConsumerState<MainShell>
           ),
         ),
       ),
-    );
+    ),
+  );
   }
 
   List<NavBarButton> _getPageOrder(NavBarConfig config) {

--- a/lib/features/onboarding/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/screens/onboarding_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -100,7 +102,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
       backgroundColor: AppColors.background,
       body: Stack(
         children: [
-          const Positioned.fill(child: _OnboardingBackdrop()),
+          Positioned.fill(
+            child: _OnboardingBackdrop(pageController: _pageController),
+          ),
           SafeArea(
             child: Column(
               children: [
@@ -274,48 +278,160 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen>
   }
 }
 
-class _OnboardingBackdrop extends StatelessWidget {
-  const _OnboardingBackdrop();
+// ─── Animated Onboarding Backdrop ─────────────────────────────────────────────
+// Each page has a unique arrangement of glowing orbs. As the user swipes,
+// the orbs interpolate smoothly between configurations. A subtle breathing
+// animation keeps the backdrop feeling alive even when idle.
+
+class _OrbState {
+  final double x; // fraction of screen width  (0 = left edge)
+  final double y; // fraction of screen height (0 = top edge)
+  final double size;
+  final Color color;
+
+  const _OrbState(this.x, this.y, this.size, this.color);
+
+  _OrbState lerp(_OrbState other, double t) {
+    return _OrbState(
+      _lerpDouble(x, other.x, t),
+      _lerpDouble(y, other.y, t),
+      _lerpDouble(size, other.size, t),
+      Color.lerp(color, other.color, t) ?? color,
+    );
+  }
+
+  static double _lerpDouble(double a, double b, double t) => a + (b - a) * t;
+}
+
+/// Per-page configurations for 3 orbs.
+const _orbConfigs = <List<_OrbState>>[
+  // Page 0 – Welcome: cool blues, centered
+  [
+    _OrbState(-0.15, -0.10, 340, Color(0xFF1B3258)),
+    _OrbState(0.70, 0.35, 300, Color(0xFF1A2D44)),
+    _OrbState(0.05, 0.82, 240, Color(0xFF1A2D44)),
+  ],
+  // Page 1 – Library: warmer tones appear
+  [
+    _OrbState(0.55, -0.08, 320, Color(0xFF2A1D45)),
+    _OrbState(-0.20, 0.45, 360, Color(0xFF4A2A1F)),
+    _OrbState(0.40, 0.78, 260, Color(0xFF1B3258)),
+  ],
+  // Page 2 – Browse: spread out, purple accent
+  [
+    _OrbState(0.10, 0.05, 280, Color(0xFF3B1D5E)),
+    _OrbState(0.75, 0.50, 320, Color(0xFF1B3258)),
+    _OrbState(-0.10, 0.70, 300, Color(0xFF2A1D45)),
+  ],
+  // Page 3 – Playback: vibrant, tighter
+  [
+    _OrbState(0.60, -0.05, 360, Color(0xFF4A2A1F)),
+    _OrbState(-0.15, 0.40, 280, Color(0xFF3B1D5E)),
+    _OrbState(0.35, 0.85, 320, Color(0xFF1B3258)),
+  ],
+  // Page 4 – All Set: calm, centred glow
+  [
+    _OrbState(0.25, 0.05, 380, Color(0xFF1A2D44)),
+    _OrbState(0.60, 0.45, 340, Color(0xFF1B3258)),
+    _OrbState(0.10, 0.75, 280, Color(0xFF2A1D45)),
+  ],
+];
+
+class _OnboardingBackdrop extends StatefulWidget {
+  final PageController pageController;
+
+  const _OnboardingBackdrop({required this.pageController});
+
+  @override
+  State<_OnboardingBackdrop> createState() => _OnboardingBackdropState();
+}
+
+class _OnboardingBackdropState extends State<_OnboardingBackdrop>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _breathe;
+  double _page = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _breathe = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    )..repeat(reverse: true);
+    widget.pageController.addListener(_onScroll);
+  }
+
+  void _onScroll() {
+    final p = widget.pageController.page;
+    if (p != null && mounted) setState(() => _page = p);
+  }
+
+  @override
+  void dispose() {
+    widget.pageController.removeListener(_onScroll);
+    _breathe.dispose();
+    super.dispose();
+  }
+
+  List<_OrbState> _interpolatedOrbs() {
+    final base = _page.floor().clamp(0, _orbConfigs.length - 1);
+    final next = (base + 1).clamp(0, _orbConfigs.length - 1);
+    final t = _page - _page.floor();
+    return [
+      for (int i = 0; i < 3; i++) _orbConfigs[base][i].lerp(_orbConfigs[next][i], t),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
     return IgnorePointer(
-      child: Stack(
-        children: [
-          const DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [Color(0xFF040608), Color(0xFF0A0A0A)],
+      child: AnimatedBuilder(
+        animation: _breathe,
+        builder: (context, _) {
+          final orbs = _interpolatedOrbs();
+          final breath = _breathe.value; // 0 → 1 → 0
+          final w = MediaQuery.sizeOf(context).width;
+          final h = MediaQuery.sizeOf(context).height;
+
+          return Stack(
+            children: [
+              // Base gradient
+              const Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Color(0xFF040608), Color(0xFF0A0A0A)],
+                    ),
+                  ),
+                ),
               ),
-            ),
-          ),
-          Positioned(
-            top: -140,
-            left: -60,
-            child: _GlowOrb(
-              size: 340,
-              colors: const [Color(0xFF1B3258), Color(0x001B3258)],
-            ),
-          ),
-          Positioned(
-            top: context.screenHeight * 0.32,
-            right: -100,
-            child: _GlowOrb(
-              size: 300,
-              colors: const [Color(0xFF4A2A1F), Color(0x004A2A1F)],
-            ),
-          ),
-          Positioned(
-            bottom: -80,
-            left: 20,
-            child: _GlowOrb(
-              size: 240,
-              colors: const [Color(0xFF1A2D44), Color(0x001A2D44)],
-            ),
-          ),
-        ],
+              // Animated orbs
+              for (int i = 0; i < orbs.length; i++)
+                _buildOrb(orbs[i], i, breath, w, h),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildOrb(_OrbState orb, int index, double breath, double w, double h) {
+    // Each orb breathes with a slightly different phase offset
+    final phase = math.sin((breath + index * 0.33) * math.pi);
+    final sizeScale = 1.0 + phase * 0.08; // ±8% size pulse
+    final offsetX = phase * 12.0 * (index.isEven ? 1 : -1); // subtle drift
+    final offsetY = phase * 8.0 * (index.isOdd ? 1 : -1);
+    final s = orb.size * sizeScale;
+
+    return Positioned(
+      left: orb.x * w + offsetX - s / 2,
+      top: orb.y * h + offsetY - s / 2,
+      child: _GlowOrb(
+        size: s,
+        color: orb.color,
+        opacity: 0.85 + phase * 0.15,
       ),
     );
   }
@@ -393,18 +509,28 @@ class _StepContent extends StatelessWidget {
 
 class _GlowOrb extends StatelessWidget {
   final double size;
-  final List<Color> colors;
+  final Color color;
+  final double opacity;
 
-  const _GlowOrb({required this.size, required this.colors});
+  const _GlowOrb({
+    required this.size,
+    required this.color,
+    this.opacity = 1.0,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: RadialGradient(colors: colors),
+    return Opacity(
+      opacity: opacity.clamp(0.0, 1.0),
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(
+            colors: [color, color.withValues(alpha: 0)],
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'dart:async';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
@@ -25,6 +26,7 @@ import 'package:flick/providers/album_color_provider.dart';
 import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/providers/playlist_provider.dart';
 import 'package:flick/features/player/widgets/audio_visualizer.dart';
+import 'package:flick/features/player/widgets/lyrics_editor_bottom_sheet.dart';
 import 'package:flick/features/player/widgets/line_seek_bar.dart';
 import 'package:flick/features/player/widgets/waveform_seek_bar.dart';
 import 'package:flick/models/progress_bar_style.dart';
@@ -3040,6 +3042,7 @@ class _InlineLyricsPanelState extends State<_InlineLyricsPanel> {
   final ScrollController _scrollController = ScrollController();
   LyricsData? _lyricsData;
   bool _isLoading = true;
+  bool _hasManualLyricsSelection = false;
   int _activeLineIndex = -1;
   int _lastScrolledIndex = -1;
 
@@ -3087,12 +3090,20 @@ class _InlineLyricsPanelState extends State<_InlineLyricsPanel> {
       _lastScrolledIndex = -1;
     });
 
-    final loaded = await widget.lyricsService.loadLyricsForSong(song);
+    final loaded = await widget.lyricsService.loadLyricsForSong(
+      song,
+      forceRefresh: true,
+    );
+    final manualSource = await widget.lyricsService.getManualLyricsPathForSong(
+      song,
+    );
     if (!mounted) return;
     if (widget.song.id != song.id) return;
 
     setState(() {
       _lyricsData = loaded;
+      _hasManualLyricsSelection =
+          manualSource != null && manualSource.isNotEmpty;
       _isLoading = false;
     });
 
@@ -3158,6 +3169,126 @@ class _InlineLyricsPanelState extends State<_InlineLyricsPanel> {
     return normalized.split('/').last;
   }
 
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+      );
+  }
+
+  Future<void> _openLyricsEditor() async {
+    final result = await LyricsEditorBottomSheet.show(
+      context: context,
+      song: widget.song,
+      playerService: widget.playerService,
+      lyricsService: widget.lyricsService,
+      initialLyrics: _lyricsData,
+    );
+    if (!mounted || result == null) return;
+    _showMessage(result.message);
+    await _loadLyricsForSong(widget.song);
+  }
+
+  Future<void> _importLyricsFile() async {
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['lrc', 'txt', 'xml'],
+        withData: true,
+      );
+      final pickedFile = result?.files.single;
+      if (pickedFile == null) return;
+
+      final content = await readTextFromPickedLyricsFile(pickedFile);
+      if (content == null || content.trim().isEmpty) {
+        _showMessage('Could not read the selected lyrics file.');
+        return;
+      }
+
+      await widget.lyricsService.importLyricsForSong(
+        song: widget.song,
+        fileName: pickedFile.name,
+        content: content,
+      );
+      if (!mounted) return;
+      await _loadLyricsForSong(widget.song);
+      _showMessage('Linked "${pickedFile.name}" to this song.');
+    } catch (_) {
+      _showMessage('Could not use the selected lyrics file.');
+    }
+  }
+
+  Future<void> _resetManualLyricsSource() async {
+    await widget.lyricsService.clearManualLyricsPathForSong(widget.song);
+    if (!mounted) return;
+    await _loadLyricsForSong(widget.song);
+    if (!mounted) return;
+    _showMessage('Switched back to the automatic lyrics source.');
+  }
+
+  Widget _buildActionButtons() {
+    Widget action({
+      required IconData icon,
+      required String label,
+      required VoidCallback onPressed,
+      bool emphasized = false,
+    }) {
+      final fillColor = emphasized
+          ? Colors.white.withValues(alpha: 0.16)
+          : Colors.white.withValues(alpha: 0.08);
+      return TextButton.icon(
+        onPressed: onPressed,
+        style: TextButton.styleFrom(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          backgroundColor: fillColor,
+          foregroundColor: Colors.white.withValues(alpha: 0.92),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(999),
+            side: BorderSide(color: Colors.white.withValues(alpha: 0.10)),
+          ),
+        ),
+        icon: Icon(icon, size: 16),
+        label: Text(
+          label,
+          style: const TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Wrap(
+        alignment: WrapAlignment.center,
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          action(
+            icon: LucideIcons.pencilLine,
+            label: _lyricsData == null ? 'Create Lyrics' : 'Edit & Sync',
+            onPressed: () => unawaited(_openLyricsEditor()),
+            emphasized: true,
+          ),
+          action(
+            icon: LucideIcons.filePlus,
+            label: 'Use Existing File',
+            onPressed: () => unawaited(_importLyricsFile()),
+          ),
+          if (_hasManualLyricsSelection)
+            action(
+              icon: LucideIcons.refreshCcw,
+              label: 'Use Auto Source',
+              onPressed: () => unawaited(_resetManualLyricsSource()),
+            ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildLyricsMeta(LyricsData lyrics) {
     final sourceLabel = _lyricsSourceLabel(lyrics.source);
     final textColor = Colors.white.withValues(alpha: 0.82);
@@ -3189,21 +3320,32 @@ class _InlineLyricsPanelState extends State<_InlineLyricsPanel> {
       );
     }
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
-      child: Wrap(
-        alignment: WrapAlignment.center,
-        spacing: 8,
-        runSpacing: 8,
-        children: [
-          chip(LucideIcons.fileText, 'Lyrics'),
-          chip(
-            lyrics.isSynchronized ? LucideIcons.clock3 : Icons.notes_rounded,
-            lyrics.isSynchronized ? 'Tap a line to seek' : 'Static lyrics',
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
+          child: Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              chip(LucideIcons.fileText, 'Lyrics'),
+              chip(
+                lyrics.isSynchronized
+                    ? LucideIcons.clock3
+                    : Icons.notes_rounded,
+                lyrics.isSynchronized ? 'Tap a line to seek' : 'Static lyrics',
+              ),
+              chip(
+                LucideIcons.slidersHorizontal,
+                'Simple + advanced sync tools',
+              ),
+              if (sourceLabel != null) chip(LucideIcons.badgeInfo, sourceLabel),
+            ],
           ),
-          if (sourceLabel != null) chip(LucideIcons.badgeInfo, sourceLabel),
-        ],
-      ),
+        ),
+        _buildActionButtons(),
+      ],
     );
   }
 
@@ -3367,15 +3509,22 @@ class _InlineLyricsPanelState extends State<_InlineLyricsPanel> {
       return Center(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Text(
-            'No lyrics file found.\nAdd an .lrc or .txt file with the same name as the song.',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontFamily: 'ProductSans',
-              fontSize: 14,
-              height: 1.5,
-              color: Colors.white.withValues(alpha: 0.72),
-            ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'No lyrics file found yet.\nCreate a new `.lrc`, sync it while the song plays, or choose an existing lyric file.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  height: 1.5,
+                  color: Colors.white.withValues(alpha: 0.72),
+                ),
+              ),
+              const SizedBox(height: 16),
+              _buildActionButtons(),
+            ],
           ),
         ),
       );

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -3736,9 +3736,21 @@ class _LyricsModeWaveformStrip extends StatefulWidget {
       _LyricsModeWaveformStripState();
 }
 
-class _LyricsModeWaveformStripState extends State<_LyricsModeWaveformStrip> {
+class _LyricsModeWaveformStripState extends State<_LyricsModeWaveformStrip>
+    with SingleTickerProviderStateMixin {
   Offset? _pointerDownPosition;
   bool _didTriggerSwipe = false;
+
+  late final AnimationController _arrowAnimController = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1000),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _arrowAnimController.dispose();
+    super.dispose();
+  }
 
   void _resetPointerTracking() {
     _pointerDownPosition = null;
@@ -3775,10 +3787,22 @@ class _LyricsModeWaveformStripState extends State<_LyricsModeWaveformStrip> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            Icons.keyboard_double_arrow_up_rounded,
-            color: Colors.white.withValues(alpha: 0.72),
-            size: context.responsive(18.0, 20.0, 22.0),
+          AnimatedBuilder(
+            animation: _arrowAnimController,
+            builder: (context, child) {
+              final t = _arrowAnimController.value;
+              final bounce = -4.0 * math.sin(t * math.pi);
+              final opacity = 0.72 + 0.28 * math.sin(t * math.pi);
+              return Transform.translate(
+                offset: Offset(0, bounce),
+                child: Opacity(opacity: opacity, child: child!),
+              );
+            },
+            child: Icon(
+              Icons.keyboard_double_arrow_up_rounded,
+              color: Colors.white,
+              size: context.responsive(18.0, 20.0, 22.0),
+            ),
           ),
           SizedBox(height: context.responsive(2.0, 4.0, 6.0)),
           Padding(

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -2120,9 +2120,9 @@ class _AnimatedSongScene extends StatelessWidget {
                       }
                     },
               child: ValueListenableBuilder<List<Song>>(
-                valueListenable: playerService.queueNotifier,
-                builder: (context, queue, _) {
-                  final hasQueue = queue.isNotEmpty;
+                valueListenable: playerService.upNextNotifier,
+                builder: (context, upNext, _) {
+                  final hasQueue = upNext.isNotEmpty;
                   final fromLocker = song.isFromLocker;
                   final nowPlayingContent = Column(
                     mainAxisSize: MainAxisSize.min,
@@ -2174,7 +2174,7 @@ class _AnimatedSongScene extends StatelessWidget {
                           SizedBox(width: context.responsive(8.0, 10.0, 12.0)),
                           _buildQueueSummaryBadge(
                             context,
-                            count: queue.length,
+                            count: upNext.length,
                             highlighted: hasQueue,
                           ),
                         ],

--- a/lib/features/player/widgets/lyrics_editor_bottom_sheet.dart
+++ b/lib/features/player/widgets/lyrics_editor_bottom_sheet.dart
@@ -1,0 +1,1215 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/models/song.dart';
+import 'package:flick/services/lyrics_service.dart';
+import 'package:flick/services/player_service.dart';
+import 'package:flick/widgets/common/glass_bottom_sheet.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+enum LyricsEditorViewMode { simple, advanced }
+
+class LyricsEditorResult {
+  final String message;
+  final LyricsData lyricsData;
+
+  const LyricsEditorResult({required this.message, required this.lyricsData});
+}
+
+class LyricsEditorBottomSheet extends StatefulWidget {
+  final Song song;
+  final PlayerService playerService;
+  final LyricsService lyricsService;
+  final LyricsData? initialLyrics;
+
+  const LyricsEditorBottomSheet({
+    super.key,
+    required this.song,
+    required this.playerService,
+    required this.lyricsService,
+    this.initialLyrics,
+  });
+
+  static Future<LyricsEditorResult?> show({
+    required BuildContext context,
+    required Song song,
+    required PlayerService playerService,
+    required LyricsService lyricsService,
+    LyricsData? initialLyrics,
+  }) {
+    return showModalBottomSheet<LyricsEditorResult>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => AppBottomSheetSurface(
+        maxHeightRatio: 0.94,
+        child: LyricsEditorBottomSheet(
+          song: song,
+          playerService: playerService,
+          lyricsService: lyricsService,
+          initialLyrics: initialLyrics,
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<LyricsEditorBottomSheet> createState() =>
+      _LyricsEditorBottomSheetState();
+}
+
+class _LyricsEditorBottomSheetState extends State<LyricsEditorBottomSheet> {
+  final TextEditingController _lyricsTextController = TextEditingController();
+  final TextEditingController _currentTimeController = TextEditingController();
+
+  LyricsEditorViewMode _viewMode = LyricsEditorViewMode.simple;
+  List<_EditableLyricLine> _lines = const [];
+  int _selectedLineIndex = 0;
+  bool _autoAdvance = true;
+  bool _isSaving = false;
+  Duration _currentPosition = Duration.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentPosition = widget.playerService.positionNotifier.value;
+    _lines = _seedLines(widget.initialLyrics);
+    _syncEditorFromLines();
+    _updateCurrentTimeField();
+    _lyricsTextController.addListener(_handleLyricsTextChanged);
+    widget.playerService.positionNotifier.addListener(_handlePositionChanged);
+  }
+
+  @override
+  void dispose() {
+    _lyricsTextController.removeListener(_handleLyricsTextChanged);
+    widget.playerService.positionNotifier.removeListener(
+      _handlePositionChanged,
+    );
+    _lyricsTextController.dispose();
+    _currentTimeController.dispose();
+    super.dispose();
+  }
+
+  List<_EditableLyricLine> _seedLines(LyricsData? lyrics) {
+    if (lyrics == null || lyrics.lines.isEmpty) {
+      return const [_EditableLyricLine(text: '', timestamp: null)];
+    }
+
+    return lyrics.lines
+        .map(
+          (line) => _EditableLyricLine(
+            text: line.text,
+            timestamp: lyrics.isSynchronized ? line.timestamp : null,
+          ),
+        )
+        .toList();
+  }
+
+  void _handlePositionChanged() {
+    final nextPosition = widget.playerService.positionNotifier.value;
+    if (_currentPosition == nextPosition) return;
+    setState(() {
+      _currentPosition = nextPosition;
+    });
+    _updateCurrentTimeField();
+  }
+
+  void _updateCurrentTimeField() {
+    final value = widget.lyricsService.formatTimestamp(_currentPosition);
+    if (_currentTimeController.text == value) return;
+    _currentTimeController.value = TextEditingValue(
+      text: value,
+      selection: TextSelection.collapsed(offset: value.length),
+    );
+  }
+
+  void _syncEditorFromLines() {
+    final text = _lines.map((line) => line.text).join('\n');
+    _lyricsTextController.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  void _handleLyricsTextChanged() {
+    final rows = _lyricsTextController.text
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
+        .split('\n');
+    final nextLines = <_EditableLyricLine>[];
+
+    for (var index = 0; index < rows.length; index++) {
+      nextLines.add(
+        _EditableLyricLine(
+          text: rows[index],
+          timestamp: index < _lines.length ? _lines[index].timestamp : null,
+        ),
+      );
+    }
+
+    while (nextLines.isNotEmpty && nextLines.last.text.isEmpty) {
+      nextLines.removeLast();
+    }
+
+    if (nextLines.isEmpty) {
+      nextLines.add(const _EditableLyricLine(text: '', timestamp: null));
+    }
+
+    setState(() {
+      _lines = nextLines;
+      if (_selectedLineIndex >= _lines.length) {
+        _selectedLineIndex = _lines.length - 1;
+      }
+      if (_selectedLineIndex < 0) {
+        _selectedLineIndex = 0;
+      }
+    });
+  }
+
+  int get _stampedLineCount => _lines
+      .where((line) => line.text.trim().isNotEmpty && line.timestamp != null)
+      .length;
+
+  int get _usableLineCount =>
+      _lines.where((line) => line.text.trim().isNotEmpty).length;
+
+  Future<void> _seekBy(Duration delta) async {
+    final duration =
+        widget.playerService.durationNotifier.value.inMilliseconds > 0
+        ? widget.playerService.durationNotifier.value
+        : widget.song.duration;
+    final next = _currentPosition + delta;
+    final clampedMs = next.inMilliseconds.clamp(
+      0,
+      duration.inMilliseconds > 0
+          ? duration.inMilliseconds
+          : next.inMilliseconds,
+    );
+    final target = Duration(milliseconds: clampedMs);
+    await widget.playerService.seek(target);
+  }
+
+  Future<void> _togglePlayPause() async {
+    if (widget.playerService.isPlayingNotifier.value) {
+      await widget.playerService.pause();
+    } else {
+      await widget.playerService.resume();
+    }
+  }
+
+  void _selectLine(int index) {
+    if (index < 0 || index >= _lines.length) return;
+    setState(() {
+      _selectedLineIndex = index;
+    });
+  }
+
+  void _stampSelectedLine({required bool advance}) {
+    if (_selectedLineIndex < 0 || _selectedLineIndex >= _lines.length) return;
+    final current = _lines[_selectedLineIndex];
+    if (current.text.trim().isEmpty) return;
+
+    setState(() {
+      _lines = [
+        for (var index = 0; index < _lines.length; index++)
+          if (index == _selectedLineIndex)
+            _lines[index].copyWith(timestamp: _currentPosition)
+          else
+            _lines[index],
+      ];
+      if (advance && _selectedLineIndex < _lines.length - 1) {
+        _selectedLineIndex += 1;
+      }
+    });
+  }
+
+  void _clearSelectedTimestamp() {
+    if (_selectedLineIndex < 0 || _selectedLineIndex >= _lines.length) return;
+    setState(() {
+      _lines = [
+        for (var index = 0; index < _lines.length; index++)
+          if (index == _selectedLineIndex)
+            _lines[index].copyWith(timestamp: null)
+          else
+            _lines[index],
+      ];
+    });
+  }
+
+  void _shiftAll(Duration delta) {
+    setState(() {
+      _lines = _lines
+          .map(
+            (line) => line.timestamp == null
+                ? line
+                : line.copyWith(
+                    timestamp: Duration(
+                      milliseconds:
+                          (line.timestamp!.inMilliseconds +
+                                  delta.inMilliseconds)
+                              .clamp(0, 1 << 31),
+                    ),
+                  ),
+          )
+          .toList();
+    });
+  }
+
+  void _applyTimestampText(int index, String value) {
+    final normalized = value.replaceAll('[', '').replaceAll(']', '').trim();
+    if (normalized.isEmpty) {
+      setState(() {
+        _lines = [
+          for (var lineIndex = 0; lineIndex < _lines.length; lineIndex++)
+            if (lineIndex == index)
+              _lines[lineIndex].copyWith(timestamp: null)
+            else
+              _lines[lineIndex],
+        ];
+      });
+      return;
+    }
+
+    final parsed = widget.lyricsService.parseTimestamp(normalized);
+    if (parsed == null) return;
+
+    setState(() {
+      _lines = [
+        for (var lineIndex = 0; lineIndex < _lines.length; lineIndex++)
+          if (lineIndex == index)
+            _lines[lineIndex].copyWith(timestamp: parsed)
+          else
+            _lines[lineIndex],
+      ];
+    });
+  }
+
+  List<LyricsLine> _buildNormalizedLyricsLines() {
+    final sourceLines = _lines
+        .where((line) => line.text.trim().isNotEmpty)
+        .map((line) => line.copyWith(text: line.text.trim()))
+        .toList();
+    if (sourceLines.isEmpty) return const [];
+
+    final filled = List<Duration?>.from(
+      sourceLines.map((line) => line.timestamp),
+    );
+    final stampedIndices = <int>[
+      for (var index = 0; index < sourceLines.length; index++)
+        if (filled[index] != null) index,
+    ];
+
+    if (stampedIndices.isEmpty) {
+      return [
+        for (var index = 0; index < sourceLines.length; index++)
+          LyricsLine(
+            timestamp: Duration(seconds: index * 2),
+            text: sourceLines[index].text,
+          ),
+      ];
+    }
+
+    const defaultStep = Duration(seconds: 2);
+    final firstStampedIndex = stampedIndices.first;
+    final firstStampedTime = filled[firstStampedIndex]!;
+    for (var index = firstStampedIndex - 1; index >= 0; index--) {
+      final backfilled =
+          firstStampedTime -
+          Duration(
+            seconds: defaultStep.inSeconds * (firstStampedIndex - index),
+          );
+      filled[index] = backfilled.isNegative ? Duration.zero : backfilled;
+    }
+
+    for (
+      var stampIndex = 0;
+      stampIndex < stampedIndices.length - 1;
+      stampIndex++
+    ) {
+      final startIndex = stampedIndices[stampIndex];
+      final endIndex = stampedIndices[stampIndex + 1];
+      final start = filled[startIndex]!;
+      final end = filled[endIndex]!;
+      final gapCount = endIndex - startIndex - 1;
+      if (gapCount <= 0) continue;
+
+      final deltaMs = end.inMilliseconds - start.inMilliseconds;
+      final stepMs = gapCount <= 0 ? 0 : deltaMs ~/ (gapCount + 1);
+      for (var offset = 1; offset <= gapCount; offset++) {
+        filled[startIndex + offset] = Duration(
+          milliseconds: start.inMilliseconds + (stepMs * offset),
+        );
+      }
+    }
+
+    final lastStampedIndex = stampedIndices.last;
+    for (var index = lastStampedIndex + 1; index < filled.length; index++) {
+      final previous = filled[index - 1] ?? Duration.zero;
+      filled[index] = previous + defaultStep;
+    }
+
+    var lastMs = 0;
+    final normalized = <LyricsLine>[];
+    for (var index = 0; index < sourceLines.length; index++) {
+      final timestamp = filled[index] ?? Duration(milliseconds: lastMs);
+      final nextMs = timestamp.inMilliseconds < lastMs
+          ? lastMs
+          : timestamp.inMilliseconds;
+      lastMs = nextMs;
+      normalized.add(
+        LyricsLine(
+          timestamp: Duration(milliseconds: nextMs),
+          text: sourceLines[index].text,
+        ),
+      );
+    }
+    return normalized;
+  }
+
+  Future<void> _save() async {
+    final normalizedLines = _buildNormalizedLyricsLines();
+    if (normalizedLines.isEmpty) {
+      _showMessage('Add at least one lyric line first.');
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      final lrcContent = widget.lyricsService.buildLrcContent(
+        lines: normalizedLines,
+        song: widget.song,
+      );
+      final result = await widget.lyricsService.saveLyricsForSong(
+        song: widget.song,
+        content: lrcContent,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop(
+        LyricsEditorResult(
+          message: result.savedBesideSong
+              ? 'Saved lyrics beside the song as an `.lrc` file.'
+              : 'Saved lyrics in Flick and linked them to this song.',
+          lyricsData: result.data,
+        ),
+      );
+    } catch (_) {
+      _showMessage('Could not save the lyrics file.');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  void _showMessage(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+      );
+  }
+
+  Future<void> _showInstructions() async {
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        ),
+        title: const Text('Lyrics Sync Help'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Simple mode',
+                style: TextStyle(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '1. Paste or type one lyric line per row.\n'
+                '2. Play the song.\n'
+                '3. Select the current lyric line.\n'
+                '4. Tap "Stamp & Next" when you hear that line.\n'
+                '5. Save when done.',
+                style: TextStyle(
+                  color: context.adaptiveTextSecondary,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Advanced mode',
+                style: TextStyle(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '1. Edit timestamps directly for each line.\n'
+                '2. Use "Use Current Time" to capture the live playback time.\n'
+                '3. Use the shift controls to move all stamped lyrics together.\n'
+                '4. Save to generate the final `.lrc` file.',
+                style: TextStyle(
+                  color: context.adaptiveTextSecondary,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Tips',
+                style: TextStyle(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '- "Use Existing File" links an `.lrc`, `.txt`, or `.xml` file.\n'
+                '- If some lines are not stamped, Flick fills their times automatically.\n'
+                '- Save writes beside the song when possible, otherwise Flick stores a linked copy.',
+                style: TextStyle(
+                  color: context.adaptiveTextSecondary,
+                  height: 1.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Got it'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Lyrics Sync Studio',
+                    style: TextStyle(
+                      color: context.adaptiveTextPrimary,
+                      fontSize: 22,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    widget.song.title,
+                    style: TextStyle(
+                      color: context.adaptiveTextSecondary,
+                      fontSize: 14,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: _isSaving ? null : () => Navigator.of(context).pop(),
+              icon: const Icon(Icons.close_rounded),
+            ),
+            IconButton(
+              onPressed: _isSaving ? null : _showInstructions,
+              icon: const Icon(Icons.help_outline_rounded),
+              tooltip: 'Instructions',
+            ),
+          ],
+        ),
+        const SizedBox(height: AppConstants.spacingMd),
+        _buildModePicker(context),
+        const SizedBox(height: AppConstants.spacingMd),
+        _buildStatusCards(context),
+        const SizedBox(height: AppConstants.spacingMd),
+        Flexible(
+          child: SingleChildScrollView(
+            physics: const BouncingScrollPhysics(),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildLyricsTextEditor(context),
+                const SizedBox(height: AppConstants.spacingMd),
+                if (_viewMode == LyricsEditorViewMode.simple)
+                  _buildSimpleSyncView(context)
+                else
+                  _buildAdvancedSyncView(context),
+                const SizedBox(height: AppConstants.spacingMd),
+                _buildSaveNotice(context),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppConstants.spacingMd),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: _isSaving ? null : () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+            ),
+            const SizedBox(width: AppConstants.spacingSm),
+            Expanded(
+              child: FilledButton.icon(
+                onPressed: _isSaving ? null : _save,
+                icon: _isSaving
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(LucideIcons.save),
+                label: Text(_isSaving ? 'Saving...' : 'Save LRC'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModePicker(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      children: LyricsEditorViewMode.values.map((mode) {
+        final selected = mode == _viewMode;
+        return ChoiceChip(
+          selected: selected,
+          onSelected: (_) {
+            setState(() {
+              _viewMode = mode;
+            });
+          },
+          label: Text(
+            mode == LyricsEditorViewMode.simple
+                ? 'Simple Mode'
+                : 'Advanced Mode',
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildStatusCards(BuildContext context) {
+    Widget card(IconData icon, String label, String value) {
+      return Expanded(
+        child: Container(
+          padding: const EdgeInsets.all(AppConstants.spacingSm),
+          decoration: BoxDecoration(
+            color: AppColors.surfaceLight,
+            borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+            border: Border.all(color: AppColors.glassBorder),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon, size: 16, color: context.adaptiveTextSecondary),
+              const SizedBox(height: 8),
+              Text(
+                value,
+                style: TextStyle(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 15,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                label,
+                style: TextStyle(
+                  color: context.adaptiveTextSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        card(Icons.format_list_bulleted_rounded, 'Lines', '$_usableLineCount'),
+        const SizedBox(width: AppConstants.spacingSm),
+        card(LucideIcons.clock3, 'Stamped', '$_stampedLineCount'),
+        const SizedBox(width: AppConstants.spacingSm),
+        card(LucideIcons.timer, 'Now', _currentTimeController.text),
+      ],
+    );
+  }
+
+  Widget _buildLyricsTextEditor(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Lyrics Text',
+          style: TextStyle(
+            color: context.adaptiveTextPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          'One line per lyric row. The sync tools below attach timestamps to these lines.',
+          style: TextStyle(color: context.adaptiveTextSecondary, fontSize: 12),
+        ),
+        const SizedBox(height: 10),
+        TextField(
+          controller: _lyricsTextController,
+          minLines: 6,
+          maxLines: 10,
+          decoration: InputDecoration(
+            hintText: 'Paste or type the song lyrics here',
+            filled: true,
+            fillColor: AppColors.surfaceLight,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSimpleSyncView(BuildContext context) {
+    final selectedLine =
+        _selectedLineIndex >= 0 && _selectedLineIndex < _lines.length
+        ? _lines[_selectedLineIndex]
+        : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Quick Sync',
+          style: TextStyle(
+            color: context.adaptiveTextPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 10),
+        _buildPlaybackTools(context),
+        const SizedBox(height: AppConstants.spacingSm),
+        Container(
+          padding: const EdgeInsets.all(AppConstants.spacingSm),
+          decoration: BoxDecoration(
+            color: AppColors.surfaceLight,
+            borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+            border: Border.all(color: AppColors.glassBorder),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  IconButton(
+                    onPressed: _selectedLineIndex > 0
+                        ? () => _selectLine(_selectedLineIndex - 1)
+                        : null,
+                    icon: const Icon(Icons.keyboard_arrow_up_rounded),
+                  ),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text(
+                          'Selected line ${_selectedLineIndex + 1} of ${_lines.length}',
+                          style: TextStyle(
+                            color: context.adaptiveTextSecondary,
+                            fontSize: 12,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          selectedLine?.text.trim().isNotEmpty == true
+                              ? selectedLine!.text
+                              : 'Pick a lyric line from the list below.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: context.adaptiveTextPrimary,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (selectedLine?.timestamp != null) ...[
+                          const SizedBox(height: 6),
+                          Text(
+                            widget.lyricsService.formatTimestamp(
+                              selectedLine!.timestamp!,
+                            ),
+                            style: TextStyle(
+                              color: context.adaptiveTextSecondary,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _selectedLineIndex < _lines.length - 1
+                        ? () => _selectLine(_selectedLineIndex + 1)
+                        : null,
+                    icon: const Icon(Icons.keyboard_arrow_down_rounded),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppConstants.spacingSm),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  FilledButton.icon(
+                    onPressed: selectedLine?.text.trim().isNotEmpty == true
+                        ? () => _stampSelectedLine(advance: _autoAdvance)
+                        : null,
+                    icon: const Icon(LucideIcons.clock3),
+                    label: Text(_autoAdvance ? 'Stamp & Next' : 'Stamp Now'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: selectedLine?.timestamp != null
+                        ? _clearSelectedTimestamp
+                        : null,
+                    icon: const Icon(LucideIcons.eraser),
+                    label: const Text('Clear Stamp'),
+                  ),
+                  FilterChip(
+                    selected: _autoAdvance,
+                    onSelected: (value) {
+                      setState(() {
+                        _autoAdvance = value;
+                      });
+                    },
+                    label: const Text('Auto Advance'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _buildShiftTools(context),
+        const SizedBox(height: AppConstants.spacingSm),
+        _buildLinePickerList(context, compact: false),
+      ],
+    );
+  }
+
+  Widget _buildAdvancedSyncView(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Advanced Sync',
+          style: TextStyle(
+            color: context.adaptiveTextPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 10),
+        _buildPlaybackTools(context),
+        const SizedBox(height: AppConstants.spacingSm),
+        _buildShiftTools(context),
+        const SizedBox(height: AppConstants.spacingSm),
+        ListView.separated(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: _lines.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, index) {
+            final line = _lines[index];
+            final timestampText = line.timestamp == null
+                ? ''
+                : widget.lyricsService
+                      .formatTimestamp(line.timestamp!)
+                      .replaceAll('[', '')
+                      .replaceAll(']', '');
+            return Container(
+              padding: const EdgeInsets.all(AppConstants.spacingSm),
+              decoration: BoxDecoration(
+                color: index == _selectedLineIndex
+                    ? AppColors.surfaceLight.withValues(alpha: 0.95)
+                    : AppColors.surfaceDark,
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                border: Border.all(
+                  color: index == _selectedLineIndex
+                      ? AppColors.accentDim
+                      : AppColors.glassBorder,
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        'Line ${index + 1}',
+                        style: TextStyle(
+                          color: context.adaptiveTextSecondary,
+                          fontSize: 12,
+                        ),
+                      ),
+                      const Spacer(),
+                      TextButton.icon(
+                        onPressed: () {
+                          _selectLine(index);
+                          _stampSelectedLine(advance: false);
+                        },
+                        icon: const Icon(LucideIcons.clock3, size: 14),
+                        label: const Text('Use Current Time'),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    line.text.isEmpty ? '(Empty line)' : line.text,
+                    style: TextStyle(
+                      color: context.adaptiveTextPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    initialValue: timestampText,
+                    onTap: () => _selectLine(index),
+                    onChanged: (value) => _applyTimestampText(index, value),
+                    decoration: InputDecoration(
+                      labelText: 'Timestamp',
+                      hintText: '00:12.34',
+                      filled: true,
+                      fillColor: AppColors.surfaceLight,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(
+                          AppConstants.radiusMd,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPlaybackTools(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingSm),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Playback Assist',
+            style: TextStyle(
+              color: context.adaptiveTextPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              OutlinedButton(
+                onPressed: () => _seekBy(const Duration(seconds: -2)),
+                child: const Text('-2s'),
+              ),
+              const SizedBox(width: 8),
+              ValueListenableBuilder<bool>(
+                valueListenable: widget.playerService.isPlayingNotifier,
+                builder: (context, isPlaying, _) {
+                  return FilledButton.icon(
+                    onPressed: _togglePlayPause,
+                    icon: Icon(
+                      isPlaying ? LucideIcons.pause : LucideIcons.play,
+                    ),
+                    label: Text(isPlaying ? 'Pause' : 'Play'),
+                  );
+                },
+              ),
+              const SizedBox(width: 8),
+              OutlinedButton(
+                onPressed: () => _seekBy(const Duration(seconds: 2)),
+                child: const Text('+2s'),
+              ),
+              const Spacer(),
+              SizedBox(
+                width: 108,
+                child: TextField(
+                  controller: _currentTimeController,
+                  readOnly: true,
+                  decoration: InputDecoration(
+                    labelText: 'Now',
+                    filled: true,
+                    fillColor: AppColors.surfaceDark,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusMd,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShiftTools(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingSm),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Time Shift',
+            style: TextStyle(
+              color: context.adaptiveTextPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Move every stamped lyric forward or backward together.',
+            style: TextStyle(
+              color: context.adaptiveTextSecondary,
+              fontSize: 12,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              OutlinedButton(
+                onPressed: () => _shiftAll(const Duration(milliseconds: -500)),
+                child: const Text('-500ms'),
+              ),
+              OutlinedButton(
+                onPressed: () => _shiftAll(const Duration(milliseconds: -100)),
+                child: const Text('-100ms'),
+              ),
+              OutlinedButton(
+                onPressed: () => _shiftAll(const Duration(milliseconds: 100)),
+                child: const Text('+100ms'),
+              ),
+              OutlinedButton(
+                onPressed: () => _shiftAll(const Duration(milliseconds: 500)),
+                child: const Text('+500ms'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLinePickerList(BuildContext context, {required bool compact}) {
+    return Container(
+      constraints: BoxConstraints(maxHeight: compact ? 200 : 280),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: ListView.separated(
+        shrinkWrap: true,
+        itemCount: _lines.length,
+        separatorBuilder: (_, _) =>
+            Divider(height: 1, color: AppColors.glassBorder),
+        itemBuilder: (context, index) {
+          final line = _lines[index];
+          final selected = index == _selectedLineIndex;
+          return Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () => _selectLine(index),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppConstants.spacingSm,
+                  vertical: AppConstants.spacingSm,
+                ),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 26,
+                      height: 26,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: selected
+                            ? AppColors.accent
+                            : AppColors.surfaceDark,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Text(
+                        '${index + 1}',
+                        style: TextStyle(
+                          color: selected
+                              ? AppColors.surface
+                              : context.adaptiveTextSecondary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            line.text.isEmpty ? '(Empty line)' : line.text,
+                            maxLines: compact ? 1 : 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: context.adaptiveTextPrimary,
+                              fontWeight: selected
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            line.timestamp == null
+                                ? 'Not stamped yet'
+                                : widget.lyricsService.formatTimestamp(
+                                    line.timestamp!,
+                                  ),
+                            style: TextStyle(
+                              color: context.adaptiveTextSecondary,
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSaveNotice(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingSm),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            LucideIcons.badgeInfo,
+            size: 16,
+            color: context.adaptiveTextSecondary,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Save creates an `.lrc` file. If some lines are not stamped yet, Flick fills their times automatically so the file stays usable.',
+              style: TextStyle(
+                color: context.adaptiveTextSecondary,
+                fontSize: 12,
+                height: 1.4,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EditableLyricLine {
+  final String text;
+  final Duration? timestamp;
+
+  const _EditableLyricLine({required this.text, required this.timestamp});
+
+  _EditableLyricLine copyWith({
+    String? text,
+    Duration? timestamp,
+    bool clearTimestamp = false,
+  }) {
+    return _EditableLyricLine(
+      text: text ?? this.text,
+      timestamp: clearTimestamp ? null : (timestamp ?? this.timestamp),
+    );
+  }
+}
+
+Future<String?> readTextFromPickedLyricsFile(PlatformFile file) async {
+  if (file.bytes != null) {
+    return _decodeLyricsBytes(file.bytes!);
+  }
+
+  final path = file.path;
+  if (path == null || path.isEmpty) return null;
+  final diskFile = File(path);
+  if (!await diskFile.exists()) return null;
+  final bytes = await diskFile.readAsBytes();
+  return _decodeLyricsBytes(bytes);
+}
+
+String? _decodeLyricsBytes(Uint8List bytes) {
+  try {
+    return utf8.decode(bytes);
+  } catch (_) {
+    try {
+      return latin1.decode(bytes);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/features/player/widgets/mini_player.dart
+++ b/lib/features/player/widgets/mini_player.dart
@@ -231,11 +231,11 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                       // Controls
                       if (!song.isFromLocker)
                         ValueListenableBuilder<List<Song>>(
-                          valueListenable: _playerService.queueNotifier,
-                          builder: (context, queue, _) {
+                          valueListenable: _playerService.upNextNotifier,
+                          builder: (context, upNext, _) {
                             return Padding(
                               padding: const EdgeInsets.only(right: 4),
-                              child: _buildQueueButton(context, queue.length),
+                              child: _buildQueueButton(context, upNext.length),
                             );
                           },
                         ),

--- a/lib/features/queue/screens/queue_screen.dart
+++ b/lib/features/queue/screens/queue_screen.dart
@@ -8,11 +8,85 @@ import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 
-class QueueScreen extends ConsumerWidget {
+class QueueScreen extends ConsumerStatefulWidget {
   const QueueScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<QueueScreen> createState() => _QueueScreenState();
+}
+
+class _QueueScreenState extends ConsumerState<QueueScreen> {
+  bool _selectionMode = false;
+  final Set<String> _selectedKeys = {};
+
+  String _upNextKey(int i) => 'upnext-$i';
+  String _queueKey(int i) => 'queue-$i';
+
+  void _enterSelectionMode(String? key) {
+    setState(() {
+      _selectionMode = true;
+      if (key != null) _selectedKeys.add(key);
+    });
+  }
+
+  void _exitSelectionMode() {
+    setState(() {
+      _selectionMode = false;
+      _selectedKeys.clear();
+    });
+  }
+
+  void _toggleSelection(String key) {
+    setState(() {
+      if (_selectedKeys.contains(key)) {
+        _selectedKeys.remove(key);
+        if (_selectedKeys.isEmpty) _selectionMode = false;
+      } else {
+        _selectedKeys.add(key);
+      }
+    });
+  }
+
+  void _selectAll() {
+    final upNext = ref.read(upNextProvider);
+    final queue = ref.read(queueProvider);
+    setState(() {
+      for (int i = 0; i < upNext.length; i++) {
+        _selectedKeys.add(_upNextKey(i));
+      }
+      for (int i = 0; i < queue.length; i++) {
+        _selectedKeys.add(_queueKey(i));
+      }
+    });
+  }
+
+  Future<void> _removeSelected() async {
+    final upNextIndices = <int>[];
+    final queueIndices = <int>[];
+    for (final key in _selectedKeys) {
+      if (key.startsWith('upnext-')) {
+        upNextIndices.add(int.parse(key.substring(7)));
+      } else if (key.startsWith('queue-')) {
+        queueIndices.add(int.parse(key.substring(6)));
+      }
+    }
+    setState(() {
+      _selectedKeys.clear();
+      _selectionMode = false;
+    });
+    // Remove in reverse order to keep indices stable
+    upNextIndices.sort((a, b) => b.compareTo(a));
+    queueIndices.sort((a, b) => b.compareTo(a));
+    for (final i in queueIndices) {
+      await ref.read(playerProvider.notifier).removeFromQueue(i);
+    }
+    for (final i in upNextIndices) {
+      await ref.read(playerProvider.notifier).removeFromUpNext(i);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final queue = ref.watch(queueProvider);
     final upNext = ref.watch(upNextProvider);
     final currentSong = ref.watch(currentSongProvider);
@@ -23,13 +97,17 @@ class QueueScreen extends ConsumerWidget {
         bottom: false,
         child: Column(
           children: [
-            _Header(
-              queueCount: upNext.length,
-              canClear: queue.isNotEmpty,
-              onClear: () async {
-                await ref.read(playerProvider.notifier).clearQueue();
-              },
-            ),
+            if (_selectionMode)
+              _buildSelectionHeader(upNext.length + queue.length)
+            else
+              _Header(
+                queueCount: upNext.length + queue.length,
+                canClear: upNext.isNotEmpty || queue.isNotEmpty,
+                onClear: () async {
+                  await ref.read(playerProvider.notifier).clearAllUpcoming();
+                },
+                onSelectMode: () => _enterSelectionMode(null),
+              ),
             Expanded(
               child: upNext.isEmpty && currentSong == null
                   ? const _EmptyQueue()
@@ -79,6 +157,19 @@ class QueueScreen extends ConsumerWidget {
                               itemCount: upNext.length,
                               itemBuilder: (context, index) {
                                 final song = upNext[index];
+                                final key = _upNextKey(index);
+                                if (_selectionMode) {
+                                  final isSelected =
+                                      _selectedKeys.contains(key);
+                                  return _UpcomingTile(
+                                    song: song,
+                                    index: index,
+                                    isSelectionMode: true,
+                                    isSelected: isSelected,
+                                    onTap: () => _toggleSelection(key),
+                                    onLongPress: () {},
+                                  );
+                                }
                                 return _UpcomingTile(
                                   song: song,
                                   index: index,
@@ -86,6 +177,13 @@ class QueueScreen extends ConsumerWidget {
                                     await ref
                                         .read(playerProvider.notifier)
                                         .playFromUpNextIndex(index);
+                                  },
+                                  onLongPress: () =>
+                                      _enterSelectionMode(key),
+                                  onRemove: () async {
+                                    await ref
+                                        .read(playerProvider.notifier)
+                                        .removeFromUpNext(index);
                                   },
                                 );
                               },
@@ -118,42 +216,74 @@ class QueueScreen extends ConsumerWidget {
                               AppConstants.spacingLg,
                               AppConstants.navBarHeight + 120,
                             ),
-                            sliver: SliverReorderableList(
-                              itemCount: queue.length,
-                              onReorder: (oldIndex, newIndex) async {
-                                final targetIndex = newIndex > oldIndex
-                                    ? newIndex - 1
-                                    : newIndex;
-                                await ref
-                                    .read(playerProvider.notifier)
-                                    .moveQueueItem(oldIndex, targetIndex);
-                              },
-                              itemBuilder: (context, index) {
-                                final song = queue[index];
-                                return _QueueTile(
-                                  key: ValueKey('${song.id}-$index'),
-                                  song: song,
-                                  index: index,
-                                  onTap: () async {
-                                    await ref
-                                        .read(playerProvider.notifier)
-                                        .playFromQueueIndex(index);
-                                  },
-                                  onRemove: () async {
-                                    await ref
-                                        .read(playerProvider.notifier)
-                                        .removeFromQueue(index);
-                                  },
-                                  onMoveToNext: index == 0
-                                      ? null
-                                      : () async {
+                            sliver: _selectionMode
+                                ? SliverList.builder(
+                                    itemCount: queue.length,
+                                    itemBuilder: (context, index) {
+                                      final song = queue[index];
+                                      final key = _queueKey(index);
+                                      final isSelected =
+                                          _selectedKeys.contains(key);
+                                      return _QueueTile(
+                                        key: ValueKey(
+                                            'queue-sel-${song.id}-$index'),
+                                        song: song,
+                                        index: index,
+                                        isSelectionMode: true,
+                                        isSelected: isSelected,
+                                        onTap: () =>
+                                            _toggleSelection(key),
+                                        onLongPress: () {},
+                                        onRemove: () async {
                                           await ref
                                               .read(playerProvider.notifier)
-                                              .moveQueueItemToNext(index);
+                                              .removeFromQueue(index);
                                         },
-                                );
-                              },
-                            ),
+                                        onMoveToNext: null,
+                                      );
+                                    },
+                                  )
+                                : SliverReorderableList(
+                                    itemCount: queue.length,
+                                    onReorder: (oldIndex, newIndex) async {
+                                      final targetIndex = newIndex > oldIndex
+                                          ? newIndex - 1
+                                          : newIndex;
+                                      await ref
+                                          .read(playerProvider.notifier)
+                                          .moveQueueItem(oldIndex, targetIndex);
+                                    },
+                                    itemBuilder: (context, index) {
+                                      final song = queue[index];
+                                      return _QueueTile(
+                                        key: ValueKey('${song.id}-$index'),
+                                        song: song,
+                                        index: index,
+                                        onTap: () async {
+                                          await ref
+                                              .read(playerProvider.notifier)
+                                              .playFromQueueIndex(index);
+                                        },
+                                        onLongPress: () =>
+                                            _enterSelectionMode(
+                                                _queueKey(index)),
+                                        onRemove: () async {
+                                          await ref
+                                              .read(playerProvider.notifier)
+                                              .removeFromQueue(index);
+                                        },
+                                        onMoveToNext: index == 0
+                                            ? null
+                                            : () async {
+                                                await ref
+                                                    .read(playerProvider
+                                                        .notifier)
+                                                    .moveQueueItemToNext(
+                                                        index);
+                                              },
+                                      );
+                                    },
+                                  ),
                           ),
                       ],
                     ),
@@ -163,17 +293,89 @@ class QueueScreen extends ConsumerWidget {
       ),
     );
   }
+
+  Widget _buildSelectionHeader(int queueCount) {
+    final upNext = ref.read(upNextProvider);
+    final queue = ref.read(queueProvider);
+    final count = _selectedKeys.length;
+    final totalItems = upNext.length + queue.length;
+    final allSelected = totalItems > 0 && count == totalItems;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingLg,
+        vertical: AppConstants.spacingMd,
+      ),
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: AppColors.glassBackground,
+              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: IconButton(
+              icon: Icon(
+                LucideIcons.x,
+                color: context.adaptiveTextPrimary,
+              ),
+              onPressed: _exitSelectionMode,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Queue',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.adaptiveTextPrimary,
+                      ),
+                ),
+                Text(
+                  '$count selected of $queueCount song${queueCount == 1 ? '' : 's'}',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.adaptiveTextTertiary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+          if (!allSelected)
+            TextButton(
+              onPressed: _selectAll,
+              child: Text(
+                'Select All',
+                style: TextStyle(color: context.adaptiveTextSecondary),
+              ),
+            ),
+          IconButton(
+            icon: Icon(
+              LucideIcons.trash2,
+              color: Colors.redAccent.withValues(alpha: 0.8),
+            ),
+            onPressed: count > 0 ? _removeSelected : null,
+            tooltip: 'Remove selected',
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _Header extends StatelessWidget {
   final int queueCount;
   final bool canClear;
   final Future<void> Function() onClear;
+  final VoidCallback onSelectMode;
 
   const _Header({
     required this.queueCount,
     required this.canClear,
     required this.onClear,
+    required this.onSelectMode,
   });
 
   @override
@@ -207,21 +409,37 @@ class _Header extends StatelessWidget {
                 Text(
                   'Queue',
                   style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: context.adaptiveTextPrimary,
-                  ),
+                        fontWeight: FontWeight.w600,
+                        color: context.adaptiveTextPrimary,
+                      ),
                 ),
                 Text(
                   '$queueCount upcoming song${queueCount == 1 ? '' : 's'}',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.adaptiveTextTertiary,
-                  ),
+                        color: context.adaptiveTextTertiary,
+                      ),
                 ),
               ],
             ),
           ),
+          Container(
+            decoration: BoxDecoration(
+              color: AppColors.glassBackground,
+              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: IconButton(
+              icon: Icon(
+                LucideIcons.checkCheck,
+                color: context.adaptiveTextPrimary,
+              ),
+              tooltip: 'Select',
+              onPressed: onSelectMode,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
           if (canClear)
-            TextButton(onPressed: onClear, child: const Text('Clear')),
+            TextButton(onPressed: onClear, child: const Text('Clear All')),
         ],
       ),
     );
@@ -248,17 +466,17 @@ class _EmptyQueue extends StatelessWidget {
             Text(
               'Queue is empty',
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                color: context.adaptiveTextSecondary,
-                fontWeight: FontWeight.w600,
-              ),
+                    color: context.adaptiveTextSecondary,
+                    fontWeight: FontWeight.w600,
+                  ),
             ),
             const SizedBox(height: AppConstants.spacingSm),
             Text(
               'Add songs from the player or song actions menu.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: context.adaptiveTextTertiary,
-              ),
+                    color: context.adaptiveTextTertiary,
+                  ),
             ),
           ],
         ),
@@ -296,8 +514,8 @@ class _EmptyUpcomingState extends StatelessWidget {
               child: Text(
                 'No upcoming queue items yet.',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.adaptiveTextSecondary,
-                ),
+                      color: context.adaptiveTextSecondary,
+                    ),
               ),
             ),
           ],
@@ -339,9 +557,9 @@ class _NowPlayingCard extends StatelessWidget {
                 Text(
                   'Now playing',
                   style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                    color: AppColors.accent,
-                    fontWeight: FontWeight.w700,
-                  ),
+                        color: AppColors.accent,
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
                 const SizedBox(height: 2),
                 Text(
@@ -349,9 +567,9 @@ class _NowPlayingCard extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: context.adaptiveTextPrimary,
-                    fontWeight: FontWeight.w700,
-                  ),
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
                 const SizedBox(height: 2),
                 Text(
@@ -359,8 +577,8 @@ class _NowPlayingCard extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.adaptiveTextSecondary,
-                  ),
+                        color: context.adaptiveTextSecondary,
+                      ),
                 ),
               ],
             ),
@@ -375,22 +593,34 @@ class _UpcomingTile extends StatelessWidget {
   final Song song;
   final int index;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final VoidCallback? onRemove;
+  final bool isSelectionMode;
+  final bool isSelected;
 
   const _UpcomingTile({
     required this.song,
     required this.index,
     required this.onTap,
+    this.onLongPress,
+    this.onRemove,
+    this.isSelectionMode = false,
+    this.isSelected = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    final tile = Padding(
       padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
       child: Material(
-        color: Colors.transparent,
+        color: isSelected
+            ? AppColors.accent.withValues(alpha: 0.12)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
         child: InkWell(
           borderRadius: BorderRadius.circular(AppConstants.radiusLg),
           onTap: onTap,
+          onLongPress: onLongPress,
           child: Container(
             padding: const EdgeInsets.symmetric(
               horizontal: AppConstants.spacingMd,
@@ -410,17 +640,27 @@ class _UpcomingTile extends StatelessWidget {
             ),
             child: Row(
               children: [
-                Container(
-                  width: 24,
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    '${index + 1}',
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                      color: context.adaptiveTextTertiary,
-                      fontWeight: FontWeight.w700,
+                if (isSelectionMode) ...[
+                  Icon(
+                    isSelected ? LucideIcons.check : LucideIcons.circle,
+                    color: isSelected
+                        ? AppColors.accent
+                        : context.adaptiveTextTertiary,
+                    size: 22,
+                  ),
+                  const SizedBox(width: AppConstants.spacingSm),
+                ] else
+                  Container(
+                    width: 24,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      '${index + 1}',
+                      style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                            color: context.adaptiveTextTertiary,
+                            fontWeight: FontWeight.w700,
+                          ),
                     ),
                   ),
-                ),
                 _Artwork(song: song),
                 const SizedBox(width: AppConstants.spacingMd),
                 Expanded(
@@ -432,9 +672,9 @@ class _UpcomingTile extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: context.adaptiveTextPrimary,
-                          fontWeight: FontWeight.w600,
-                        ),
+                              color: context.adaptiveTextPrimary,
+                              fontWeight: FontWeight.w600,
+                            ),
                       ),
                       const SizedBox(height: 2),
                       Text(
@@ -442,23 +682,44 @@ class _UpcomingTile extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: context.adaptiveTextSecondary,
-                        ),
+                            color: context.adaptiveTextSecondary),
                       ),
                     ],
                   ),
                 ),
-                Text(
-                  song.formattedDuration,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.adaptiveTextTertiary,
+                if (!isSelectionMode)
+                  Text(
+                    song.formattedDuration,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: context.adaptiveTextTertiary,
+                        ),
                   ),
-                ),
               ],
             ),
           ),
         ),
       ),
+    );
+
+    if (isSelectionMode || onRemove == null) return tile;
+
+    return Dismissible(
+      key: ValueKey('upnext-dismiss-$index-${song.id}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          color: Colors.redAccent.withValues(alpha: 0.18),
+          border: Border.all(color: Colors.redAccent.withValues(alpha: 0.35)),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppConstants.spacingLg,
+        ),
+        alignment: Alignment.centerRight,
+        child: const Icon(LucideIcons.trash2, color: Colors.redAccent),
+      ),
+      onDismissed: (_) => onRemove!(),
+      child: tile,
     );
   }
 }
@@ -467,63 +728,68 @@ class _QueueTile extends StatelessWidget {
   final Song song;
   final int index;
   final VoidCallback onTap;
+  final VoidCallback onLongPress;
   final VoidCallback onRemove;
   final VoidCallback? onMoveToNext;
+  final bool isSelectionMode;
+  final bool isSelected;
 
   const _QueueTile({
     required super.key,
     required this.song,
     required this.index,
     required this.onTap,
+    this.onLongPress = _noop,
     required this.onRemove,
     required this.onMoveToNext,
+    this.isSelectionMode = false,
+    this.isSelected = false,
   });
+
+  static void _noop() {}
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      key: key,
+    final tile = Padding(
       padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
-      child: Dismissible(
-        key: ValueKey('queue-dismiss-$index-${song.id}'),
-        direction: DismissDirection.endToStart,
-        background: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-            color: Colors.redAccent.withValues(alpha: 0.18),
-            border: Border.all(color: Colors.redAccent.withValues(alpha: 0.35)),
-          ),
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppConstants.spacingLg,
-          ),
-          alignment: Alignment.centerRight,
-          child: const Icon(LucideIcons.trash2, color: Colors.redAccent),
-        ),
-        onDismissed: (_) => onRemove(),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-            onTap: onTap,
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingMd,
-                vertical: AppConstants.spacingSm,
+      child: Material(
+        color: isSelected
+            ? AppColors.accent.withValues(alpha: 0.12)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          onTap: onTap,
+          onLongPress: onLongPress,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppConstants.spacingMd,
+              vertical: AppConstants.spacingSm,
+            ),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  AppColors.surfaceLight.withValues(alpha: 0.7),
+                  AppColors.surface.withValues(alpha: 0.82),
+                ],
               ),
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: [
-                    AppColors.surfaceLight.withValues(alpha: 0.7),
-                    AppColors.surface.withValues(alpha: 0.82),
-                  ],
-                ),
-                border: Border.all(color: AppColors.glassBorder),
-              ),
-              child: Row(
-                children: [
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: Row(
+              children: [
+                if (isSelectionMode) ...[
+                  Icon(
+                    isSelected ? LucideIcons.check : LucideIcons.circle,
+                    color: isSelected
+                        ? AppColors.accent
+                        : context.adaptiveTextTertiary,
+                    size: 22,
+                  ),
+                  const SizedBox(width: AppConstants.spacingSm),
+                ] else
                   ReorderableDragStartListener(
                     index: index,
                     child: Padding(
@@ -537,33 +803,33 @@ class _QueueTile extends StatelessWidget {
                       ),
                     ),
                   ),
-                  _Artwork(song: song),
-                  const SizedBox(width: AppConstants.spacingMd),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          song.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                color: context.adaptiveTextPrimary,
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                        const SizedBox(height: 2),
-                        Text(
-                          song.artist,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: context.adaptiveTextSecondary),
-                        ),
-                      ],
-                    ),
+                _Artwork(song: song),
+                const SizedBox(width: AppConstants.spacingMd),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        song.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              color: context.adaptiveTextPrimary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        song.artist,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.adaptiveTextSecondary),
+                      ),
+                    ],
                   ),
+                ),
+                if (!isSelectionMode)
                   PopupMenuButton<_QueueAction>(
                     onSelected: (action) {
                       switch (action) {
@@ -591,12 +857,32 @@ class _QueueTile extends StatelessWidget {
                       color: context.adaptiveTextTertiary,
                     ),
                   ),
-                ],
-              ),
+              ],
             ),
           ),
         ),
       ),
+    );
+
+    if (isSelectionMode) return tile;
+
+    return Dismissible(
+      key: ValueKey('queue-dismiss-$index-${song.id}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          color: Colors.redAccent.withValues(alpha: 0.18),
+          border: Border.all(color: Colors.redAccent.withValues(alpha: 0.35)),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppConstants.spacingLg,
+        ),
+        alignment: Alignment.centerRight,
+        child: const Icon(LucideIcons.trash2, color: Colors.redAccent),
+      ),
+      onDismissed: (_) => onRemove(),
+      child: tile,
     );
   }
 }

--- a/lib/features/queue/screens/queue_screen.dart
+++ b/lib/features/queue/screens/queue_screen.dart
@@ -13,10 +13,9 @@ class QueueScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final queue = ref.watch(playerProvider.select((state) => state.queue));
-    final currentSong = ref.watch(
-      playerProvider.select((state) => state.currentSong),
-    );
+    final queue = ref.watch(queueProvider);
+    final upNext = ref.watch(upNextProvider);
+    final currentSong = ref.watch(currentSongProvider);
 
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -25,14 +24,14 @@ class QueueScreen extends ConsumerWidget {
         child: Column(
           children: [
             _Header(
-              queueCount: queue.length,
+              queueCount: upNext.length,
               canClear: queue.isNotEmpty,
               onClear: () async {
                 await ref.read(playerProvider.notifier).clearQueue();
               },
             ),
             Expanded(
-              child: queue.isEmpty && currentSong == null
+              child: upNext.isEmpty && currentSong == null
                   ? const _EmptyQueue()
                   : CustomScrollView(
                       slivers: [
@@ -57,7 +56,7 @@ class QueueScreen extends ConsumerWidget {
                               AppConstants.spacingSm,
                             ),
                             child: Text(
-                              queue.isEmpty ? 'Up next' : 'Next in queue',
+                              'Up next',
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
                                     color: context.adaptiveTextSecondary,
@@ -66,9 +65,52 @@ class QueueScreen extends ConsumerWidget {
                             ),
                           ),
                         ),
-                        if (queue.isEmpty)
+                        if (upNext.isEmpty)
                           const SliverToBoxAdapter(child: _EmptyUpcomingState())
                         else
+                          SliverPadding(
+                            padding: const EdgeInsets.fromLTRB(
+                              AppConstants.spacingLg,
+                              0,
+                              AppConstants.spacingLg,
+                              AppConstants.spacingLg,
+                            ),
+                            sliver: SliverList.builder(
+                              itemCount: upNext.length,
+                              itemBuilder: (context, index) {
+                                final song = upNext[index];
+                                return _UpcomingTile(
+                                  song: song,
+                                  index: index,
+                                  onTap: () async {
+                                    await ref
+                                        .read(playerProvider.notifier)
+                                        .playFromUpNextIndex(index);
+                                  },
+                                );
+                              },
+                            ),
+                          ),
+                        if (queue.isNotEmpty)
+                          SliverToBoxAdapter(
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(
+                                AppConstants.spacingLg,
+                                0,
+                                AppConstants.spacingLg,
+                                AppConstants.spacingSm,
+                              ),
+                              child: Text(
+                                'Manual queue',
+                                style: Theme.of(context).textTheme.titleMedium
+                                    ?.copyWith(
+                                      color: context.adaptiveTextSecondary,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                              ),
+                            ),
+                          ),
+                        if (queue.isNotEmpty)
                           SliverPadding(
                             padding: const EdgeInsets.fromLTRB(
                               AppConstants.spacingLg,
@@ -324,6 +366,98 @@ class _NowPlayingCard extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _UpcomingTile extends StatelessWidget {
+  final Song song;
+  final int index;
+  final VoidCallback onTap;
+
+  const _UpcomingTile({
+    required this.song,
+    required this.index,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppConstants.spacingMd,
+              vertical: AppConstants.spacingSm,
+            ),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  AppColors.surfaceLight.withValues(alpha: 0.7),
+                  AppColors.surface.withValues(alpha: 0.82),
+                ],
+              ),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 24,
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${index + 1}',
+                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                _Artwork(song: song),
+                const SizedBox(width: AppConstants.spacingMd),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        song.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: context.adaptiveTextPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        song.artist,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: context.adaptiveTextSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Text(
+                  song.formattedDuration,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/recap/screens/listening_recap_screen.dart
+++ b/lib/features/recap/screens/listening_recap_screen.dart
@@ -10,6 +10,7 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/data/repositories/recently_played_repository.dart';
+import 'package:flick/services/csv_export_service.dart';
 import 'package:flick/services/gallery_save_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
@@ -29,6 +30,7 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
   final GallerySaveService _gallerySaveService = GallerySaveService();
+  final CsvExportService _csvExportService = CsvExportService();
   final ImagePicker _imagePicker = ImagePicker();
   final GlobalKey _cardBoundaryKey = GlobalKey();
   final GlobalKey _topSongsPosterBoundaryKey = GlobalKey();
@@ -40,6 +42,8 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = {};
   bool _isLoading = true;
   bool _isSaving = false;
+  bool _isExportingCsv = false;
+  bool _isExportingTxt = false;
   String? _cameraBackgroundPath;
   String? _galleryBackgroundPath;
   _RecapRankingPosterType? _savingPosterType;
@@ -214,6 +218,52 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
       if (mounted) {
         setState(() => _isSaving = false);
       }
+    }
+  }
+
+  Future<void> _saveRecapCsv() async {
+    if (_isExportingCsv || _isExportingTxt) return;
+
+    setState(() => _isExportingCsv = true);
+
+    try {
+      final recap = _currentRecap();
+      await _csvExportService.saveCsv(recap);
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Recap saved as CSV')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_saveErrorMessage(error))));
+    } finally {
+      if (mounted) setState(() => _isExportingCsv = false);
+    }
+  }
+
+  Future<void> _saveRecapTxt() async {
+    if (_isExportingCsv || _isExportingTxt) return;
+
+    setState(() => _isExportingTxt = true);
+
+    try {
+      final recap = _currentRecap();
+      await _csvExportService.saveTxt(recap);
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Recap saved as TXT')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(_saveErrorMessage(error))));
+    } finally {
+      if (mounted) setState(() => _isExportingTxt = false);
     }
   }
 
@@ -632,6 +682,34 @@ class _ListeningRecapScreenState extends State<ListeningRecapScreen> {
           isPrimary: true,
           onTap: _isSaving ? null : _saveCurrentRecap,
         ),
+        if (recap.hasData) ...[
+          const SizedBox(height: AppConstants.spacingSm),
+          Row(
+            children: [
+              Expanded(
+                child: _RecapActionButton(
+                  icon: Icons.table_chart_rounded,
+                  label: _isExportingCsv ? 'Saving...' : 'Save as CSV',
+                  onTap:
+                      (_isExportingCsv || _isExportingTxt)
+                          ? null
+                          : _saveRecapCsv,
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingSm),
+              Expanded(
+                child: _RecapActionButton(
+                  icon: Icons.description_rounded,
+                  label: _isExportingTxt ? 'Saving...' : 'Save as TXT',
+                  onTap:
+                      (_isExportingCsv || _isExportingTxt)
+                          ? null
+                          : _saveRecapTxt,
+                ),
+              ),
+            ],
+          ),
+        ],
       ],
     );
   }

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -891,9 +891,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
     required List<Song> songs,
     required int index,
   }) async {
-    // Use the sorted songs list so next/previous follows the current sort order
+    // Play just the selected song — no playlist context so the queue stays empty
     final songToPlay = songs[index];
-    await ref.read(playerProvider.notifier).play(songToPlay, playlist: songs);
+    await ref.read(playerProvider.notifier).play(songToPlay);
 
     if (!mounted) return;
 

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -36,10 +36,13 @@ class SongsScreen extends ConsumerStatefulWidget {
 
 class _SongsScreenState extends ConsumerState<SongsScreen> {
   static const double _listItemExtent = 80;
+  static const int _folderGridPageSize = 18;
+  static const double _folderGridLoadMoreThreshold = 320;
 
   int _selectedIndex = 0;
   final TextEditingController _searchController = TextEditingController();
   final ScrollController _listScrollController = ScrollController();
+  final ScrollController _folderGridScrollController = ScrollController();
   final OrbitScrollController _orbitScrollController = OrbitScrollController();
   String _searchQuery = '';
   List<Song> _cachedSongs = [];
@@ -49,6 +52,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   bool _alignedCurrentSongAfterLoad = false;
   Timer? _fastIndexTimer;
   bool _fastIndexVisible = true;
+  int _visibleFolderCount = _folderGridPageSize;
+  int _totalFolderCount = 0;
+  String _folderPaginationSignature = '';
 
   @override
   void initState() {
@@ -60,13 +66,16 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
       _syncInterfaceToCurrentSong(next);
     });
     _listScrollController.addListener(_onListScroll);
+    _folderGridScrollController.addListener(_onFolderGridScroll);
   }
 
   @override
   void dispose() {
     _currentSongSubscription.close();
     _listScrollController.removeListener(_onListScroll);
+    _folderGridScrollController.removeListener(_onFolderGridScroll);
     _listScrollController.dispose();
+    _folderGridScrollController.dispose();
     _searchController.dispose();
     _fastIndexTimer?.cancel();
     super.dispose();
@@ -77,10 +86,13 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
     final songsAsync = ref.watch(songsProvider);
     final viewMode = ref.watch(songsViewModeProvider);
     final navBarVisible = ref.watch(navBarVisibleProvider);
-    final swipeActionsEnabled =
-        ref.watch(appPreferencesProvider).swipeActionsEnabled;
+    final swipeActionsEnabled = ref
+        .watch(appPreferencesProvider)
+        .swipeActionsEnabled;
     final navBarConfig = ref.watch(navBarConfigProvider);
-    final searchInNavBar = navBarConfig.orderedButtons.contains(NavBarButton.search);
+    final searchInNavBar = navBarConfig.orderedButtons.contains(
+      NavBarButton.search,
+    );
 
     final sortOption =
         songsAsync.value?.sortOption ?? SongSortOption.albumArtist;
@@ -401,63 +413,101 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         ),
         itemCount: songs.length,
         itemBuilder: (context, index) {
-        final song = songs[index];
-        final isSelected = index == _selectedIndex;
+          final song = songs[index];
+          final isSelected = index == _selectedIndex;
 
-        return Padding(
-          key: ValueKey(song.id),
-          padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
-          child: _QueueSwipeListItem(
-            swipeActionsEnabled: swipeActionsEnabled,
-            onQueued: () async {
-              await _queueSong(song);
-            },
-            onFavorited: () async {
-              await _favoriteSong(song);
-            },
-            child: _SongListTile(
-              song: song,
-              isSelected: isSelected,
-              onTap: () async {
-                setState(() {
-                  _selectedIndex = index;
-                });
-                _syncSelectedTokenForIndex(songs, index);
-                await _playSongAndOpenPlayer(songs: songs, index: index);
+          return Padding(
+            key: ValueKey(song.id),
+            padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
+            child: _QueueSwipeListItem(
+              swipeActionsEnabled: swipeActionsEnabled,
+              onQueued: () async {
+                await _queueSong(song);
               },
-              onLongPress: () {
-                SongActionsBottomSheet.show(context, song);
+              onFavorited: () async {
+                await _favoriteSong(song);
               },
+              child: _SongListTile(
+                song: song,
+                isSelected: isSelected,
+                onTap: () async {
+                  setState(() {
+                    _selectedIndex = index;
+                  });
+                  _syncSelectedTokenForIndex(songs, index);
+                  await _playSongAndOpenPlayer(songs: songs, index: index);
+                },
+                onLongPress: () {
+                  SongActionsBottomSheet.show(context, song);
+                },
+              ),
             ),
-          ),
-        );
-      },
-    ),
+          );
+        },
+      ),
     );
   }
 
   Widget _buildFolderGridView(List<FolderGroup> folders) {
-    return GridView.builder(
-      padding: const EdgeInsets.fromLTRB(
-        AppConstants.spacingLg,
-        0,
-        AppConstants.spacingLg,
-        AppConstants.navBarHeight + 120,
-      ),
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: context.gridColumns(compact: 2, phone: 2, tablet: 3),
-        childAspectRatio: 0.78,
-        crossAxisSpacing: AppConstants.spacingMd,
-        mainAxisSpacing: AppConstants.spacingLg,
-      ),
-      itemCount: folders.length,
-      itemBuilder: (context, index) {
-        final folder = folders[index];
-        return _FolderCard(
-          folder: folder,
-          onTap: () => _openFolderDetail(folder),
-        );
-      },
+    _syncFolderPagination(folders);
+
+    final visibleCount = min(_visibleFolderCount, folders.length);
+    final visibleFolders = folders.take(visibleCount).toList(growable: false);
+    final hasMore = visibleCount < folders.length;
+
+    return CustomScrollView(
+      controller: _folderGridScrollController,
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            AppConstants.spacingLg,
+            0,
+            AppConstants.spacingLg,
+            AppConstants.spacingLg,
+          ),
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: context.gridColumns(
+                compact: 2,
+                phone: 2,
+                tablet: 3,
+              ),
+              childAspectRatio: 0.78,
+              crossAxisSpacing: AppConstants.spacingMd,
+              mainAxisSpacing: AppConstants.spacingLg,
+            ),
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final folder = visibleFolders[index];
+              return _FolderCard(
+                folder: folder,
+                onTap: () => _openFolderDetail(folder),
+              );
+            }, childCount: visibleFolders.length),
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppConstants.spacingLg,
+              0,
+              AppConstants.spacingLg,
+              AppConstants.navBarHeight + 120,
+            ),
+            child: hasMore
+                ? _FolderLoadMoreIndicator(
+                    visibleCount: visibleCount,
+                    totalCount: folders.length,
+                  )
+                : visibleCount > _folderGridPageSize
+                ? _FolderLoadMoreIndicator(
+                    visibleCount: visibleCount,
+                    totalCount: folders.length,
+                    isComplete: true,
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ],
     );
   }
 
@@ -473,8 +523,10 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
           const begin = Offset(0.0, 0.05);
           const end = Offset.zero;
           const curve = Curves.easeOutCubic;
-          final tween = Tween(begin: begin, end: end)
-              .chain(CurveTween(curve: curve));
+          final tween = Tween(
+            begin: begin,
+            end: end,
+          ).chain(CurveTween(curve: curve));
           return SlideTransition(
             position: animation.drive(tween),
             child: child,
@@ -484,6 +536,36 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         opaque: true,
       ),
     );
+  }
+
+  void _syncFolderPagination(List<FolderGroup> folders) {
+    final totalSongCount = folders.fold<int>(
+      0,
+      (sum, folder) => sum + folder.songs.length,
+    );
+    final signature =
+        '$_searchQuery|${folders.length}|$totalSongCount|${folders.isNotEmpty ? folders.first.key : ''}|${folders.isNotEmpty ? folders.last.key : ''}';
+
+    _totalFolderCount = folders.length;
+
+    if (_folderPaginationSignature != signature) {
+      _folderPaginationSignature = signature;
+      _visibleFolderCount = min(_folderGridPageSize, folders.length);
+
+      if (_folderGridScrollController.hasClients) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || !_folderGridScrollController.hasClients) return;
+          _folderGridScrollController.jumpTo(0);
+        });
+      }
+      return;
+    }
+
+    if (_visibleFolderCount > folders.length) {
+      _visibleFolderCount = folders.length;
+    } else if (_visibleFolderCount == 0 && folders.isNotEmpty) {
+      _visibleFolderCount = min(_folderGridPageSize, folders.length);
+    }
   }
 
   Map<String, int> _buildFastIndexMap(List<Song> songs) {
@@ -735,6 +817,29 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
 
   void _onListScroll() {
     _showFastIndexOverlay();
+  }
+
+  void _onFolderGridScroll() {
+    if (!_folderGridScrollController.hasClients) return;
+
+    final position = _folderGridScrollController.position;
+    if (position.pixels >=
+        position.maxScrollExtent - _folderGridLoadMoreThreshold) {
+      _loadMoreFolders();
+    }
+  }
+
+  void _loadMoreFolders() {
+    if (!mounted || _visibleFolderCount >= _totalFolderCount) {
+      return;
+    }
+
+    setState(() {
+      _visibleFolderCount = min(
+        _visibleFolderCount + _folderGridPageSize,
+        _totalFolderCount,
+      );
+    });
   }
 
   Future<void> _playSongAndOpenPlayer({
@@ -1512,7 +1617,11 @@ class _FolderCardState extends State<_FolderCard>
                             child: Stack(
                               fit: StackFit.expand,
                               children: [
-                                _buildArtGrid(padded, artworkTargetWidth, context),
+                                _buildArtGrid(
+                                  padded,
+                                  artworkTargetWidth,
+                                  context,
+                                ),
                                 Positioned.fill(
                                   child: DecoratedBox(
                                     decoration: BoxDecoration(
@@ -1537,7 +1646,9 @@ class _FolderCardState extends State<_FolderCard>
                                       vertical: 6,
                                     ),
                                     decoration: BoxDecoration(
-                                      color: Colors.black.withValues(alpha: 0.55),
+                                      color: Colors.black.withValues(
+                                        alpha: 0.55,
+                                      ),
                                       borderRadius: BorderRadius.circular(999),
                                       border: Border.all(
                                         color: Colors.white.withValues(
@@ -1604,7 +1715,11 @@ class _FolderCardState extends State<_FolderCard>
     );
   }
 
-  Widget _buildArtGrid(List<_ArtEntry> artworks, int targetWidth, BuildContext context) {
+  Widget _buildArtGrid(
+    List<_ArtEntry> artworks,
+    int targetWidth,
+    BuildContext context,
+  ) {
     final cellSize = targetWidth ~/ 2;
     final cellRadius = AppConstants.radiusSm;
     return GridView.count(
@@ -1675,6 +1790,25 @@ class _FolderDetailScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final artworks = _getUniqueArtworks();
     final padded = List<_ArtEntry>.from(artworks);
+    final totalDuration = folder.songs.fold<Duration>(
+      Duration.zero,
+      (sum, song) => sum + song.duration,
+    );
+    final uniqueArtists = folder.songs
+        .map((song) => song.artist.trim())
+        .where((artist) => artist.isNotEmpty)
+        .toSet()
+        .length;
+    final uniqueFormats = folder.songs
+        .map((song) => song.fileType.toUpperCase())
+        .where((format) => format.isNotEmpty)
+        .toSet()
+        .length;
+    final totalAlbums = folder.songs
+        .map((song) => (song.album ?? '').trim())
+        .where((album) => album.isNotEmpty)
+        .toSet()
+        .length;
     while (padded.length < 4) {
       padded.add(const _ArtEntry(null, null));
     }
@@ -1684,14 +1818,16 @@ class _FolderDetailScreen extends ConsumerWidget {
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
-            expandedHeight: 280,
+            expandedHeight: 320,
             pinned: true,
-            backgroundColor: AppColors.surface,
+            backgroundColor: AppColors.background,
+            surfaceTintColor: Colors.transparent,
             leading: Container(
               margin: const EdgeInsets.all(8),
               decoration: BoxDecoration(
                 color: AppColors.glassBackground,
                 borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                border: Border.all(color: AppColors.glassBorder),
               ),
               child: IconButton(
                 icon: Icon(
@@ -1726,6 +1862,29 @@ class _FolderDetailScreen extends ConsumerWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppConstants.spacingSm,
+                            vertical: AppConstants.spacingXs,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.black.withValues(alpha: 0.32),
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(
+                              color: Colors.white.withValues(alpha: 0.12),
+                            ),
+                          ),
+                          child: const Text(
+                            'Folder Collection',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 0.2,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: AppConstants.spacingSm),
                         Text(
                           folder.name,
                           style: Theme.of(context).textTheme.headlineMedium
@@ -1738,9 +1897,28 @@ class _FolderDetailScreen extends ConsumerWidget {
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          '${folder.songs.length} songs',
+                          '$totalAlbums albums • $uniqueArtists artists',
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(color: context.adaptiveTextSecondary),
+                        ),
+                        const SizedBox(height: AppConstants.spacingSm),
+                        Wrap(
+                          spacing: AppConstants.spacingSm,
+                          runSpacing: AppConstants.spacingSm,
+                          children: [
+                            _FolderSummaryPill(
+                              icon: LucideIcons.music4,
+                              label: '${folder.songs.length} tracks',
+                            ),
+                            _FolderSummaryPill(
+                              icon: LucideIcons.clock3,
+                              label: _formatCollectionDuration(totalDuration),
+                            ),
+                            _FolderSummaryPill(
+                              icon: LucideIcons.audioLines,
+                              label: '$uniqueFormats formats',
+                            ),
+                          ],
                         ),
                       ],
                     ),
@@ -1748,22 +1926,116 @@ class _FolderDetailScreen extends ConsumerWidget {
                 ],
               ),
             ),
-            actions: [
-              Container(
-                margin: const EdgeInsets.all(8),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppConstants.spacingLg,
+                AppConstants.spacingLg,
+                AppConstants.spacingLg,
+                AppConstants.spacingMd,
+              ),
+              child: Container(
                 decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                ),
-                child: IconButton(
-                  icon: const Icon(
-                    LucideIcons.shuffle,
-                    color: Colors.white,
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: [
+                      AppColors.surfaceLight.withValues(alpha: 0.9),
+                      AppColors.surface.withValues(alpha: 0.95),
+                    ],
                   ),
-                  onPressed: () => _shufflePlayFolder(folder, ref, context),
+                  borderRadius: BorderRadius.circular(AppConstants.radiusXl),
+                  border: Border.all(color: AppColors.glassBorder),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.16),
+                      blurRadius: 24,
+                      offset: const Offset(0, 12),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(AppConstants.spacingMd),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Play from this folder',
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              color: context.adaptiveTextPrimary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                      ),
+                      const SizedBox(height: AppConstants.spacingXs),
+                      Text(
+                        'Tracks stay grouped in this folder, with artwork, format, and album details surfaced inline.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: context.adaptiveTextSecondary,
+                          height: 1.35,
+                        ),
+                      ),
+                      const SizedBox(height: AppConstants.spacingMd),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: _FolderActionButton(
+                              icon: LucideIcons.play,
+                              label: 'Play All',
+                              emphasized: true,
+                              onTap: () => _playFolder(
+                                folder.songs.first,
+                                folder,
+                                ref,
+                                context,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: AppConstants.spacingSm),
+                          Expanded(
+                            child: _FolderActionButton(
+                              icon: LucideIcons.shuffle,
+                              label: 'Shuffle',
+                              onTap: () =>
+                                  _shufflePlayFolder(folder, ref, context),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ],
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppConstants.spacingLg,
+                0,
+                AppConstants.spacingLg,
+                AppConstants.spacingSm,
+              ),
+              child: Row(
+                children: [
+                  Text(
+                    'Track List',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: context.adaptiveTextPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${folder.songs.length} songs',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
           SliverPadding(
             padding: const EdgeInsets.only(
@@ -1774,111 +2046,18 @@ class _FolderDetailScreen extends ConsumerWidget {
                 final song = folder.songs[index];
                 return Padding(
                   key: ValueKey(song.id),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingLg,
-                    vertical: AppConstants.spacingXxs,
+                  padding: const EdgeInsets.fromLTRB(
+                    AppConstants.spacingLg,
+                    0,
+                    AppConstants.spacingLg,
+                    AppConstants.spacingSm,
                   ),
-                  child: Material(
-                    color: Colors.transparent,
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-                      onTap: () async {
-                        await ref.read(playerProvider.notifier).play(
-                          song,
-                          playlist: folder.songs,
-                        );
-                        if (context.mounted) {
-                          await NavigationHelper.navigateToFullPlayer(
-                            context,
-                            heroTag: 'folder_song_${song.id}',
-                          );
-                        }
-                      },
-                      onLongPress: () {
-                        SongActionsBottomSheet.show(context, song);
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppConstants.spacingMd,
-                          vertical: AppConstants.spacingSm,
-                        ),
-                        child: Row(
-                          children: [
-                            ClipRRect(
-                              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                              child: SizedBox(
-                                width: 46,
-                                height: 46,
-                                child: CachedImageWidget(
-                                  imagePath: song.albumArt,
-                                  audioSourcePath: song.filePath,
-                                  fit: BoxFit.cover,
-                                  useThumbnail: true,
-                                  thumbnailWidth: 92,
-                                  thumbnailHeight: 92,
-                                  placeholder: const ColoredBox(
-                                    color: AppColors.surface,
-                                    child: Icon(
-                                      LucideIcons.music,
-                                      color: AppColors.textTertiary,
-                                      size: 18,
-                                    ),
-                                  ),
-                                  errorWidget: const ColoredBox(
-                                    color: AppColors.surface,
-                                    child: Icon(
-                                      LucideIcons.music,
-                                      color: AppColors.textTertiary,
-                                      size: 18,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: AppConstants.spacingMd),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    song.title,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyLarge
-                                        ?.copyWith(
-                                          color: context.adaptiveTextPrimary,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    '${song.artist} • ${song.fileType.toUpperCase()}',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodySmall
-                                        ?.copyWith(
-                                          color: context.adaptiveTextSecondary,
-                                        ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            const SizedBox(width: AppConstants.spacingSm),
-                            Text(
-                              song.formattedDuration,
-                              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: context.adaptiveTextTertiary,
-                                fontFeatures: const [FontFeature.tabularFigures()],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
+                  child: _FolderDetailTrackTile(
+                    song: song,
+                    index: index,
+                    onTap: () => _playFolder(song, folder, ref, context),
+                    onLongPress: () =>
+                        SongActionsBottomSheet.show(context, song),
                   ),
                 );
               }, childCount: folder.songs.length),
@@ -1926,16 +2105,392 @@ class _FolderDetailScreen extends ConsumerWidget {
   ) async {
     if (folder.songs.isEmpty) return;
     final shuffled = List<Song>.from(folder.songs)..shuffle(Random());
-    await ref.read(playerProvider.notifier).play(
-      shuffled.first,
-      playlist: shuffled,
-    );
+    await ref
+        .read(playerProvider.notifier)
+        .play(shuffled.first, playlist: shuffled);
     if (context.mounted) {
       await NavigationHelper.navigateToFullPlayer(
         context,
         heroTag: 'folder_shuffle_${folder.key}',
       );
     }
+  }
+
+  Future<void> _playFolder(
+    Song song,
+    FolderGroup folder,
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
+    await ref.read(playerProvider.notifier).play(song, playlist: folder.songs);
+    if (context.mounted) {
+      await NavigationHelper.navigateToFullPlayer(
+        context,
+        heroTag: 'folder_song_${song.id}',
+      );
+    }
+  }
+
+  String _formatCollectionDuration(Duration duration) {
+    if (duration.inHours > 0) {
+      final minutes = duration.inMinutes.remainder(60);
+      return '${duration.inHours}h ${minutes}m';
+    }
+    if (duration.inMinutes > 0) {
+      return '${duration.inMinutes}m';
+    }
+    return '${duration.inSeconds}s';
+  }
+}
+
+class _FolderLoadMoreIndicator extends StatelessWidget {
+  final int visibleCount;
+  final int totalCount;
+  final bool isComplete;
+
+  const _FolderLoadMoreIndicator({
+    required this.visibleCount,
+    required this.totalCount,
+    this.isComplete = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final label = isComplete
+        ? 'Showing all $totalCount folders'
+        : 'Showing $visibleCount of $totalCount folders';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingMd,
+        vertical: AppConstants.spacingMd,
+      ),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.surfaceLight.withValues(alpha: 0.7),
+            AppColors.surface.withValues(alpha: 0.9),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        children: [
+          if (!isComplete) ...[
+            SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  context.adaptiveTextSecondary,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppConstants.spacingSm),
+          ],
+          Expanded(
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextSecondary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Text(
+            isComplete ? 'Done' : 'Scroll for more',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FolderSummaryPill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _FolderSummaryPill({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingSm,
+        vertical: AppConstants.spacingXs,
+      ),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.28),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: Colors.white70),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FolderActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool emphasized;
+
+  const _FolderActionButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.emphasized = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final background = emphasized
+        ? AppColors.accent.withValues(alpha: 0.18)
+        : AppColors.surfaceLight.withValues(alpha: 0.8);
+    final borderColor = emphasized
+        ? AppColors.accent.withValues(alpha: 0.35)
+        : AppColors.glassBorder;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        child: Ink(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppConstants.spacingMd,
+            vertical: AppConstants.spacingMd,
+          ),
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+            border: Border.all(color: borderColor),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 18, color: context.adaptiveTextPrimary),
+              const SizedBox(width: AppConstants.spacingSm),
+              Text(
+                label,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FolderDetailTrackTile extends StatelessWidget {
+  final Song song;
+  final int index;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const _FolderDetailTrackTile({
+    required this.song,
+    required this.index,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final metaStyle = Theme.of(
+      context,
+    ).textTheme.bodySmall?.copyWith(color: context.adaptiveTextSecondary);
+    final detailStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+      color: context.adaptiveTextTertiary,
+      fontWeight: FontWeight.w500,
+    );
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(AppConstants.radiusXl),
+        child: Ink(
+          padding: const EdgeInsets.all(AppConstants.spacingSm),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                AppColors.surfaceLight.withValues(alpha: 0.82),
+                AppColors.surface.withValues(alpha: 0.94),
+              ],
+            ),
+            borderRadius: BorderRadius.circular(AppConstants.radiusXl),
+            border: Border.all(color: AppColors.glassBorder),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.12),
+                blurRadius: 16,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 34,
+                height: 34,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: AppColors.glassBackgroundStrong,
+                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                  border: Border.all(color: AppColors.glassBorder),
+                ),
+                child: Text(
+                  _trackLabel(song, index),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingSm),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+                child: SizedBox(
+                  width: 56,
+                  height: 56,
+                  child: CachedImageWidget(
+                    imagePath: song.albumArt,
+                    audioSourcePath: song.filePath,
+                    fit: BoxFit.cover,
+                    useThumbnail: true,
+                    thumbnailWidth: 112,
+                    thumbnailHeight: 112,
+                    placeholder: const ColoredBox(
+                      color: AppColors.surface,
+                      child: Icon(
+                        LucideIcons.music,
+                        color: AppColors.textTertiary,
+                        size: 18,
+                      ),
+                    ),
+                    errorWidget: const ColoredBox(
+                      color: AppColors.surface,
+                      child: Icon(
+                        LucideIcons.music,
+                        color: AppColors.textTertiary,
+                        size: 18,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingMd),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      song.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      _primaryMeta(song),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: metaStyle,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      _secondaryMeta(song),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: detailStyle,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingSm),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Icon(
+                    LucideIcons.play,
+                    size: 16,
+                    color: context.adaptiveTextTertiary,
+                  ),
+                  const SizedBox(height: AppConstants.spacingSm),
+                  Text(
+                    song.formattedDuration,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                      fontWeight: FontWeight.w700,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _trackLabel(Song song, int index) {
+    final trackNumber = song.trackNumber;
+    if (trackNumber != null && trackNumber > 0) {
+      return trackNumber.toString().padLeft(2, '0');
+    }
+    return (index + 1).toString().padLeft(2, '0');
+  }
+
+  String _primaryMeta(Song song) {
+    final album = (song.album ?? '').trim();
+    if (album.isEmpty) {
+      return song.artist;
+    }
+    return '${song.artist} • $album';
+  }
+
+  String _secondaryMeta(Song song) {
+    final parts = <String>[song.fileType.toUpperCase()];
+    if (song.resolution != null && song.resolution!.trim().isNotEmpty) {
+      parts.add(song.resolution!.trim());
+    }
+    if (song.discNumber != null && song.discNumber! > 0) {
+      parts.add('Disc ${song.discNumber}');
+    }
+    return parts.join(' • ');
   }
 }
 

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -115,10 +115,24 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
             child: Column(
               children: [
                 // Header with sort option
-                if (_selectionMode)
-                  _buildSelectionHeader()
-                else
-                  _buildHeader(songsAsync),
+                AnimatedSwitcher(
+                  duration: AppConstants.animationNormal,
+                  switchInCurve: Curves.easeOutCubic,
+                  switchOutCurve: Curves.easeInCubic,
+                  transitionBuilder: (child, animation) => FadeTransition(
+                    opacity: animation,
+                    child: child,
+                  ),
+                  child: _selectionMode
+                      ? KeyedSubtree(
+                          key: const ValueKey('selection_header'),
+                          child: _buildSelectionHeader(),
+                        )
+                      : KeyedSubtree(
+                          key: const ValueKey('normal_header'),
+                          child: _buildHeader(songsAsync),
+                        ),
+                ),
 
                 // Search Bar (hidden when Search tab is in the nav bar)
                 if (!searchInNavBar) ...[

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -55,6 +55,8 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   int _visibleFolderCount = _folderGridPageSize;
   int _totalFolderCount = 0;
   String _folderPaginationSignature = '';
+  bool _selectionMode = false;
+  final Set<String> _selectedIds = {};
 
   @override
   void initState() {
@@ -113,7 +115,10 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
             child: Column(
               children: [
                 // Header with sort option
-                _buildHeader(songsAsync),
+                if (_selectionMode)
+                  _buildSelectionHeader()
+                else
+                  _buildHeader(songsAsync),
 
                 // Search Bar (hidden when Search tab is in the nav bar)
                 if (!searchInNavBar) ...[
@@ -359,15 +364,22 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
   Widget _buildOrbitView(List<Song> songs, bool swipeActionsEnabled) {
     return GestureDetector(
       onLongPress: () {
+        if (_selectionMode) return;
         if (songs.isNotEmpty && _selectedIndex < songs.length) {
-          SongActionsBottomSheet.show(context, songs[_selectedIndex]);
+          SongActionsBottomSheet.show(
+            context,
+            songs[_selectedIndex],
+            onSelect: () => _enterSelectionMode(songs[_selectedIndex].id),
+          );
         }
       },
       child: OrbitScroll(
         controller: _orbitScrollController,
         songs: songs,
         selectedIndex: _selectedIndex.clamp(0, songs.length - 1).toInt(),
-        swipeActionsEnabled: swipeActionsEnabled,
+        swipeActionsEnabled: swipeActionsEnabled && !_selectionMode,
+        isSelectionMode: _selectionMode,
+        selectedIds: _selectedIds,
         onSelectedIndexChanged: (index) {
           if (!mounted) return;
           _showFastIndexOverlay();
@@ -377,6 +389,10 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
           _syncSelectedTokenForIndex(songs, index);
         },
         onSongSelected: (index) async {
+          if (_selectionMode) {
+            _toggleSelection(songs[index].id);
+            return;
+          }
           await _playSongAndOpenPlayer(songs: songs, index: index);
         },
         onSongSwipedLeft: (index) async {
@@ -415,12 +431,13 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
         itemBuilder: (context, index) {
           final song = songs[index];
           final isSelected = index == _selectedIndex;
+          final isMultiSelected = _selectedIds.contains(song.id);
 
           return Padding(
             key: ValueKey(song.id),
             padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
             child: _QueueSwipeListItem(
-              swipeActionsEnabled: swipeActionsEnabled,
+              swipeActionsEnabled: swipeActionsEnabled && !_selectionMode,
               onQueued: () async {
                 await _queueSong(song);
               },
@@ -430,7 +447,13 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
               child: _SongListTile(
                 song: song,
                 isSelected: isSelected,
+                isSelectionMode: _selectionMode,
+                isMultiSelected: isMultiSelected,
                 onTap: () async {
+                  if (_selectionMode) {
+                    _toggleSelection(song.id);
+                    return;
+                  }
                   setState(() {
                     _selectedIndex = index;
                   });
@@ -438,7 +461,15 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                   await _playSongAndOpenPlayer(songs: songs, index: index);
                 },
                 onLongPress: () {
-                  SongActionsBottomSheet.show(context, song);
+                  if (_selectionMode) {
+                    _toggleSelection(song.id);
+                  } else {
+                    SongActionsBottomSheet.show(
+                      context,
+                      song,
+                      onSelect: () => _enterSelectionMode(song.id),
+                    );
+                  }
                 },
               ),
             ),
@@ -898,6 +929,76 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
     );
   }
 
+  void _enterSelectionMode(String? songId) {
+    setState(() {
+      _selectionMode = true;
+      if (songId != null) _selectedIds.add(songId);
+    });
+  }
+
+  void _exitSelectionMode() {
+    setState(() {
+      _selectionMode = false;
+      _selectedIds.clear();
+    });
+  }
+
+  void _toggleSelection(String songId) {
+    setState(() {
+      if (_selectedIds.contains(songId)) {
+        _selectedIds.remove(songId);
+        if (_selectedIds.isEmpty) _selectionMode = false;
+      } else {
+        _selectedIds.add(songId);
+      }
+    });
+  }
+
+  void _selectAll(List<Song> songs) {
+    setState(() {
+      _selectedIds.addAll(songs.map((s) => s.id));
+    });
+  }
+
+  Future<void> _queueSelected() async {
+    final toQueue = _cachedDisplaySongs
+        .where((s) => _selectedIds.contains(s.id))
+        .toList();
+    for (final song in toQueue) {
+      await ref.read(playerProvider.notifier).addToQueue(song);
+    }
+    if (mounted) {
+      _showSongActionSnackBar('Queued ${toQueue.length} songs');
+      _exitSelectionMode();
+    }
+  }
+
+  Future<void> _favoriteSelected() async {
+    final toFavorite = _cachedDisplaySongs
+        .where((s) => _selectedIds.contains(s.id))
+        .toList();
+    for (final song in toFavorite) {
+      try {
+        await ref.read(favoritesServiceProvider).addFavorite(song.id);
+      } catch (_) {}
+    }
+    ref.invalidate(favoritesProvider);
+    PlayerService().refreshNotificationState();
+    if (mounted) {
+      _showSongActionSnackBar(
+        'Added ${toFavorite.length} songs to favorites',
+        onUndo: () async {
+          for (final song in toFavorite) {
+            await ref.read(favoritesServiceProvider).removeFavorite(song.id);
+          }
+          ref.invalidate(favoritesProvider);
+          PlayerService().refreshNotificationState();
+        },
+      );
+      _exitSelectionMode();
+    }
+  }
+
   void _showSongActionSnackBar(String message, {VoidCallback? onUndo}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -1049,6 +1150,12 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
             children: [
               _buildHeaderIconButton(
                 context: context,
+                icon: LucideIcons.checkCheck,
+                onTap: () => _enterSelectionMode(null),
+              ),
+              const SizedBox(width: AppConstants.spacingSm),
+              _buildHeaderIconButton(
+                context: context,
                 icon: LucideIcons.shuffle,
                 onTap: () => _shufflePlayFromLibrary(songsAsync),
               ),
@@ -1106,6 +1213,62 @@ class _SongsScreenState extends ConsumerState<SongsScreen> {
                 ),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSelectionHeader() {
+    final count = _selectedIds.length;
+    final allSelected =
+        count == _cachedDisplaySongs.length && _cachedDisplaySongs.isNotEmpty;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingMd,
+        vertical: AppConstants.spacingMd,
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(LucideIcons.x),
+            color: context.adaptiveTextPrimary,
+            onPressed: _exitSelectionMode,
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          Expanded(
+            child: Text(
+              '$count selected',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.adaptiveTextPrimary,
+                  ),
+            ),
+          ),
+          if (!allSelected)
+            TextButton(
+              onPressed: () => _selectAll(_cachedDisplaySongs),
+              child: Text(
+                'Select All',
+                style: TextStyle(color: context.adaptiveTextSecondary),
+              ),
+            ),
+          IconButton(
+            icon: Icon(
+              LucideIcons.listPlus,
+              color: AppColors.accent.withValues(alpha: 0.8),
+            ),
+            onPressed: count > 0 ? () => _queueSelected() : null,
+            tooltip: 'Queue selected',
+          ),
+          IconButton(
+            icon: Icon(
+              LucideIcons.heart,
+              color: Colors.red.withValues(alpha: 0.8),
+            ),
+            onPressed: count > 0 ? () => _favoriteSelected() : null,
+            tooltip: 'Favorite selected',
           ),
         ],
       ),
@@ -1195,12 +1358,16 @@ class _QueueSwipeListItem extends StatefulWidget {
 class _SongListTile extends StatelessWidget {
   final Song song;
   final bool isSelected;
+  final bool isSelectionMode;
+  final bool isMultiSelected;
   final Future<void> Function() onTap;
   final VoidCallback onLongPress;
 
   const _SongListTile({
     required this.song,
     required this.isSelected,
+    required this.isSelectionMode,
+    required this.isMultiSelected,
     required this.onTap,
     required this.onLongPress,
   });
@@ -1238,7 +1405,7 @@ class _SongListTile extends StatelessWidget {
             gradient: LinearGradient(
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
-              colors: isSelected
+              colors: (isSelected || isMultiSelected)
                   ? [
                       AppColors.surfaceLight.withValues(alpha: 0.9),
                       AppColors.surface.withValues(alpha: 0.95),
@@ -1249,13 +1416,25 @@ class _SongListTile extends StatelessWidget {
                     ],
             ),
             border: Border.all(
-              color: isSelected
+              color: (isSelected || isMultiSelected)
                   ? AppColors.accent.withValues(alpha: 0.45)
                   : AppColors.glassBorder,
             ),
           ),
           child: Row(
             children: [
+              if (isSelectionMode) ...[
+                Icon(
+                  isMultiSelected
+                      ? LucideIcons.check
+                      : LucideIcons.circle,
+                  color: isMultiSelected
+                      ? AppColors.accent
+                      : context.adaptiveTextTertiary,
+                  size: context.responsiveIcon(AppConstants.iconSizeMd),
+                ),
+                const SizedBox(width: AppConstants.spacingMd),
+              ],
               ClipRRect(
                 borderRadius: BorderRadius.circular(AppConstants.radiusMd),
                 child: SizedBox(

--- a/lib/features/songs/widgets/orbit_scroll.dart
+++ b/lib/features/songs/widgets/orbit_scroll.dart
@@ -48,6 +48,12 @@ class OrbitScroll extends StatefulWidget {
   /// Whether swipe-to-queue and swipe-to-favorite gestures are enabled.
   final bool swipeActionsEnabled;
 
+  /// Whether multiselect mode is active.
+  final bool isSelectionMode;
+
+  /// Set of selected song IDs in multiselect mode.
+  final Set<String> selectedIds;
+
   /// Controller for external jump-to-index actions.
   final OrbitScrollController? controller;
 
@@ -60,6 +66,8 @@ class OrbitScroll extends StatefulWidget {
     this.onSongSwipedLeft,
     this.onSongSwipedRight,
     this.swipeActionsEnabled = false,
+    this.isSelectionMode = false,
+    this.selectedIds = const {},
     this.controller,
   });
 
@@ -437,6 +445,8 @@ class _OrbitScrollState extends State<OrbitScroll>
                 opacity: transform.opacity,
                 isSelected: transform.isSelected,
                 swipeActionsEnabled: widget.swipeActionsEnabled,
+                isSelectionMode: widget.isSelectionMode,
+                isMultiSelected: widget.selectedIds.contains(widget.songs[actualIndex].id),
                 onTap: () {
                   AppHaptics.tap();
                   _animateTo(actualIndex.toDouble());

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -19,21 +19,31 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 class SongActionsBottomSheet extends ConsumerWidget {
   final Song song;
   final BuildContext rootContext;
+  final VoidCallback? onSelect;
 
   const SongActionsBottomSheet({
     super.key,
     required this.song,
     required this.rootContext,
+    this.onSelect,
   });
 
   /// Show the song actions bottom sheet
-  static Future<void> show(BuildContext context, Song song) {
+  static Future<void> show(
+    BuildContext context,
+    Song song, {
+    VoidCallback? onSelect,
+  }) {
     return showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (sheetContext) => AppBottomSheetSurface(
-        child: SongActionsBottomSheet(song: song, rootContext: context),
+        child: SongActionsBottomSheet(
+          song: song,
+          rootContext: context,
+          onSelect: onSelect,
+        ),
       ),
     );
   }
@@ -65,6 +75,16 @@ class SongActionsBottomSheet extends ConsumerWidget {
               }
             },
           ),
+          if (onSelect != null)
+            _buildActionTile(
+              context: context,
+              icon: LucideIcons.checkCheck,
+              label: 'Select',
+              onTap: () {
+                Navigator.pop(context);
+                onSelect?.call();
+              },
+            ),
           _buildActionTile(
             context: context,
             icon: LucideIcons.listPlus,

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -34,6 +34,12 @@ class SongCard extends StatefulWidget {
   /// Whether swipe-to-queue and swipe-to-favorite gestures are enabled.
   final bool swipeActionsEnabled;
 
+  /// Whether multiselect mode is active.
+  final bool isSelectionMode;
+
+  /// Whether this song is selected in multiselect mode.
+  final bool isMultiSelected;
+
   const SongCard({
     super.key,
     required this.song,
@@ -44,6 +50,8 @@ class SongCard extends StatefulWidget {
     this.onSwipeLeft,
     this.onSwipeRight,
     this.swipeActionsEnabled = false,
+    this.isSelectionMode = false,
+    this.isMultiSelected = false,
   });
 
   @override
@@ -291,6 +299,20 @@ class _SongCardState extends State<SongCard> {
                                   ),
                                 ),
                               ),
+                              if (widget.isSelectionMode)
+                                Positioned(
+                                  top: AppConstants.spacingSm,
+                                  right: AppConstants.spacingSm,
+                                  child: Icon(
+                                    widget.isMultiSelected
+                                        ? Icons.check_circle_rounded
+                                        : Icons.radio_button_unchecked_rounded,
+                                    color: widget.isMultiSelected
+                                        ? AppColors.accent
+                                        : Colors.white54,
+                                    size: 22,
+                                  ),
+                                ),
                             ],
                           ),
                         ),

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -367,6 +367,14 @@ class PlayerNotifier extends Notifier<PlayerState> {
     await _service.moveQueueItemToNext(index);
   }
 
+  Future<void> clearAllUpcoming() async {
+    await _service.clearAllUpcoming();
+  }
+
+  Future<void> removeFromUpNext(int upNextIndex) async {
+    await _service.removeFromUpNext(upNextIndex);
+  }
+
   /// Toggle loop mode.
   void toggleLoopMode() {
     unawaited(_service.toggleLoopMode());

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -23,6 +23,7 @@ class PlayerState {
   final double playbackSpeed;
   final Duration? sleepTimerRemaining;
   final List<Song> queue;
+  final List<Song> upNext;
   final int currentIndex;
 
   const PlayerState({
@@ -36,6 +37,7 @@ class PlayerState {
     this.playbackSpeed = 1.0,
     this.sleepTimerRemaining,
     this.queue = const [],
+    this.upNext = const [],
     this.currentIndex = -1,
   });
 
@@ -50,6 +52,7 @@ class PlayerState {
     double? playbackSpeed,
     Duration? sleepTimerRemaining,
     List<Song>? queue,
+    List<Song>? upNext,
     int? currentIndex,
     bool clearSong = false,
     bool clearSleepTimer = false,
@@ -67,6 +70,7 @@ class PlayerState {
           ? null
           : (sleepTimerRemaining ?? this.sleepTimerRemaining),
       queue: queue ?? this.queue,
+      upNext: upNext ?? this.upNext,
       currentIndex: currentIndex ?? this.currentIndex,
     );
   }
@@ -79,12 +83,6 @@ class PlayerState {
 
   /// Whether there is a song loaded.
   bool get hasSong => currentSong != null;
-
-  List<Song> get upNext {
-    if (queue.isEmpty) return const [];
-    final startIndex = (currentIndex + 1).clamp(0, queue.length);
-    return queue.sublist(startIndex);
-  }
 }
 
 /// Provider for the PlayerService singleton.
@@ -122,6 +120,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       playbackSpeed: _service.playbackSpeedNotifier.value,
       sleepTimerRemaining: _service.sleepTimerRemainingNotifier.value,
       queue: _service.queueNotifier.value,
+      upNext: _service.upNextNotifier.value,
       currentIndex: _service.currentIndexNotifier.value,
     );
 
@@ -172,6 +171,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
         playbackSpeed: _service.playbackSpeedNotifier.value,
         sleepTimerRemaining: _service.sleepTimerRemainingNotifier.value,
         queue: _service.queueNotifier.value,
+        upNext: _service.upNextNotifier.value,
         currentIndex: _service.currentIndexNotifier.value,
         clearSong: _service.currentSongNotifier.value == null,
         clearSleepTimer: _service.sleepTimerRemainingNotifier.value == null,
@@ -236,6 +236,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
     _service.playbackSpeedNotifier.addListener(syncState);
     _service.sleepTimerRemainingNotifier.addListener(syncState);
     _service.queueNotifier.addListener(syncState);
+    _service.upNextNotifier.addListener(syncState);
     _service.currentIndexNotifier.addListener(syncState);
 
     // Cleanup listeners when provider is disposed
@@ -250,6 +251,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
       _service.playbackSpeedNotifier.removeListener(syncState);
       _service.sleepTimerRemainingNotifier.removeListener(syncState);
       _service.queueNotifier.removeListener(syncState);
+      _service.upNextNotifier.removeListener(syncState);
       _service.currentIndexNotifier.removeListener(syncState);
     });
 
@@ -343,6 +345,10 @@ class PlayerNotifier extends Notifier<PlayerState> {
 
   Future<void> playFromQueueIndex(int index) async {
     await _service.playFromQueueIndex(index);
+  }
+
+  Future<void> playFromUpNextIndex(int index) async {
+    await _service.playFromUpNextIndex(index);
   }
 
   Future<void> clearQueue() async {

--- a/lib/services/android_audio_engine.dart
+++ b/lib/services/android_audio_engine.dart
@@ -8,7 +8,7 @@ import 'package:flick/models/song.dart';
 import 'package:flick/services/audio_engine.dart';
 
 typedef AndroidAudioSourcesBuilder =
-    Future<List<just_audio.AudioSource>> Function();
+    Future<just_audio.AudioSource> Function();
 typedef AndroidAudioSourceBuilder =
     Future<just_audio.AudioSource> Function(Song track);
 typedef AndroidPlaylistProvider = List<Song> Function();
@@ -256,12 +256,14 @@ class AndroidAudioEngine implements AudioEngine {
       debugPrint('[Playback] Android load(${track.id}) rebuilding playlist');
       _awaitingInitialSeek = true;
       try {
-        final sources = await _sourcesBuilder();
-        if (sources.isEmpty) {
+        final source = await _sourcesBuilder();
+        // ignore: deprecated_member_use
+        if (source is just_audio.ConcatenatingAudioSource &&
+            source.children.isEmpty) {
           throw StateError('No audio sources available for playback');
         }
-        await player.setAudioSources(
-          sources,
+        await player.setAudioSource(
+          source,
           initialIndex: index,
           preload: true,
         );

--- a/lib/services/csv_export_service.dart
+++ b/lib/services/csv_export_service.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import '../data/repositories/recently_played_repository.dart';
+
+class CsvExportService {
+  static const _channel = MethodChannel('com.mossapps.flick/storage');
+
+  Future<String?> saveCsv(ListeningRecap recap) async {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('CSV export is currently supported on Android only.');
+    }
+
+    final content = _buildCsv(recap);
+    final fileName = _buildFileName(recap, 'csv');
+    final documentUri = await _channel.invokeMethod<String>(
+      'createDocument',
+      {'fileName': fileName, 'mimeType': 'text/csv'},
+    );
+    if (documentUri == null || documentUri.trim().isEmpty) return null;
+
+    final success = await _channel.invokeMethod<bool>(
+      'writeTextDocument',
+      {'uri': documentUri, 'content': content},
+    );
+    if (success != true) {
+      throw const FileSystemException('Failed to write CSV file');
+    }
+
+    return fileName;
+  }
+
+  Future<String?> saveTxt(ListeningRecap recap) async {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('TXT export is currently supported on Android only.');
+    }
+
+    final content = _buildTxt(recap);
+    final fileName = _buildFileName(recap, 'txt');
+    final documentUri = await _channel.invokeMethod<String>(
+      'createDocument',
+      {'fileName': fileName, 'mimeType': 'text/plain'},
+    );
+    if (documentUri == null || documentUri.trim().isEmpty) return null;
+
+    final success = await _channel.invokeMethod<bool>(
+      'writeTextDocument',
+      {'uri': documentUri, 'content': content},
+    );
+    if (success != true) {
+      throw const FileSystemException('Failed to write TXT file');
+    }
+
+    return fileName;
+  }
+
+  String _buildFileName(ListeningRecap recap, String extension) {
+    final now = DateTime.now();
+    final ts =
+        '${now.year}-${_pad(now.month)}-${_pad(now.day)}_'
+        '${_pad(now.hour)}${_pad(now.minute)}${_pad(now.second)}';
+    return 'flick_${recap.period.label.toLowerCase()}_replay_$ts.$extension';
+  }
+
+  String _pad(int n) => n.toString().padLeft(2, '0');
+
+  String _formatDuration(Duration d) {
+    final hours = d.inHours;
+    final minutes = d.inMinutes.remainder(60);
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    }
+    return '${minutes}m';
+  }
+
+  String _formatDateTime(DateTime dt) {
+    return '${dt.year}-${_pad(dt.month)}-${_pad(dt.day)} '
+        '${_pad(dt.hour)}:${_pad(dt.minute)}';
+  }
+
+  String _csvEscape(String value) {
+    if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+      return '"${value.replaceAll('"', '""')}"';
+    }
+    return value;
+  }
+
+  String _buildCsv(ListeningRecap recap) {
+    final buf = StringBuffer();
+
+    buf.writeln('Flick Replay — ${recap.period.label} Recap');
+    buf.writeln();
+    buf.writeln('Period: ${_formatDateTime(recap.start)} → ${_formatDateTime(recap.endExclusive)}');
+    buf.writeln('Total Plays: ${recap.totalPlays}');
+    buf.writeln('Total Listening Time: ${_formatDuration(recap.totalListeningTime)}');
+    buf.writeln('Unique Songs: ${recap.uniqueSongs}');
+    buf.writeln('Unique Artists: ${recap.uniqueArtists}');
+    buf.writeln('Active Days: ${recap.activeDays}');
+    if (recap.peakHour != null) {
+      buf.writeln('Peak Listening Hour: ${recap.peakHour}:00');
+    }
+    buf.writeln();
+
+    buf.writeln('Top Songs');
+    buf.writeln('Rank,Title,Artist,Album,Plays,Listening Time,Last Played');
+    for (var i = 0; i < recap.topSongs.length; i++) {
+      final s = recap.topSongs[i];
+      buf.writeln(
+        '${i + 1},'
+        '${_csvEscape(s.song.title)},'
+        '${_csvEscape(s.song.artist)},'
+        '${_csvEscape(s.song.album ?? '')},'
+        '${s.plays},'
+        '${_formatDuration(s.listeningTime)},'
+        '${_formatDateTime(s.lastPlayedAt)}',
+      );
+    }
+    buf.writeln();
+
+    buf.writeln('Top Artists');
+    buf.writeln('Rank,Artist,Plays,Unique Songs,Listening Time,Last Played');
+    for (var i = 0; i < recap.topArtists.length; i++) {
+      final a = recap.topArtists[i];
+      buf.writeln(
+        '${i + 1},'
+        '${_csvEscape(a.artist)},'
+        '${a.plays},'
+        '${a.uniqueSongs},'
+        '${_formatDuration(a.listeningTime)},'
+        '${_formatDateTime(a.lastPlayedAt)}',
+      );
+    }
+    buf.writeln();
+
+    buf.writeln('Top Albums');
+    buf.writeln('Rank,Album,Artist,Plays,Unique Songs,Listening Time,Last Played');
+    for (var i = 0; i < recap.topAlbums.length; i++) {
+      final a = recap.topAlbums[i];
+      buf.writeln(
+        '${i + 1},'
+        '${_csvEscape(a.album)},'
+        '${_csvEscape(a.artist)},'
+        '${a.plays},'
+        '${a.uniqueSongs},'
+        '${_formatDuration(a.listeningTime)},'
+        '${_formatDateTime(a.lastPlayedAt)}',
+      );
+    }
+
+    return buf.toString();
+  }
+
+  String _buildTxt(ListeningRecap recap) {
+    final buf = StringBuffer();
+
+    buf.writeln('=== FLICK REPLAY: ${recap.period.label.toUpperCase()} RECAP ===');
+    buf.writeln();
+    buf.writeln('Period:       ${_formatDateTime(recap.start)} → ${_formatDateTime(recap.endExclusive)}');
+    buf.writeln('Total Plays:  ${recap.totalPlays}');
+    buf.writeln('Listening:    ${_formatDuration(recap.totalListeningTime)}');
+    buf.writeln('Songs:        ${recap.uniqueSongs} unique');
+    buf.writeln('Artists:      ${recap.uniqueArtists} unique');
+    buf.writeln('Active Days:  ${recap.activeDays}');
+    if (recap.peakHour != null) {
+      buf.writeln('Peak Hour:    ${recap.peakHour}:00');
+    }
+    buf.writeln();
+
+    buf.writeln('--- Top Songs ---');
+    for (var i = 0; i < recap.topSongs.length; i++) {
+      final s = recap.topSongs[i];
+      buf.writeln('  ${i + 1}. ${s.song.title} — ${s.song.artist}');
+      buf.writeln('     Plays: ${s.plays} | Time: ${_formatDuration(s.listeningTime)} | Last: ${_formatDateTime(s.lastPlayedAt)}');
+    }
+    buf.writeln();
+
+    buf.writeln('--- Top Artists ---');
+    for (var i = 0; i < recap.topArtists.length; i++) {
+      final a = recap.topArtists[i];
+      buf.writeln('  ${i + 1}. ${a.artist}');
+      buf.writeln('     Plays: ${a.plays} | Songs: ${a.uniqueSongs} | Time: ${_formatDuration(a.listeningTime)} | Last: ${_formatDateTime(a.lastPlayedAt)}');
+    }
+    buf.writeln();
+
+    buf.writeln('--- Top Albums ---');
+    for (var i = 0; i < recap.topAlbums.length; i++) {
+      final a = recap.topAlbums[i];
+      buf.writeln('  ${i + 1}. ${a.album} — ${a.artist}');
+      buf.writeln('     Plays: ${a.plays} | Songs: ${a.uniqueSongs} | Time: ${_formatDuration(a.listeningTime)} | Last: ${_formatDateTime(a.lastPlayedAt)}');
+    }
+
+    return buf.toString();
+  }
+}

--- a/lib/services/lyrics_service.dart
+++ b/lib/services/lyrics_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:flick/models/song.dart';
 
@@ -19,11 +21,25 @@ class LyricsData {
   final List<LyricsLine> lines;
   final bool isSynchronized;
   final String? source;
+  final String rawContent;
 
   const LyricsData({
     required this.lines,
     required this.isSynchronized,
     this.source,
+    required this.rawContent,
+  });
+}
+
+class LyricsSaveResult {
+  final LyricsData data;
+  final String path;
+  final bool savedBesideSong;
+
+  const LyricsSaveResult({
+    required this.data,
+    required this.path,
+    required this.savedBesideSong,
   });
 }
 
@@ -31,15 +47,36 @@ class LyricsService {
   static const MethodChannel _storageChannel = MethodChannel(
     'com.mossapps.flick/storage',
   );
+  static const String _manualLyricsOverridesKey = 'lyrics_manual_overrides_v1';
+  static const String _managedLyricsDirectoryName = 'lyrics';
 
   final Map<String, LyricsData?> _cache = {};
 
-  Future<LyricsData?> loadLyricsForSong(Song song) async {
+  Future<LyricsData?> loadLyricsForSong(
+    Song song, {
+    bool forceRefresh = false,
+  }) async {
     final filePath = song.filePath;
     if (filePath == null || filePath.isEmpty) return null;
 
-    if (_cache.containsKey(filePath)) {
+    if (forceRefresh) {
+      _cache.remove(filePath);
+    }
+
+    if (!forceRefresh && _cache.containsKey(filePath)) {
       return _cache[filePath];
+    }
+
+    final manualPath = await getManualLyricsPathForSong(song);
+    if (manualPath != null && manualPath.isNotEmpty) {
+      final manualLoaded = await _loadLyricsFromAbsolutePath(manualPath);
+      if (manualLoaded != null && manualLoaded.content.trim().isNotEmpty) {
+        final parsed = _parseLyrics(manualLoaded.content, source: manualLoaded.source);
+        _cache[filePath] = parsed;
+        return parsed;
+      }
+
+      await clearManualLyricsPathForSong(song);
     }
 
     final embedded = await _loadEmbeddedLyricsText(filePath);
@@ -58,6 +95,95 @@ class LyricsService {
     final parsed = _parseLyrics(loaded.content, source: loaded.source);
     _cache[filePath] = parsed;
     return parsed;
+  }
+
+  Future<String?> getManualLyricsPathForSong(Song song) async {
+    final filePath = song.filePath;
+    if (filePath == null || filePath.isEmpty) return null;
+
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_manualLyricsOverridesKey);
+    if (raw == null || raw.isEmpty) return null;
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) return null;
+      final value = decoded[filePath];
+      if (value is String && value.isNotEmpty) {
+        return value;
+      }
+    } catch (_) {
+      // Ignore malformed preference payload and fall back to auto lookup.
+    }
+
+    return null;
+  }
+
+  Future<void> clearManualLyricsPathForSong(Song song) async {
+    await _setManualLyricsPath(song, null);
+  }
+
+  Future<LyricsSaveResult> importLyricsForSong({
+    required Song song,
+    required String fileName,
+    required String content,
+  }) async {
+    final extension = _preferredLyricsExtension(fileName);
+    final savedPath = await _writeManagedLyricsCopy(
+      song: song,
+      extension: extension,
+      content: content,
+    );
+    await _setManualLyricsPath(song, savedPath);
+    final data = (await loadLyricsForSong(song, forceRefresh: true)) ??
+        _parseLyrics(content, source: savedPath);
+    return LyricsSaveResult(
+      data: data,
+      path: savedPath,
+      savedBesideSong: false,
+    );
+  }
+
+  Future<LyricsSaveResult> saveLyricsForSong({
+    required Song song,
+    required String content,
+  }) async {
+    final sidecarPath = suggestSidecarLrcPath(song);
+    var savedBesideSong = false;
+    late final String savedPath;
+
+    if (sidecarPath != null) {
+      try {
+        final file = File(sidecarPath);
+        await file.parent.create(recursive: true);
+        await file.writeAsString(content);
+        await _setManualLyricsPath(song, null);
+        savedBesideSong = true;
+        savedPath = file.path;
+      } catch (_) {
+        savedPath = await _writeManagedLyricsCopy(
+          song: song,
+          extension: 'lrc',
+          content: content,
+        );
+        await _setManualLyricsPath(song, savedPath);
+      }
+    } else {
+      savedPath = await _writeManagedLyricsCopy(
+        song: song,
+        extension: 'lrc',
+        content: content,
+      );
+      await _setManualLyricsPath(song, savedPath);
+    }
+
+    final data = (await loadLyricsForSong(song, forceRefresh: true)) ??
+        _parseLyrics(content, source: savedPath);
+    return LyricsSaveResult(
+      data: data,
+      path: savedPath,
+      savedBesideSong: savedBesideSong,
+    );
   }
 
   int findCurrentLineIndex(LyricsData lyrics, Duration position) {
@@ -82,6 +208,57 @@ class LyricsService {
     return result;
   }
 
+  LyricsData parseLyricsText(String raw, {String? source}) {
+    return _parseLyrics(raw, source: source);
+  }
+
+  Duration? parseTimestamp(String timestamp) {
+    return _parseTimestamp(timestamp);
+  }
+
+  String formatTimestamp(Duration duration) {
+    final totalMinutes = duration.inMinutes;
+    final seconds = duration.inSeconds.remainder(60);
+    final centiseconds = (duration.inMilliseconds.remainder(1000) ~/ 10);
+    return '[${totalMinutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}.${centiseconds.toString().padLeft(2, '0')}]';
+  }
+
+  String buildLrcContent({
+    required List<LyricsLine> lines,
+    Song? song,
+  }) {
+    final buffer = StringBuffer();
+    if (song?.title case final title? when title.trim().isNotEmpty) {
+      buffer.writeln('[ti:${title.trim()}]');
+    }
+    if (song?.artist case final artist? when artist.trim().isNotEmpty) {
+      buffer.writeln('[ar:${artist.trim()}]');
+    }
+    if (song?.album case final album? when album.trim().isNotEmpty) {
+      buffer.writeln('[al:${album.trim()}]');
+    }
+    if (buffer.isNotEmpty) {
+      buffer.writeln();
+    }
+
+    for (final line in lines) {
+      buffer.writeln('${formatTimestamp(line.timestamp)}${line.text}');
+    }
+    return buffer.toString().trimRight();
+  }
+
+  String? suggestSidecarLrcPath(Song song) {
+    final filePath = song.filePath;
+    if (filePath == null || filePath.isEmpty) return null;
+    final localPath = _resolveLocalPath(filePath);
+    if (localPath == null || localPath.isEmpty) return null;
+
+    final audioFile = File(localPath);
+    final parent = audioFile.parent;
+    final stem = _basenameWithoutExtension(audioFile.path);
+    return '${parent.path}${Platform.pathSeparator}$stem.lrc';
+  }
+
   Future<_LoadedLyrics?> _loadEmbeddedLyricsText(String filePath) async {
     try {
       final result = await _storageChannel.invokeMapMethod<String, dynamic>(
@@ -99,6 +276,14 @@ class LyricsService {
       // Best-effort lookup. Fall back to sidecar lookup.
     }
     return null;
+  }
+
+  Future<_LoadedLyrics?> _loadLyricsFromAbsolutePath(String absolutePath) async {
+    final file = File(absolutePath);
+    if (!await file.exists()) return null;
+    final content = await _readTextFile(file);
+    if (content == null || content.trim().isEmpty) return null;
+    return _LoadedLyrics(content: content, source: file.path);
   }
 
   Future<_LoadedLyrics?> _loadLyricsText(String filePath) async {
@@ -262,6 +447,7 @@ class LyricsService {
         lines: parsedLines,
         isSynchronized: true,
         source: source,
+        rawContent: raw,
       );
     }
 
@@ -269,6 +455,7 @@ class LyricsService {
       lines: parsedLines.where((line) => line.text.isNotEmpty).toList(),
       isSynchronized: false,
       source: source,
+      rawContent: raw,
     );
   }
 
@@ -311,7 +498,12 @@ class LyricsService {
 
       if (lines.isNotEmpty) {
         lines.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-        return LyricsData(lines: lines, isSynchronized: hasTimestamps, source: source);
+        return LyricsData(
+          lines: lines,
+          isSynchronized: hasTimestamps,
+          source: source,
+          rawContent: xml,
+        );
       }
     } catch (_) {
       // Fall through to plain-text parser
@@ -358,6 +550,78 @@ class LyricsService {
     if (fractionRaw.length == 1) return int.parse(fractionRaw) * 100;
     if (fractionRaw.length == 2) return int.parse(fractionRaw) * 10;
     return int.parse(fractionRaw.substring(0, 3));
+  }
+
+  Future<void> _setManualLyricsPath(Song song, String? manualPath) async {
+    final filePath = song.filePath;
+    if (filePath == null || filePath.isEmpty) return;
+
+    final prefs = await SharedPreferences.getInstance();
+    final existingRaw = prefs.getString(_manualLyricsOverridesKey);
+    final map = <String, String>{};
+    if (existingRaw != null && existingRaw.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(existingRaw);
+        if (decoded is Map) {
+          for (final entry in decoded.entries) {
+            if (entry.key is String && entry.value is String) {
+              map[entry.key as String] = entry.value as String;
+            }
+          }
+        }
+      } catch (_) {
+        // Reset malformed preferences payload.
+      }
+    }
+
+    if (manualPath == null || manualPath.isEmpty) {
+      map.remove(filePath);
+    } else {
+      map[filePath] = manualPath;
+    }
+
+    if (map.isEmpty) {
+      await prefs.remove(_manualLyricsOverridesKey);
+    } else {
+      await prefs.setString(_manualLyricsOverridesKey, jsonEncode(map));
+    }
+    _cache.remove(filePath);
+  }
+
+  Future<String> _writeManagedLyricsCopy({
+    required Song song,
+    required String extension,
+    required String content,
+  }) async {
+    final documentsDirectory = await getApplicationDocumentsDirectory();
+    final lyricsDirectory = Directory(
+      '${documentsDirectory.path}${Platform.pathSeparator}$_managedLyricsDirectoryName',
+    );
+    await lyricsDirectory.create(recursive: true);
+
+    final safeStem = _safeLyricsStem(song);
+    final file = File(
+      '${lyricsDirectory.path}${Platform.pathSeparator}$safeStem.$extension',
+    );
+    await file.writeAsString(content);
+    return file.path;
+  }
+
+  String _preferredLyricsExtension(String fileName) {
+    final normalized = fileName.toLowerCase();
+    if (normalized.endsWith('.txt')) return 'txt';
+    if (normalized.endsWith('.xml')) return 'xml';
+    return 'lrc';
+  }
+
+  String _safeLyricsStem(Song song) {
+    final parts = [
+      if (song.artist.trim().isNotEmpty) song.artist.trim(),
+      if (song.title.trim().isNotEmpty) song.title.trim(),
+      song.id,
+    ];
+    final stem = parts.join('_');
+    return stem.replaceAll(RegExp(r'[^a-zA-Z0-9._-]+'), '_');
   }
 }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -323,6 +323,7 @@ class PlayerService {
 
   // Queue State
   final ValueNotifier<List<Song>> queueNotifier = ValueNotifier(const []);
+  final ValueNotifier<List<Song>> upNextNotifier = ValueNotifier(const []);
   final ValueNotifier<int> currentIndexNotifier = ValueNotifier(-1);
   int _nextQueueEntryId = 0;
 
@@ -542,6 +543,10 @@ class PlayerService {
     );
   }
 
+  void _notifyUpNextChanged() {
+    upNextNotifier.value = upNext;
+  }
+
   void _debounceQueueChanged() {
     _queueDebounceTimer?.cancel();
     _queueDebounceTimer = Timer(_queueDebounce, () {
@@ -556,6 +561,7 @@ class PlayerService {
     if (_currentIndex == newIndex) return;
     _currentIndex = newIndex;
     currentIndexNotifier.value = newIndex;
+    _notifyUpNextChanged();
   }
 
   void _replacePlaybackContext(List<Song> songs) {
@@ -569,6 +575,7 @@ class PlayerService {
     _playlistQueueEntryIds
       ..clear()
       ..addAll(List<int?>.filled(songs.length, null));
+    _notifyUpNextChanged();
   }
 
   void syncAlbumArtPaths({
@@ -671,6 +678,7 @@ class PlayerService {
       _playlist.insert(insertIndex + i, entry.song);
       _playlistQueueEntryIds.insert(insertIndex + i, entry.id);
     }
+    _notifyUpNextChanged();
   }
 
   void _consumeQueueEntryAt(int playlistIndex) {
@@ -682,6 +690,7 @@ class PlayerService {
     _playlistQueueEntryIds[playlistIndex] = null;
     _queuedEntries.removeWhere((entry) => entry.id == queueEntryId);
     _notifyQueueChanged();
+    _notifyUpNextChanged();
   }
 
   int _findPlaylistIndexForQueueEntry(int queueEntryId) {
@@ -700,6 +709,7 @@ class PlayerService {
       _removeFromAudioSequence(playlistIndex);
     }
     _notifyQueueChanged();
+    _notifyUpNextChanged();
     if (_usingRustBackend || _audioSourceSequence == null) {
       _debounceQueueChanged();
     }
@@ -3565,6 +3575,7 @@ class PlayerService {
       }
     }
     _notifyQueueChanged();
+    _notifyUpNextChanged();
     if (!_playlist.isNotEmpty ||
         _usingRustBackend ||
         _audioSourceSequence == null) {
@@ -3590,6 +3601,7 @@ class PlayerService {
     }
 
     _notifyQueueChanged();
+    _notifyUpNextChanged();
     await _playInternal(entry.song);
   }
 
@@ -3607,6 +3619,7 @@ class PlayerService {
       }
     }
     _queuedEntries.clear();
+    _notifyUpNextChanged();
     _debounceQueueChanged();
   }
 
@@ -3635,7 +3648,22 @@ class PlayerService {
       }
     }
     _insertQueuedEntriesAfterCurrent();
+    _notifyUpNextChanged();
     _debounceQueueChanged();
+  }
+
+  Future<void> playFromUpNextIndex(int index) {
+    return _enqueuePlaybackRequest(() => _playFromUpNextIndexInternal(index));
+  }
+
+  Future<void> _playFromUpNextIndexInternal(int index) async {
+    final playlistIndex = _currentIndex + 1 + index;
+    if (playlistIndex < 0 || playlistIndex >= _playlist.length) {
+      return;
+    }
+
+    _setCurrentIndex(playlistIndex);
+    await _playSongAtCurrentIndex();
   }
 
   Future<void> moveQueueItemToNext(int index) async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -341,6 +341,8 @@ class PlayerService {
   int _currentIndex = -1;
   bool _isRebuildingPlaylist =
       false; // Flag to prevent unwanted updates during rebuild
+  // ignore: deprecated_member_use
+  just_audio.ConcatenatingAudioSource? _audioSourceSequence;
 
   // Track previous position to detect repeat wrap-around for notification progress
   Duration _lastPosition = Duration.zero;
@@ -557,6 +559,7 @@ class PlayerService {
   }
 
   void _replacePlaybackContext(List<Song> songs) {
+    _audioSourceSequence = null;
     _playlist
       ..clear()
       ..addAll(songs);
@@ -694,8 +697,12 @@ class PlayerService {
       if (playlistIndex < _currentIndex) {
         _setCurrentIndex(_currentIndex - 1);
       }
+      _removeFromAudioSequence(playlistIndex);
     }
-    _debounceQueueChanged();
+    _notifyQueueChanged();
+    if (_usingRustBackend || _audioSourceSequence == null) {
+      _debounceQueueChanged();
+    }
   }
 
   /// Android: current audio session ID from just_audio (for Equalizer attachment).
@@ -1915,8 +1922,12 @@ class PlayerService {
   }
 
   /// Build audio sources for the playlist (gapless playback).
-  Future<List<just_audio.AudioSource>> _buildAudioSources() async {
-    if (_playlist.isEmpty) return const [];
+  // ignore: deprecated_member_use
+  Future<just_audio.ConcatenatingAudioSource> _buildAudioSources() async {
+    if (_playlist.isEmpty) {
+      // ignore: deprecated_member_use
+      return just_audio.ConcatenatingAudioSource(children: const []);
+    }
 
     const batchSize = 12;
     final sources = <just_audio.AudioSource>[];
@@ -1930,7 +1941,9 @@ class PlayerService {
       sources.addAll(resolvedBatch);
     }
 
-    return sources;
+    // ignore: deprecated_member_use
+    _audioSourceSequence = just_audio.ConcatenatingAudioSource(children: sources);
+    return _audioSourceSequence!;
   }
 
   Future<just_audio.AudioSource> _buildAudioSourceForSong(Song song) async {
@@ -1953,6 +1966,19 @@ class PlayerService {
     }
 
     return just_audio.AudioSource.uri(uri);
+  }
+
+  Future<void> _insertIntoAudioSequence(int playlistIndex, Song song) async {
+    if (_usingRustBackend || _audioSourceSequence == null) return;
+    final source = await _buildAudioSourceForSong(song);
+    _audioSourceSequence!.insert(playlistIndex, source);
+  }
+
+  void _removeFromAudioSequence(int playlistIndex) {
+    if (_usingRustBackend || _audioSourceSequence == null) return;
+    if (playlistIndex < _audioSourceSequence!.children.length) {
+      _audioSourceSequence!.removeAt(playlistIndex);
+    }
   }
 
   Future<Uri> _resolvePlaybackUri(Song song) async {
@@ -2503,6 +2529,7 @@ class PlayerService {
     await player.dispose();
     await _deactivateAndroidAudioSession();
     _justAudioPlayer = null;
+    _audioSourceSequence = null;
   }
 
   Future<void> _disposeUsbEngine() async {
@@ -3330,11 +3357,12 @@ class PlayerService {
       final wasPlaying = isPlayingNotifier.value;
       final currentPosition = positionNotifier.value;
 
-      final sources = await _buildAudioSources();
+      final source = await _buildAudioSources();
+      _audioSourceSequence = source;
 
       await _runWithSuppressedSequenceStateUpdates(() async {
-        await player.setAudioSources(
-          sources,
+        await player.setAudioSource(
+          _audioSourceSequence!,
           initialIndex: _currentIndex,
           preload: true,
         );
@@ -3471,8 +3499,17 @@ class PlayerService {
       );
       _playlist.insert(insertIndex, song);
       _playlistQueueEntryIds.insert(insertIndex, entry.id);
+
+      if (!_usingRustBackend && _audioSourceSequence != null) {
+        await _insertIntoAudioSequence(insertIndex, song);
+      }
     }
-    _debounceQueueChanged();
+    _notifyQueueChanged();
+    if (!_playlist.isNotEmpty ||
+        _usingRustBackend ||
+        _audioSourceSequence == null) {
+      _debounceQueueChanged();
+    }
     return index;
   }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -575,7 +575,19 @@ class PlayerService {
     _playlistQueueEntryIds
       ..clear()
       ..addAll(List<int?>.filled(songs.length, null));
+    _queuedEntries.clear();
+    _notifyQueueChanged();
     _notifyUpNextChanged();
+  }
+
+  List<String> _playlistNonQueueIds() {
+    final ids = <String>[];
+    for (var i = 0; i < _playlist.length; i++) {
+      if (_playlistQueueEntryIds[i] == null) {
+        ids.add(_playlist[i].id);
+      }
+    }
+    return ids;
   }
 
   void syncAlbumArtPaths({
@@ -2922,7 +2934,6 @@ class PlayerService {
         if (existingIndex == -1) {
           _replacePlaybackContext([song]);
           _setCurrentIndex(0);
-          _insertQueuedEntriesAfterCurrent();
         } else {
           _setCurrentIndex(existingIndex);
         }
@@ -3012,7 +3023,7 @@ class PlayerService {
       await _lastPlayedService.saveLastPlayed(
         persistedSong.id,
         position ?? positionNotifier.value,
-        playlistSongIds: _playlist.map((s) => s.id).toList(),
+        playlistSongIds: _playlistNonQueueIds(),
         currentIndex: _currentIndex,
         wasPlaying: isPlayingNotifier.value,
       );
@@ -3621,6 +3632,50 @@ class PlayerService {
     _queuedEntries.clear();
     _notifyUpNextChanged();
     _debounceQueueChanged();
+  }
+
+  /// Clears everything after the current song: both manual queue entries
+  /// and all upcoming playlist items.
+  Future<void> clearAllUpcoming() async {
+    // First clear manual queue entries
+    _queuedEntries.clear();
+
+    // Then remove everything after the current index from the playlist
+    if (_playlist.isNotEmpty && _currentIndex >= 0) {
+      final keepCount = (_currentIndex + 1).clamp(0, _playlist.length);
+      if (keepCount < _playlist.length) {
+        _playlist.removeRange(keepCount, _playlist.length);
+        _playlistQueueEntryIds.removeRange(
+            keepCount, _playlistQueueEntryIds.length);
+      }
+    }
+
+    _notifyQueueChanged();
+    _notifyUpNextChanged();
+    _debounceQueueChanged();
+  }
+
+  /// Removes a single song from the up-next list by its upNext-relative index.
+  /// Index 0 is the first song after the currently playing song.
+  Future<void> removeFromUpNext(int upNextIndex) async {
+    final playlistIndex = _currentIndex + 1 + upNextIndex;
+    if (playlistIndex < 0 || playlistIndex >= _playlist.length) return;
+
+    // If this playlist slot belongs to a manual queue entry, remove that too
+    final queueEntryId = _playlistQueueEntryIds[playlistIndex];
+    if (queueEntryId != null) {
+      _queuedEntries.removeWhere((entry) => entry.id == queueEntryId);
+      _notifyQueueChanged();
+    }
+
+    _playlist.removeAt(playlistIndex);
+    _playlistQueueEntryIds.removeAt(playlistIndex);
+    _removeFromAudioSequence(playlistIndex);
+
+    _notifyUpNextChanged();
+    if (_usingRustBackend || _audioSourceSequence == null) {
+      _debounceQueueChanged();
+    }
   }
 
   Future<void> removeFromQueue(int index) async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -3364,10 +3364,10 @@ class PlayerService {
         await player.setAudioSource(
           _audioSourceSequence!,
           initialIndex: _currentIndex,
+          initialPosition: currentPosition,
           preload: true,
         );
 
-        await player.seek(currentPosition, index: _currentIndex);
         await _updateLoopMode();
       });
 
@@ -3406,6 +3406,7 @@ class PlayerService {
     isShuffleNotifier.value = enable;
 
     final current = currentSongNotifier.value;
+    final oldCurrentIndex = _currentIndex;
     final basePlaylist = <Song>[];
     for (var i = 0; i < _playlist.length; i++) {
       if (_playlistQueueEntryIds[i] == null) {
@@ -3435,11 +3436,70 @@ class PlayerService {
     }
     _insertQueuedEntriesAfterCurrent();
 
-    // Rebuild playlist with new order (just_audio only).
     if (!_usingRustBackend) {
-      await _rebuildPlaylist();
+      await _syncPlaylistAfterShuffle(oldCurrentIndex: oldCurrentIndex);
     }
     await _updateNotificationState();
+  }
+
+  Future<void> _syncPlaylistAfterShuffle({required int oldCurrentIndex}) async {
+    final player = _justAudioPlayer;
+    final seq = _audioSourceSequence;
+    if (player == null || seq == null) {
+      await _rebuildPlaylist();
+      return;
+    }
+    if (_playlist.isEmpty || _currentIndex < 0) {
+      await _rebuildPlaylist();
+      return;
+    }
+    final seqLen = seq.children.length;
+    if (oldCurrentIndex < 0 || oldCurrentIndex >= seqLen) {
+      await _rebuildPlaylist();
+      return;
+    }
+    if (seqLen != _playlist.length) {
+      await _rebuildPlaylist();
+      return;
+    }
+
+    _isRebuildingPlaylist = true;
+    try {
+      final newSources = <just_audio.AudioSource>[];
+      for (final song in _playlist) {
+        newSources.add(await _buildAudioSourceForSong(song));
+      }
+
+      await _runWithSuppressedSequenceStateUpdates(() async {
+        final int newIdx = _currentIndex;
+
+        if (oldCurrentIndex > 0) {
+          seq.removeRange(0, oldCurrentIndex);
+        }
+        final afterCurrent = seq.children.length - 1;
+        if (afterCurrent > 0) {
+          seq.removeRange(1, seq.children.length);
+        }
+
+        if (newIdx > 0) {
+          seq.insertAll(0, newSources.sublist(0, newIdx));
+        }
+        if (newIdx + 1 < newSources.length) {
+          seq.insertAll(
+            newIdx + 1,
+            newSources.sublist(newIdx + 1),
+          );
+        }
+
+        await _updateLoopMode();
+
+        // Give ExoPlayer's queued index-change events time to drain while
+        // suppression is still active so they don't flash the wrong song.
+        await Future.delayed(const Duration(milliseconds: 50));
+      });
+    } finally {
+      _isRebuildingPlaylist = false;
+    }
   }
 
   Future<void> toggleLoopMode() async {

--- a/test_file_picker.dart
+++ b/test_file_picker.dart
@@ -1,0 +1,5 @@
+import 'package:file_picker/file_picker.dart';
+
+void main() async {
+  await FilePicker.platform.saveFile(fileName: 'test.txt');
+}


### PR DESCRIPTION
### **Summary**
- **just_audio migration**: Migrated to `setAudioSource` API with `ConcatenatingAudioSource` for efficient queue updates
- **Lyrics editor**: Added `LyricsEditorBottomSheet` with sync modes, manual import/save, and LRC utilities
- **Multi-select**: Added multi-select mode to songs screen and queue screen with bulk actions for queue, favorite, remove
- **Queue refactor**: Refactored queue system with independent up-next state, clear/populate/sync operations
- **Folders**: Added folder grid pagination with lazy loading and enhanced detail screen
- **Export**: Added CSV/TXT export service for listening recap data
- **Onboarding**: Refactored onboarding backdrop to animated orb system with page interpolation
- **Navigation**: Added double back press to exit app, removed auto-full-player navigation
- **Lyrics UX**: Added lyrics panel controls for create/edit/import/reset and play single song without queue

---

### **Changes**

#### **just_audio API Migration**
- Replaced deprecated `setAudioSources`/`setAudioSourcesList` with `setAudioSource` using a single `ConcatenatingAudioSource`
- Added `_audioSourceSequence` field for incremental insert/remove on playlist changes
- Added `_insertIntoAudioSequence` and `_removeFromAudioSequence` for efficient queue updates
- Sync audio source sequence in-place after shuffle instead of full rebuild
- Eliminated redundant seek calls by passing `initialPosition` directly

#### **Queue System Refactor**
- Replaced computed `upNext` getter with dedicated `upNext` field and `ValueNotifier`
- Added `playFromUpNextIndex` method and notify upNext changes on all queue mutations
- Refactored queue screen into "Up next" and "Manual queue" sections with dedicated providers
- Added `clearAllUpcoming` and `removeFromUpNext` to player service
- Switched from `queueNotifier` to `upNextNotifier` in full player and mini player

#### **Multi-Select Mode**
- Added multi-select mode to songs screen with queue/favorite bulk actions
- Added multiselect support to `OrbitScroll` for visual selection state
- Added optional `onSelect` callback to `SongActionsBottomSheet`
- Added multi-select and bulk remove to queue screen with selection header: count, select-all, delete
- Added `AnimatedSwitcher` with fade transition to songs screen header

#### **Lyrics Editor**
- Added `LyricsEditorBottomSheet` with simple and advanced sync modes
- Added playback assist controls, timestamp stamping/shifting, and LRC save support
- Added manual lyrics import/save/overrides and LRC utilities to `LyricsService`
- Added `rawContent` field, `parseLyricsText`, `parseTimestamp`, `formatTimestamp`, `buildLrcContent` helpers
- Support manual lyrics path overrides via `SharedPreferences`
- Added manual lyrics import/edit/reset controls to lyrics panel

#### **Folder Grid**
- Added folder grid pagination with lazy loading
- Enhanced folder detail screen with metadata stats
- Major songs screen restructure for pagination support

#### **Export**
- Added CSV and TXT export service for listening recap data
- Android-only file export via platform channel
- Integrated export into listening recap screen

#### **Onboarding**
- Converted backdrop from `StatelessWidget` to `StatefulWidget` with breathing orb animations
- Added per-page orb configurations with interpolation for position, size, and color
- Added subtle breathing animation with phase-offset per orb

#### **UI & Navigation**
- Added double back press to exit app using `PopScope`
- Removed automatic navigation to full player when song changes
- Added bounce and fade animation to lyrics mode swipe arrow indicator
- Changed song tap behavior to play single song without populating queue

---

### **Files Changed**

| Category | Files |
| --- | --- |
| **Services** | `lib/services/android_audio_engine.dart`<br>`lib/services/player_service.dart`<br>`lib/services/csv_export_service.dart`<br>`lib/services/lyrics_service.dart` |
| **Features - Queue** | `lib/features/queue/screens/queue_screen.dart` |
| **Features - Songs** | `lib/features/songs/screens/songs_screen.dart`<br>`lib/features/songs/widgets/song_card.dart`<br>`lib/features/songs/widgets/orbit_scroll.dart`<br>`lib/features/songs/widgets/song_actions_bottom_sheet.dart` |
| **Features - Player** | `lib/features/player/screens/full_player_screen.dart`<br>`lib/features/player/widgets/mini_player.dart`<br>`lib/features/player/widgets/lyrics_editor_bottom_sheet.dart` |
| **Features - Recap** | `lib/features/recap/screens/listening_recap_screen.dart` |
| **Features - Onboarding** | `lib/features/onboarding/screens/onboarding_screen.dart` |
| **Providers** | `lib/providers/player_provider.dart` |
| **App** | `lib/app/app.dart` |
| **Tests** | `test_file_picker.dart` |