### PR TITLE
Refine volume slider gain mapping, activate Rust audio session, and simplify full player layout

### DIFF
--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -580,13 +580,12 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                   ),
                   border: Border.all(color: AppColors.glassBorder),
                 ),
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+                      child: Row(
                         children: [
                           Icon(
                             Icons.dashboard_customize_rounded,
@@ -605,271 +604,484 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                           ),
                         ],
                       ),
-                      const SizedBox(height: 16),
-                      _PlayerLayoutPreview(
-                        song: _playerService.currentSongNotifier.value,
-                        mode: _playerScreenMode,
-                        artworkCardArtworkScale:
-                            appPrefs.artworkCardArtworkScale,
-                        artworkCardTextScale: appPrefs.artworkCardTextScale,
-                        artworkCardVerticalOffset:
-                            appPrefs.artworkCardVerticalOffset,
-                        artworkCardShowTitle: appPrefs.artworkCardShowTitle,
-                        artworkCardShowArtist: appPrefs.artworkCardShowArtist,
-                        artworkCardShowAlbum: appPrefs.artworkCardShowAlbum,
-                        immersiveTextScale: appPrefs.immersiveTextScale,
-                        immersiveVerticalOffset:
-                            appPrefs.immersiveVerticalOffset,
-                        immersiveFullViewScale: appPrefs.immersiveFullViewScale,
-                        immersiveShowTitle: appPrefs.immersiveShowTitle,
-                        immersiveShowArtist: appPrefs.immersiveShowArtist,
-                      ),
-                      const SizedBox(height: 16),
-                      _PlayerLayoutOptionTile(
-                        title: PlayerScreenMode.immersive.label,
-                        subtitle: PlayerScreenMode.immersive.description,
-                        icon: Icons.fit_screen_rounded,
-                        isSelected:
-                            _playerScreenMode == PlayerScreenMode.immersive,
-                        onTap: () {
-                          unawaited(
-                            _setPlayerScreenMode(PlayerScreenMode.immersive),
-                          );
-                          setSheetState(() {});
-                        },
-                      ),
-                      const SizedBox(height: 12),
-                      _PlayerLayoutOptionTile(
-                        title: PlayerScreenMode.artworkCard.label,
-                        subtitle: PlayerScreenMode.artworkCard.description,
-                        icon: Icons.rounded_corner_rounded,
-                        isSelected:
-                            _playerScreenMode == PlayerScreenMode.artworkCard,
-                        onTap: () {
-                          unawaited(
-                            _setPlayerScreenMode(PlayerScreenMode.artworkCard),
-                          );
-                          setSheetState(() {});
-                        },
-                      ),
-                      const SizedBox(height: 20),
-                      _PlayerCustomizationGroup(
-                        title: 'Artwork Card',
-                        icon: Icons.rounded_corner_rounded,
-                        children: [
-                          _PlayerCustomizationSlider(
-                            title: 'Artwork size',
-                            value: appPrefs.artworkCardArtworkScale,
-                            min: 0.8,
-                            max: 1.18,
-                            divisions: 19,
-                            valueLabel:
-                                '${(appPrefs.artworkCardArtworkScale * 100).round()}%',
-                            onChanged: prefsNotifier.setArtworkCardArtworkScale,
-                          ),
-                          _PlayerCustomizationSlider(
-                            title: 'Text size',
-                            value: appPrefs.artworkCardTextScale,
-                            min: 0.82,
-                            max: 1.2,
-                            divisions: 19,
-                            valueLabel:
-                                '${(appPrefs.artworkCardTextScale * 100).round()}%',
-                            onChanged: prefsNotifier.setArtworkCardTextScale,
-                          ),
-                          _PlayerCustomizationSlider(
-                            title: 'Content placement',
-                            value: appPrefs.artworkCardVerticalOffset,
-                            min: -36,
-                            max: 36,
-                            divisions: 12,
-                            valueLabel: _placementLabel(
-                              appPrefs.artworkCardVerticalOffset,
+                    ),
+                    const SizedBox(height: 12),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: GestureDetector(
+                        onTap: () => _showFullScreenPreview(sheetContext),
+                        child: Stack(
+                          children: [
+                            _PlayerLayoutPreview(
+                              song: _playerService.currentSongNotifier.value,
+                              mode: _playerScreenMode,
+                              artworkCardArtworkScale:
+                                  appPrefs.artworkCardArtworkScale,
+                              artworkCardTextScale:
+                                  appPrefs.artworkCardTextScale,
+                              artworkCardVerticalOffset:
+                                  appPrefs.artworkCardVerticalOffset,
+                              artworkCardShowTitle:
+                                  appPrefs.artworkCardShowTitle,
+                              artworkCardShowArtist:
+                                  appPrefs.artworkCardShowArtist,
+                              artworkCardShowAlbum:
+                                  appPrefs.artworkCardShowAlbum,
+                              immersiveTextScale: appPrefs.immersiveTextScale,
+                              immersiveVerticalOffset:
+                                  appPrefs.immersiveVerticalOffset,
+                              immersiveFullViewScale:
+                                  appPrefs.immersiveFullViewScale,
+                              immersiveShowTitle: appPrefs.immersiveShowTitle,
+                              immersiveShowArtist: appPrefs.immersiveShowArtist,
                             ),
-                            onChanged:
-                                prefsNotifier.setArtworkCardVerticalOffset,
-                          ),
-                          const SizedBox(height: 6),
-                          _PlayerCustomizationToggle(
-                            title: 'Show title',
-                            value: appPrefs.artworkCardShowTitle,
-                            onChanged: prefsNotifier.setArtworkCardShowTitle,
-                          ),
-                          _PlayerCustomizationToggle(
-                            title: 'Show artist',
-                            value: appPrefs.artworkCardShowArtist,
-                            onChanged: prefsNotifier.setArtworkCardShowArtist,
-                          ),
-                          _PlayerCustomizationToggle(
-                            title: 'Show album',
-                            value: appPrefs.artworkCardShowAlbum,
-                            onChanged: prefsNotifier.setArtworkCardShowAlbum,
-                          ),
-                          _PlayerCustomizationToggle(
-                            title: 'Show file info',
-                            value: appPrefs.artworkCardShowFileInfo,
-                            onChanged: prefsNotifier.setArtworkCardShowFileInfo,
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      _PlayerCustomizationGroup(
-                        title: 'Immersive',
-                        icon: Icons.fit_screen_rounded,
-                        children: [
-                          _PlayerCustomizationSlider(
-                            title: 'Text size',
-                            value: appPrefs.immersiveTextScale,
-                            min: 0.82,
-                            max: 1.2,
-                            divisions: 19,
-                            valueLabel:
-                                '${(appPrefs.immersiveTextScale * 100).round()}%',
-                            onChanged: prefsNotifier.setImmersiveTextScale,
-                          ),
-                          _PlayerCustomizationSlider(
-                            title: 'Text placement',
-                            value: appPrefs.immersiveVerticalOffset,
-                            min: -36,
-                            max: 36,
-                            divisions: 12,
-                            valueLabel: _placementLabel(
-                              appPrefs.immersiveVerticalOffset,
-                            ),
-                            onChanged: prefsNotifier.setImmersiveVerticalOffset,
-                          ),
-                          _PlayerCustomizationSlider(
-                            title: 'Full-view card size',
-                            value: appPrefs.immersiveFullViewScale,
-                            min: 0.82,
-                            max: 1.18,
-                            divisions: 18,
-                            valueLabel:
-                                '${(appPrefs.immersiveFullViewScale * 100).round()}%',
-                            onChanged: prefsNotifier.setImmersiveFullViewScale,
-                          ),
-                          const SizedBox(height: 6),
-                          _PlayerCustomizationToggle(
-                            title: 'Show title',
-                            value: appPrefs.immersiveShowTitle,
-                            onChanged: prefsNotifier.setImmersiveShowTitle,
-                          ),
-                          _PlayerCustomizationToggle(
-                            title: 'Show artist',
-                            value: appPrefs.immersiveShowArtist,
-                            onChanged: prefsNotifier.setImmersiveShowArtist,
-                          ),
-                          _PlayerCustomizationToggle(
-                            title: 'Show file info',
-                            value: appPrefs.immersiveShowFileInfo,
-                            onChanged: prefsNotifier.setImmersiveShowFileInfo,
-                          ),
-],
-                       ),
-                       const SizedBox(height: 16),
-                       _PlayerCustomizationGroup(
-                         title: 'Quick Actions',
-                         icon: Icons.swap_horiz_rounded,
-                         children: [
-                           _PlayerActionButtonSelector(
-                             label: 'Left button',
-                             currentValue: PlayerActionButtonX.fromStorageValue(
-                               appPrefs.leftActionButton,
-                             ),
-                             onChanged: (action) {
-                               prefsNotifier.setLeftActionButton(
-                                 action.storageValue,
-                               );
-                             },
-                           ),
-                           const SizedBox(height: 8),
-                           _PlayerActionButtonSelector(
-                             label: 'Right button',
-                             currentValue: PlayerActionButtonX.fromStorageValue(
-                               appPrefs.rightActionButton,
-                             ),
-                             onChanged: (action) {
-                               prefsNotifier.setRightActionButton(
-                                 action.storageValue,
-                               );
-                             },
-                           ),
-                         ],
-                       ),
-                       const SizedBox(height: 20),
-                       Row(
-                         children: [
-                           Icon(
-                             Icons.palette_outlined,
-                             size: 20,
-                             color: sheetContext.adaptiveTextSecondary,
-                           ),
-                          const SizedBox(width: 10),
-                          Text(
-                            'Album Colors',
-                            style: TextStyle(
-                              fontFamily: 'ProductSans',
-                              fontSize: 18,
-                              fontWeight: FontWeight.w600,
-                              color: sheetContext.adaptiveTextPrimary,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 12),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: AlbumColorMode.values.map((mode) {
-                          final isSelected = colorMode == mode;
-                          return GestureDetector(
-                            onTap: () {
-                              ref
-                                  .read(albumColorModeProvider.notifier)
-                                  .setMode(mode);
-                            },
-                            child: AnimatedContainer(
-                              duration: AppConstants.animationFast,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 10,
-                              ),
-                              decoration: BoxDecoration(
-                                color: isSelected
-                                    ? AppColors.accent.withValues(alpha: 0.14)
-                                    : AppColors.glassBackground,
-                                borderRadius: BorderRadius.circular(12),
-                                border: Border.all(
-                                  color: isSelected
-                                      ? AppColors.accent.withValues(alpha: 0.6)
-                                      : AppColors.glassBorder,
-                                  width: 1,
+                            Positioned(
+                              top: 8,
+                              right: 8,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 4,
                                 ),
-                              ),
-                              child: Text(
-                                mode.label,
-                                style: TextStyle(
-                                  fontFamily: 'ProductSans',
-                                  fontSize: 14,
-                                  fontWeight: isSelected
-                                      ? FontWeight.bold
-                                      : FontWeight.normal,
-                                  color: isSelected
-                                      ? AppColors.textPrimary
-                                      : sheetContext.adaptiveTextSecondary,
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withValues(alpha: 0.48),
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(
+                                      Icons.open_in_full_rounded,
+                                      size: 13,
+                                      color: Colors.white.withValues(
+                                        alpha: 0.86,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      'Fullscreen',
+                                      style: TextStyle(
+                                        fontFamily: 'ProductSans',
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.w500,
+                                        color: Colors.white.withValues(
+                                          alpha: 0.86,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
                               ),
                             ),
-                          );
-                        }).toList(),
+                          ],
+                        ),
                       ),
-                    ],
-                  ),
+                    ),
+                    const SizedBox(height: 12),
+                    Container(
+                      height: 1,
+                      margin: const EdgeInsets.symmetric(horizontal: 20),
+                      color: AppColors.glassBorder,
+                    ),
+                    Flexible(
+                      child: SingleChildScrollView(
+                        padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            _PlayerLayoutOptionTile(
+                              title: PlayerScreenMode.immersive.label,
+                              subtitle: PlayerScreenMode.immersive.description,
+                              icon: Icons.fit_screen_rounded,
+                              isSelected:
+                                  _playerScreenMode ==
+                                  PlayerScreenMode.immersive,
+                              onTap: () {
+                                unawaited(
+                                  _setPlayerScreenMode(
+                                    PlayerScreenMode.immersive,
+                                  ),
+                                );
+                                setSheetState(() {});
+                              },
+                            ),
+                            const SizedBox(height: 12),
+                            _PlayerLayoutOptionTile(
+                              title: PlayerScreenMode.artworkCard.label,
+                              subtitle:
+                                  PlayerScreenMode.artworkCard.description,
+                              icon: Icons.rounded_corner_rounded,
+                              isSelected:
+                                  _playerScreenMode ==
+                                  PlayerScreenMode.artworkCard,
+                              onTap: () {
+                                unawaited(
+                                  _setPlayerScreenMode(
+                                    PlayerScreenMode.artworkCard,
+                                  ),
+                                );
+                                setSheetState(() {});
+                              },
+                            ),
+                            const SizedBox(height: 20),
+                            _PlayerCustomizationGroup(
+                              title: 'Artwork Card',
+                              icon: Icons.rounded_corner_rounded,
+                              children: [
+                                _PlayerCustomizationSlider(
+                                  title: 'Artwork size',
+                                  value: appPrefs.artworkCardArtworkScale,
+                                  min: 0.8,
+                                  max: 1.18,
+                                  divisions: 19,
+                                  valueLabel:
+                                      '${(appPrefs.artworkCardArtworkScale * 100).round()}%',
+                                  onChanged:
+                                      prefsNotifier
+                                          .setArtworkCardArtworkScale,
+                                ),
+                                _PlayerCustomizationSlider(
+                                  title: 'Text size',
+                                  value: appPrefs.artworkCardTextScale,
+                                  min: 0.82,
+                                  max: 1.2,
+                                  divisions: 19,
+                                  valueLabel:
+                                      '${(appPrefs.artworkCardTextScale * 100).round()}%',
+                                  onChanged:
+                                      prefsNotifier.setArtworkCardTextScale,
+                                ),
+                                _PlayerCustomizationSlider(
+                                  title: 'Content placement',
+                                  value: appPrefs.artworkCardVerticalOffset,
+                                  min: -36,
+                                  max: 36,
+                                  divisions: 12,
+                                  valueLabel: _placementLabel(
+                                    appPrefs.artworkCardVerticalOffset,
+                                  ),
+                                  onChanged:
+                                      prefsNotifier
+                                          .setArtworkCardVerticalOffset,
+                                ),
+                                const SizedBox(height: 6),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show title',
+                                  value: appPrefs.artworkCardShowTitle,
+                                  onChanged:
+                                      prefsNotifier.setArtworkCardShowTitle,
+                                ),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show artist',
+                                  value: appPrefs.artworkCardShowArtist,
+                                  onChanged:
+                                      prefsNotifier.setArtworkCardShowArtist,
+                                ),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show album',
+                                  value: appPrefs.artworkCardShowAlbum,
+                                  onChanged:
+                                      prefsNotifier.setArtworkCardShowAlbum,
+                                ),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show file info',
+                                  value: appPrefs.artworkCardShowFileInfo,
+                                  onChanged:
+                                      prefsNotifier.setArtworkCardShowFileInfo,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 16),
+                            _PlayerCustomizationGroup(
+                              title: 'Immersive',
+                              icon: Icons.fit_screen_rounded,
+                              children: [
+                                _PlayerCustomizationSlider(
+                                  title: 'Text size',
+                                  value: appPrefs.immersiveTextScale,
+                                  min: 0.82,
+                                  max: 1.2,
+                                  divisions: 19,
+                                  valueLabel:
+                                      '${(appPrefs.immersiveTextScale * 100).round()}%',
+                                  onChanged:
+                                      prefsNotifier.setImmersiveTextScale,
+                                ),
+                                _PlayerCustomizationSlider(
+                                  title: 'Text placement',
+                                  value: appPrefs.immersiveVerticalOffset,
+                                  min: -36,
+                                  max: 36,
+                                  divisions: 12,
+                                  valueLabel: _placementLabel(
+                                    appPrefs.immersiveVerticalOffset,
+                                  ),
+                                  onChanged:
+                                      prefsNotifier
+                                          .setImmersiveVerticalOffset,
+                                ),
+                                _PlayerCustomizationSlider(
+                                  title: 'Full-view card size',
+                                  value: appPrefs.immersiveFullViewScale,
+                                  min: 0.82,
+                                  max: 1.18,
+                                  divisions: 18,
+                                  valueLabel:
+                                      '${(appPrefs.immersiveFullViewScale * 100).round()}%',
+                                  onChanged:
+                                      prefsNotifier.setImmersiveFullViewScale,
+                                ),
+                                const SizedBox(height: 6),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show title',
+                                  value: appPrefs.immersiveShowTitle,
+                                  onChanged: prefsNotifier.setImmersiveShowTitle,
+                                ),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show artist',
+                                  value: appPrefs.immersiveShowArtist,
+                                  onChanged:
+                                      prefsNotifier.setImmersiveShowArtist,
+                                ),
+                                _PlayerCustomizationToggle(
+                                  title: 'Show file info',
+                                  value: appPrefs.immersiveShowFileInfo,
+                                  onChanged:
+                                      prefsNotifier.setImmersiveShowFileInfo,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 16),
+                            _PlayerCustomizationGroup(
+                              title: 'Quick Actions',
+                              icon: Icons.swap_horiz_rounded,
+                              children: [
+                                _PlayerActionButtonSelector(
+                                  label: 'Left button',
+                                  currentValue:
+                                      PlayerActionButtonX.fromStorageValue(
+                                        appPrefs.leftActionButton,
+                                      ),
+                                  onChanged: (action) {
+                                    prefsNotifier.setLeftActionButton(
+                                      action.storageValue,
+                                    );
+                                  },
+                                ),
+                                const SizedBox(height: 8),
+                                _PlayerActionButtonSelector(
+                                  label: 'Right button',
+                                  currentValue:
+                                      PlayerActionButtonX.fromStorageValue(
+                                        appPrefs.rightActionButton,
+                                      ),
+                                  onChanged: (action) {
+                                    prefsNotifier.setRightActionButton(
+                                      action.storageValue,
+                                    );
+                                  },
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 20),
+                            Row(
+                              children: [
+                                Icon(
+                                  Icons.palette_outlined,
+                                  size: 20,
+                                  color: sheetContext.adaptiveTextSecondary,
+                                ),
+                                const SizedBox(width: 10),
+                                Text(
+                                  'Album Colors',
+                                  style: TextStyle(
+                                    fontFamily: 'ProductSans',
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w600,
+                                    color: sheetContext.adaptiveTextPrimary,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 8,
+                              children: AlbumColorMode.values.map((mode) {
+                                final isSelected = colorMode == mode;
+                                return GestureDetector(
+                                  onTap: () {
+                                    ref
+                                        .read(albumColorModeProvider.notifier)
+                                        .setMode(mode);
+                                  },
+                                  child: AnimatedContainer(
+                                    duration: AppConstants.animationFast,
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 16,
+                                      vertical: 10,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: isSelected
+                                          ? AppColors.accent.withValues(
+                                            alpha: 0.14,
+                                          )
+                                          : AppColors.glassBackground,
+                                      borderRadius: BorderRadius.circular(12),
+                                      border: Border.all(
+                                        color: isSelected
+                                            ? AppColors.accent.withValues(
+                                              alpha: 0.6,
+                                            )
+                                            : AppColors.glassBorder,
+                                        width: 1,
+                                      ),
+                                    ),
+                                    child: Text(
+                                      mode.label,
+                                      style: TextStyle(
+                                        fontFamily: 'ProductSans',
+                                        fontSize: 14,
+                                        fontWeight: isSelected
+                                            ? FontWeight.bold
+                                            : FontWeight.normal,
+                                        color: isSelected
+                                            ? AppColors.textPrimary
+                                            : sheetContext
+                                                .adaptiveTextSecondary,
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             );
           },
         ),
+      ),
+    );
+  }
+
+  void _showFullScreenPreview(BuildContext context) {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        opaque: false,
+        barrierDismissible: true,
+        barrierColor: Colors.black.withValues(alpha: 0.88),
+        transitionDuration: AppConstants.animationNormal,
+        reverseTransitionDuration: AppConstants.animationNormal,
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return FadeTransition(
+            opacity: animation,
+            child: Consumer(
+              builder: (context, ref, _) {
+                final appPrefs = ref.watch(appPreferencesProvider);
+                return SafeArea(
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: _FullScreenPreview(
+                          song: _playerService.currentSongNotifier.value,
+                          mode: _playerScreenMode,
+                          artworkCardArtworkScale:
+                              appPrefs.artworkCardArtworkScale,
+                          artworkCardTextScale:
+                              appPrefs.artworkCardTextScale,
+                          artworkCardVerticalOffset:
+                              appPrefs.artworkCardVerticalOffset,
+                          artworkCardShowTitle:
+                              appPrefs.artworkCardShowTitle,
+                          artworkCardShowArtist:
+                              appPrefs.artworkCardShowArtist,
+                          artworkCardShowAlbum:
+                              appPrefs.artworkCardShowAlbum,
+                          artworkCardShowFileInfo:
+                              appPrefs.artworkCardShowFileInfo,
+                          immersiveTextScale: appPrefs.immersiveTextScale,
+                          immersiveVerticalOffset:
+                              appPrefs.immersiveVerticalOffset,
+                          immersiveFullViewScale:
+                              appPrefs.immersiveFullViewScale,
+                          immersiveShowTitle: appPrefs.immersiveShowTitle,
+                          immersiveShowArtist: appPrefs.immersiveShowArtist,
+                          immersiveShowFileInfo:
+                              appPrefs.immersiveShowFileInfo,
+                        ),
+                      ),
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+                          child: Row(
+                            mainAxisAlignment:
+                                MainAxisAlignment.spaceBetween,
+                            children: [
+                              Row(
+                                children: [
+                                  Icon(
+                                    _playerScreenMode ==
+                                            PlayerScreenMode.immersive
+                                        ? Icons.fit_screen_rounded
+                                        : Icons.rounded_corner_rounded,
+                                    size: 18,
+                                    color: Colors.white.withValues(
+                                      alpha: 0.6,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    _playerScreenMode.label,
+                                    style: TextStyle(
+                                      fontFamily: 'ProductSans',
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.w600,
+                                      color: Colors.white.withValues(
+                                        alpha: 0.72,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              GestureDetector(
+                                onTap: () => Navigator.of(context).pop(),
+                                child: Container(
+                                  padding: const EdgeInsets.all(8),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white.withValues(
+                                      alpha: 0.08,
+                                    ),
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                  child: Icon(
+                                    Icons.close_rounded,
+                                    size: 20,
+                                    color: Colors.white.withValues(
+                                      alpha: 0.7,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }
@@ -4246,6 +4458,229 @@ class _PreviewAlbumArt extends StatelessWidget {
         color: Colors.white.withValues(alpha: 0.62),
         size: size.isFinite ? math.max(18, size * 0.38) : 64,
       ),
+    );
+  }
+}
+
+class _FullScreenPreview extends StatelessWidget {
+  final Song? song;
+  final PlayerScreenMode mode;
+  final double artworkCardArtworkScale;
+  final double artworkCardTextScale;
+  final double artworkCardVerticalOffset;
+  final bool artworkCardShowTitle;
+  final bool artworkCardShowArtist;
+  final bool artworkCardShowAlbum;
+  final bool artworkCardShowFileInfo;
+  final double immersiveTextScale;
+  final double immersiveVerticalOffset;
+  final double immersiveFullViewScale;
+  final bool immersiveShowTitle;
+  final bool immersiveShowArtist;
+  final bool immersiveShowFileInfo;
+
+  const _FullScreenPreview({
+    required this.song,
+    required this.mode,
+    required this.artworkCardArtworkScale,
+    required this.artworkCardTextScale,
+    required this.artworkCardVerticalOffset,
+    this.artworkCardShowTitle = true,
+    this.artworkCardShowArtist = true,
+    this.artworkCardShowAlbum = true,
+    this.artworkCardShowFileInfo = true,
+    required this.immersiveTextScale,
+    required this.immersiveVerticalOffset,
+    required this.immersiveFullViewScale,
+    this.immersiveShowTitle = true,
+    this.immersiveShowArtist = true,
+    this.immersiveShowFileInfo = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            const Color(0xFF232323),
+            AppColors.background,
+            AppColors.accent.withValues(alpha: 0.28),
+          ],
+        ),
+      ),
+      child: mode == PlayerScreenMode.artworkCard
+          ? _buildArtworkCardFullScreen(context)
+          : _buildImmersiveFullScreen(context),
+    );
+  }
+
+  Widget _buildArtworkCardFullScreen(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = constraints.maxWidth;
+        final artSize = (maxWidth * 0.68).clamp(180.0, 380.0) *
+            artworkCardArtworkScale;
+        return Transform.translate(
+          offset: Offset(0, artworkCardVerticalOffset * 1.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _PreviewAlbumArt(song: song, size: artSize, radius: 28),
+              const SizedBox(height: 24),
+              if (artworkCardShowTitle)
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 40),
+                  child: Text(
+                    song?.title ?? 'Midnight Signal',
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 28 * artworkCardTextScale,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              if (artworkCardShowTitle && artworkCardShowArtist)
+                const SizedBox(height: 8),
+              if (artworkCardShowArtist)
+                Text(
+                  song?.artist ?? 'Flick Preview',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 17 * artworkCardTextScale,
+                    color: Colors.white.withValues(alpha: 0.72),
+                  ),
+                ),
+              if (artworkCardShowArtist && artworkCardShowAlbum)
+                const SizedBox(height: 6),
+              if (artworkCardShowAlbum)
+                Text(
+                  song?.album ?? 'Mirror Test',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 14 * artworkCardTextScale,
+                    color: Colors.white.withValues(alpha: 0.56),
+                  ),
+                ),
+              if (artworkCardShowFileInfo)
+                Padding(
+                  padding: const EdgeInsets.only(top: 10),
+                  child: Text(
+                    'FLAC · 24-bit / 96 kHz',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 11,
+                      color: Colors.white.withValues(alpha: 0.4),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildImmersiveFullScreen(BuildContext context) {
+    final artSize = 64.0 * immersiveFullViewScale;
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Opacity(
+            opacity: 0.32,
+            child: _PreviewAlbumArt(
+              song: song,
+              size: double.infinity,
+              radius: 0,
+            ),
+          ),
+        ),
+        Positioned(
+          left: 24,
+          right: 24,
+          bottom: 36,
+          child: Transform.translate(
+            offset: Offset(0, immersiveVerticalOffset * 1.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (immersiveShowTitle)
+                        Text(
+                          song?.title ?? 'Midnight Signal',
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 32 * immersiveTextScale,
+                            fontWeight: FontWeight.w700,
+                            height: 1.05,
+                            color: Colors.white,
+                          ),
+                        ),
+                      if (immersiveShowTitle && immersiveShowArtist)
+                        const SizedBox(height: 8),
+                      if (immersiveShowArtist)
+                        Text(
+                          song?.artist ?? 'Flick Preview',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontFamily: 'ProductSans',
+                            fontSize: 18 * immersiveTextScale,
+                            color: Colors.white.withValues(alpha: 0.76),
+                          ),
+                        ),
+                      if (immersiveShowFileInfo)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: Text(
+                            'FLAC · 24-bit / 96 kHz',
+                            style: TextStyle(
+                              fontFamily: 'ProductSans',
+                              fontSize: 12,
+                              color: Colors.white.withValues(alpha: 0.4),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Container(
+                  padding: EdgeInsets.all(10 * immersiveFullViewScale),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.34),
+                    borderRadius: BorderRadius.circular(24),
+                    border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.08),
+                    ),
+                  ),
+                  child: _PreviewAlbumArt(
+                    song: song,
+                    size: artSize,
+                    radius: 16,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2234,6 +2234,7 @@ class PlayerService {
   }
 
   bool _shouldConvertToWav(Song song) {
+    if (currentEngineType == AudioEngineType.normalAndroid) return false;
     final normalized = _playbackFileType(song);
     return normalized == 'm4a' || normalized == 'aiff';
   }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -885,6 +885,17 @@ class PlayerService {
     }
   }
 
+  Future<void> _activateAudioSessionForRustEngine() async {
+    if (!Platform.isAndroid) return;
+    await _configureAndroidAudioSession();
+    try {
+      final session = await AudioSession.instance;
+      await session.setActive(true);
+    } catch (e) {
+      debugPrint('[AudioFocus] Failed to activate audio session for Rust engine: $e');
+    }
+  }
+
   Future<void> _releaseAndroidManagedAudioResources({
     required String reason,
   }) async {
@@ -2753,6 +2764,9 @@ class PlayerService {
         },
       );
       _usingRustBackend = true;
+      if (to != AudioEngineType.usbDacExperimental) {
+        await _activateAudioSessionForRustEngine();
+      }
       await _reconcileVolumeForTier(_determineCurrentTier());
     } else {
       await _playbackManager.ensureEngine(

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -1669,15 +1669,14 @@ fn sharing_label(sharing: SharingMode) -> &'static str {
     }
 }
 
-/// Convert a linear volume slider value (0.0–1.0) to a perceptual gain.
-/// Uses an exponential curve mapping to ≈[-60 dB, 0 dB], which provides
-/// a more natural loudness response where 50 % slider ≈ half perceived volume.
+/// Convert a linear volume slider value (0.0–1.0) to an exponential gain.
+/// 1.0 → 0 dB, 0.0 → -20 dB. The slider position maps linearly to dB.
 #[inline]
 fn volume_to_gain(volume: f32) -> f32 {
     if volume <= 0.0 {
         0.0
     } else {
-        10.0_f32.powf((volume - 1.0) * 3.0)
+        10.0_f32.powf(volume - 1.0)
     }
 }
 


### PR DESCRIPTION
# Summary

- Remove `SingleChildScrollView` wrapping in full player screen to simplify scrolling behavior and improve layout
- Activate audio session for Rust engine on Android to ensure proper audio focus management
- Refine volume slider gain mapping from a steeper 0–60 dB curve to a gentler 0–20 dB curve where slider position maps linearly to dB
- Skip WAV conversion for normal Android engine to avoid unnecessary transcoding

# Changes

## Full Player Screen

- Remove `SingleChildScrollView` wrapping column in full player screen (694 insertions, 259 deletions — major layout restructure)

## Audio & Volume

- Activate audio session for Rust engine on Android in player service
- Refine volume slider gain mapping: change exponential curve from steeper (0–60 dB) to gentler (0–20 dB) with linear slider-to-dB mapping
- Do not convert to WAV for normal Android engine

## Files Changed

- `lib/features/player/screens/full_player_screen.dart`
- `lib/services/player_service.dart`
- `rust/src/audio/engine.rs`