### PR TITLE
Add milestone tracking system, support donation screen, and animated welcome card

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -11,6 +11,7 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/features/songs/screens/songs_screen.dart';
 import 'package:flick/features/menu/screens/menu_screen.dart';
 import 'package:flick/features/settings/screens/settings_screen.dart';
+import 'package:flick/features/settings/screens/support_flick_screen.dart';
 import 'package:flick/features/albums/screens/albums_screen.dart';
 import 'package:flick/features/artists/screens/artists_screen.dart';
 import 'package:flick/features/folders/screens/folders_screen.dart';
@@ -25,9 +26,11 @@ import 'package:flick/widgets/navigation/flick_nav_bar.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/onboarding/screens/onboarding_screen.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/glass_dialog.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/library_scanner_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/milestone_service.dart';
 import 'package:flick/services/widget_sync_service.dart';
 import 'package:flick/services/widget_intent_handler.dart';
 import 'package:flick/models/nav_bar_config.dart';
@@ -170,6 +173,8 @@ class _MainShellState extends ConsumerState<MainShell>
       _previousSong = nextSong;
     });
 
+    _playerService.pendingMilestoneNotifier.addListener(_handleMilestone);
+
     ref.listenManual<NavBarConfig>(navBarConfigProvider, (previous, next) {
       if (previous == null || !mounted) return;
       final currentPageIndex = ref.read(navigationIndexProvider);
@@ -278,6 +283,63 @@ class _MainShellState extends ConsumerState<MainShell>
     }
   }
 
+  void _handleMilestone() {
+    final milestone = _playerService.pendingMilestoneNotifier.value;
+    if (milestone == null || !mounted) return;
+
+    _playerService.pendingMilestoneNotifier.value = null;
+    showGeneralDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Milestone',
+      transitionDuration: const Duration(milliseconds: 400),
+      pageBuilder: (context, anim1, anim2) => const SizedBox.shrink(),
+      transitionBuilder: (context, anim1, anim2, child) {
+        return FadeTransition(
+          opacity: CurvedAnimation(
+            parent: anim1,
+            curve: Curves.easeOutCubic,
+          ),
+          child: ScaleTransition(
+            scale: Tween<double>(
+              begin: 0.9,
+              end: 1.0,
+            ).animate(
+              CurvedAnimation(
+                parent: anim1,
+                curve: Curves.easeOutBack,
+              ),
+            ),
+            child: GlassDialog(
+              title: milestone.title,
+              content: Text(milestone.message),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Dismiss'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const SupportFlickScreen(),
+                      ),
+                    );
+                  },
+                  child: Text(
+                    'Support Flick',
+                    style: TextStyle(color: AppColors.accent),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   void _onPlaybackDesyncChanged() {
     if (!mounted) return;
     final desynced = _playerService.playbackDesyncedNotifier.value;
@@ -306,6 +368,7 @@ class _MainShellState extends ConsumerState<MainShell>
     _playerService.playbackDesyncedNotifier.removeListener(
       _onPlaybackDesyncChanged,
     );
+    _playerService.pendingMilestoneNotifier.removeListener(_handleMilestone);
     WidgetsBinding.instance.removeObserver(this);
     _navBarVisibilitySubscription.close();
     _navBarAlwaysVisibleSubscription.close();

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -40,7 +40,8 @@ class MenuScreen extends ConsumerStatefulWidget {
   ConsumerState<MenuScreen> createState() => _MenuScreenState();
 }
 
-class _MenuScreenState extends ConsumerState<MenuScreen> {
+class _MenuScreenState extends ConsumerState<MenuScreen>
+    with SingleTickerProviderStateMixin {
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
   final PlayerService _playerService = PlayerService();
@@ -50,10 +51,31 @@ class _MenuScreenState extends ConsumerState<MenuScreen> {
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = const {};
   bool _isHistoryLoading = true;
   bool _showEngineCard = true;
+  late final AnimationController _welcomeCardController;
+  late final Animation<double> _welcomeCardFade;
+  late final Animation<Offset> _welcomeCardSlide;
 
   @override
   void initState() {
     super.initState();
+    _welcomeCardController = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
+    _welcomeCardFade = CurvedAnimation(
+      parent: _welcomeCardController,
+      curve: Curves.easeOutCubic,
+    );
+    _welcomeCardSlide = Tween<Offset>(
+      begin: const Offset(0, -0.15),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _welcomeCardController,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+    _welcomeCardController.forward();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadHistoryData();
       _watchHistory();
@@ -62,6 +84,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen> {
 
   @override
   void dispose() {
+    _welcomeCardController.dispose();
     _historySubscription?.cancel();
     super.dispose();
   }
@@ -210,6 +233,106 @@ class _MenuScreenState extends ConsumerState<MenuScreen> {
     if (hour < 12) return 'Good morning';
     if (hour < 18) return 'Good afternoon';
     return 'Good evening';
+  }
+
+  Widget _buildWelcomeCard(BuildContext context, WidgetRef ref) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingLg),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.accent.withValues(alpha: 0.08),
+            AppColors.accent.withValues(alpha: 0.03),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Welcome to Flick!',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: AppConstants.spacingSm),
+                    Text(
+                      'This app is built by a solo developer with zero budget. If you love high-fidelity audio, consider supporting its development on Ko-fi.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.adaptiveTextSecondary,
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  _welcomeCardController.reverse().then((_) {
+                    if (mounted) {
+                      ref
+                          .read(appPreferencesProvider.notifier)
+                          .setWelcomeCardDismissed(true);
+                    }
+                  });
+                },
+                child: Padding(
+                  padding: const EdgeInsets.only(left: AppConstants.spacingSm),
+                  child: Icon(
+                    LucideIcons.x,
+                    size: 18,
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingMd),
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              onPressed: () {
+                try {
+                  launchUrl(
+                    Uri.parse('https://ko-fi.com/ultraelectronica'),
+                    mode: LaunchMode.externalApplication,
+                  );
+                } catch (_) {}
+              },
+              style: OutlinedButton.styleFrom(
+                side: BorderSide(color: AppColors.glassBorder),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppConstants.spacingMd,
+                  vertical: AppConstants.spacingSm,
+                ),
+                backgroundColor: AppColors.glassBackgroundStrong,
+              ),
+              child: Text(
+                'Support Flick',
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _buildEngineSelector(
@@ -624,6 +747,30 @@ class _MenuScreenState extends ConsumerState<MenuScreen> {
                         child: _MenuLoadingState(),
                       )
                     else ...[
+                      SliverToBoxAdapter(
+                        child: AnimatedSize(
+                          duration: const Duration(milliseconds: 400),
+                          curve: Curves.easeOutCubic,
+                          child:
+                              !appPreferences.welcomeCardDismissed
+                                  ? FadeTransition(
+                                      opacity: _welcomeCardFade,
+                                      child: SlideTransition(
+                                        position: _welcomeCardSlide,
+                                        child: Padding(
+                                          padding: const EdgeInsets.fromLTRB(
+                                            AppConstants.spacingLg,
+                                            0,
+                                            AppConstants.spacingLg,
+                                            AppConstants.spacingMd,
+                                          ),
+                                          child: _buildWelcomeCard(context, ref),
+                                        ),
+                                      ),
+                                    )
+                                  : const SizedBox.shrink(),
+                        ),
+                      ),
                       SliverToBoxAdapter(
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(

--- a/lib/features/recap/screens/listening_recap_screen.dart
+++ b/lib/features/recap/screens/listening_recap_screen.dart
@@ -17,6 +17,7 @@ import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Wrapped-style listening recap with daily, weekly, monthly, and yearly views.
 class ListeningRecapScreen extends StatefulWidget {
@@ -966,6 +967,20 @@ class _PosterBackgroundSelector extends StatelessWidget {
             ),
           ],
         ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _RecapActionButton(
+          icon: LucideIcons.heart,
+          label: 'Enjoying Flick Replay?  Buy me a Ko-fi',
+          isPrimary: false,
+          onTap: () async {
+            try {
+              await launchUrl(
+                Uri.parse('https://ko-fi.com/ultraelectronica'),
+                mode: LaunchMode.externalApplication,
+              );
+            } catch (_) {}
+          },
+        ),
       ],
     );
   }
@@ -1208,7 +1223,7 @@ class _ListeningRecapHeroCard extends StatelessWidget {
           Positioned(
             left: 26,
             right: 26,
-            bottom: 28,
+            bottom: 34,
             child: Text(
               _heroClosingLine(recap),
               maxLines: 2,
@@ -1217,6 +1232,21 @@ class _ListeningRecapHeroCard extends StatelessWidget {
                 height: 1.25,
                 color: Colors.white.withValues(alpha: 0.78),
                 fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Positioned(
+            left: 26,
+            right: 26,
+            bottom: 10,
+            child: Text(
+              'Made with Flick Player  |  Support Development',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                height: 1.1,
+                color: Colors.white.withValues(alpha: 0.28),
+                fontWeight: FontWeight.w500,
+                letterSpacing: 0.4,
               ),
             ),
           ),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/features/onboarding/screens/onboarding_screen.dart';
 import 'package:flick/features/settings/screens/privacy_policy_screen.dart';
+import 'package:flick/features/settings/screens/support_flick_screen.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
@@ -623,10 +624,15 @@ SOFTWARE.
                 children: [
                   NavigationSetting(
                     icon: LucideIcons.heart,
-                    title: 'Buy me a coffee',
-                    subtitle: 'Support development on Ko-fi',
-                    onTap: () =>
-                        _launchUrl('https://ko-fi.com/ultraelectronica'),
+                    title: 'Support Flick',
+                    subtitle: 'Donate, fund features, and keep the app alive',
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const SupportFlickScreen(),
+                        ),
+                      );
+                    },
                   ),
                 ],
               );

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import 'package:flick/features/settings/screens/ui_customization_settings_screen
 import 'package:flick/features/settings/screens/integrations_settings_screen.dart';
 import 'package:flick/features/settings/screens/lyrics_settings_screen.dart';
 import 'package:flick/features/settings/screens/widget_settings_screen.dart';
+import 'package:flick/features/settings/screens/support_flick_screen.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -181,22 +182,40 @@ class SettingsScreen extends StatelessWidget {
         horizontal: AppConstants.spacingLg,
         vertical: AppConstants.spacingMd,
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            'Settings',
-            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: context.adaptiveTextPrimary,
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Settings',
+                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Configure your music experience',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(height: 4),
-          Text(
-            'Configure your music experience',
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: context.adaptiveTextTertiary,
-            ),
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const SupportFlickScreen(),
+                ),
+              );
+            },
+            icon: _PulsingHeartIcon(),
+            visualDensity: VisualDensity.compact,
           ),
         ],
       ),
@@ -287,6 +306,51 @@ class _CategoryTile extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _PulsingHeartIcon extends StatefulWidget {
+  const _PulsingHeartIcon();
+
+  @override
+  State<_PulsingHeartIcon> createState() => _PulsingHeartIconState();
+}
+
+class _PulsingHeartIconState extends State<_PulsingHeartIcon>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
+    _scale = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 1.0, end: 1.15), weight: 30),
+      TweenSequenceItem(tween: Tween(begin: 1.15, end: 1.0), weight: 70),
+    ]).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+    _controller.repeat(reverse: false);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: _scale,
+      child: Icon(
+        LucideIcons.heart,
+        color: context.adaptiveTextTertiary,
+        size: 22,
       ),
     );
   }

--- a/lib/features/settings/screens/support_flick_screen.dart
+++ b/lib/features/settings/screens/support_flick_screen.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/features/settings/widgets/settings_widgets.dart';
+
+class SupportFlickScreen extends ConsumerStatefulWidget {
+  const SupportFlickScreen({super.key});
+
+  @override
+  ConsumerState<SupportFlickScreen> createState() =>
+      _SupportFlickScreenState();
+}
+
+class _SupportFlickScreenState extends ConsumerState<SupportFlickScreen>
+    with SingleTickerProviderStateMixin {
+  static const _kofiUrl = 'https://ko-fi.com/ultraelectronica';
+
+  late final AnimationController _pulseController;
+  late final Animation<double> _pulseAnimation;
+  late final AnimationController _revealController;
+  late final Animation<double> _fade1;
+  late final Animation<double> _fade2;
+  late final Animation<double> _fade3;
+  late final Animation<Offset> _slide1;
+  late final Animation<Offset> _slide2;
+  late final Animation<Offset> _slide3;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      duration: const Duration(milliseconds: 2000),
+      vsync: this,
+    );
+    _pulseAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _pulseController,
+        curve: Curves.easeInOut,
+      ),
+    );
+    _pulseController.repeat(reverse: true);
+
+    _revealController = AnimationController(
+      duration: const Duration(milliseconds: 900),
+      vsync: this,
+    );
+    final Curve easeOut = Curves.easeOutCubic;
+    _fade1 = CurvedAnimation(
+      parent: _revealController,
+      curve: Interval(0.0, 0.5, curve: easeOut),
+    );
+    _fade2 = CurvedAnimation(
+      parent: _revealController,
+      curve: Interval(0.2, 0.7, curve: easeOut),
+    );
+    _fade3 = CurvedAnimation(
+      parent: _revealController,
+      curve: Interval(0.4, 0.9, curve: easeOut),
+    );
+    _slide1 = Tween<Offset>(
+      begin: const Offset(0, 0.08),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _revealController,
+        curve: Interval(0.0, 0.5, curve: easeOut),
+      ),
+    );
+    _slide2 = Tween<Offset>(
+      begin: const Offset(0, 0.08),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _revealController,
+        curve: Interval(0.2, 0.7, curve: easeOut),
+      ),
+    );
+    _slide3 = Tween<Offset>(
+      begin: const Offset(0, 0.08),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _revealController,
+        curve: Interval(0.4, 0.9, curve: easeOut),
+      ),
+    );
+    _revealController.forward();
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    _revealController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _launchKoFi() async {
+    final uri = Uri.parse(_kofiUrl);
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Could not open link'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: 'Support Flick',
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          FadeTransition(
+            opacity: _fade1,
+            child: SlideTransition(
+              position: _slide1,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SettingsSectionHeader('Why Donate'),
+                  SettingsCard(
+                    children: [
+                      _InfoTile(
+                        icon: LucideIcons.user,
+                        title: 'Solo Developer',
+                        subtitle:
+                            'Flick is built and maintained by one person with zero budget. No team, no funding, no ads.',
+                      ),
+                      const SettingsDivider(),
+                      _InfoTile(
+                        icon: LucideIcons.code,
+                        title: 'Free & Open Source',
+                        subtitle:
+                            'Flick will always be free. Donations keep the project alive without paywalls or subscriptions.',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          FadeTransition(
+            opacity: _fade2,
+            child: SlideTransition(
+              position: _slide2,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SettingsSectionHeader('Where Your Money Goes'),
+                  SettingsCard(
+                    children: [
+                      _InfoTile(
+                        icon: LucideIcons.smartphone,
+                        title: 'Google Play Developer Fees',
+                        subtitle:
+                            'Keeping Flick on the Play Store costs \$25/year in developer registration fees.',
+                      ),
+                      const SettingsDivider(),
+                      _InfoTile(
+                        icon: LucideIcons.headphones,
+                        title: 'Audio Testing Equipment',
+                        subtitle:
+                            'USB DACs, headphones, and reference gear to test and improve playback quality.',
+                      ),
+                      const SettingsDivider(),
+                      _InfoTile(
+                        icon: LucideIcons.music,
+                        title: 'DSD / DSF Playback',
+                        subtitle:
+                            'Funding native DSD/DSF playback development — a highly requested feature for audiophiles.',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          FadeTransition(
+            opacity: _fade3,
+            child: SlideTransition(
+              position: _slide3,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SettingsSectionHeader('Donate'),
+                  AnimatedBuilder(
+                    animation: _pulseAnimation,
+                    builder: (context, child) {
+                      return SettingsCard(
+                        border: Border.all(
+                          color: AppColors.textPrimary.withValues(
+                            alpha: 0.25 + _pulseAnimation.value * 0.55,
+                          ),
+                          width: 1.0 + _pulseAnimation.value * 1.2,
+                        ),
+                        children: [
+                          NavigationSetting(
+                            icon: LucideIcons.heart,
+                            title: 'Buy me a coffee',
+                            subtitle: 'Support development on Ko-fi',
+                            onTap: _launchKoFi,
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SizedBox(height: AppConstants.navBarHeight + 40),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoTile extends StatelessWidget {
+  const _InfoTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: context.scaleSize(AppConstants.containerSizeMd),
+            height: context.scaleSize(AppConstants.containerSizeMd),
+            decoration: BoxDecoration(
+              color: AppColors.glassBackgroundStrong,
+              borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+            ),
+            child: Icon(
+              icon,
+              color: context.adaptiveTextSecondary,
+              size: context.responsiveIcon(AppConstants.iconSizeLg),
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/songs/widgets/orbit_scroll.dart
+++ b/lib/features/songs/widgets/orbit_scroll.dart
@@ -79,17 +79,18 @@ class _OrbitScrollState extends State<OrbitScroll>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
 
-  // The physics state
-  double _scrollOffset = 0.0;
+  // The physics state — notifier drives only the song items rebuild
+  final ValueNotifier<double> _scrollOffset = ValueNotifier<double>(0.0);
 
   // Track if we're actively scrolling to reduce visible range when idle
   bool _isScrolling = false;
   DateTime _lastScrollTime = DateTime.now();
   int _lastReportedIndex = 0;
 
-  // Cache for transform calculations
+  // Cache for transform calculations (bounded)
   final Map<int, _Position> _positionCache = {};
   final Map<int, _ItemTransform> _transformCache = {};
+  static const int _maxCacheSize = 120;
 
   static final List<int> _orderedIndices = (() {
     final visibleRange = AppConstants.orbitVisibleItems ~/ 2;
@@ -103,7 +104,7 @@ class _OrbitScrollState extends State<OrbitScroll>
   @override
   void initState() {
     super.initState();
-    _scrollOffset = widget.selectedIndex.toDouble();
+    _scrollOffset.value = widget.selectedIndex.toDouble();
     _lastReportedIndex = widget.selectedIndex;
     _controller = AnimationController.unbounded(
       vsync: this,
@@ -123,7 +124,7 @@ class _OrbitScrollState extends State<OrbitScroll>
     if (widget.selectedIndex != oldWidget.selectedIndex) {
       _lastReportedIndex = widget.selectedIndex;
       // If the index changed externally, snap/spring to it
-      if ((widget.selectedIndex.toDouble() - _scrollOffset).abs() > 0.05) {
+      if ((widget.selectedIndex.toDouble() - _scrollOffset.value).abs() > 0.05) {
         _animateTo(widget.selectedIndex.toDouble());
       }
     }
@@ -133,6 +134,7 @@ class _OrbitScrollState extends State<OrbitScroll>
   void dispose() {
     widget.controller?._detach();
     _controller.dispose();
+    _scrollOffset.dispose();
     super.dispose();
   }
 
@@ -146,8 +148,8 @@ class _OrbitScrollState extends State<OrbitScroll>
     }
 
     _controller.stop();
+    _scrollOffset.value = clampedIndex.toDouble();
     setState(() {
-      _scrollOffset = clampedIndex.toDouble();
       _isScrolling = false;
       _lastScrollTime = DateTime.now();
     });
@@ -160,12 +162,16 @@ class _OrbitScrollState extends State<OrbitScroll>
   void _onPhysicsTick() {
     if (_controller.isAnimating) {
       final newOffset = _controller.value;
-      if ((newOffset - _scrollOffset).abs() > 0.001) {
-        setState(() {
-          _scrollOffset = newOffset;
-          _isScrolling = true;
+      if ((newOffset - _scrollOffset.value).abs() > 0.001) {
+        _scrollOffset.value = newOffset;
+        if (!_isScrolling) {
+          setState(() {
+            _isScrolling = true;
+            _lastScrollTime = DateTime.now();
+          });
+        } else {
           _lastScrollTime = DateTime.now();
-        });
+        }
       }
     } else if (_isScrolling) {
       final now = DateTime.now();
@@ -195,7 +201,7 @@ class _OrbitScrollState extends State<OrbitScroll>
       metrics: FixedScrollMetrics(
         minScrollExtent: 0,
         maxScrollExtent: widget.songs.length.toDouble(),
-        pixels: _scrollOffset,
+        pixels: _scrollOffset.value,
         viewportDimension: 100,
         axisDirection: AxisDirection.down,
         devicePixelRatio: 1.0,
@@ -207,23 +213,26 @@ class _OrbitScrollState extends State<OrbitScroll>
     const itemHeight = 90.0;
     var itemDelta = -(delta / itemHeight);
 
-    double newOffset = _scrollOffset + itemDelta;
+    double newOffset = _scrollOffset.value + itemDelta;
     if (newOffset < -0.5 || newOffset > widget.songs.length - 0.5) {
       itemDelta = itemDelta * 0.4;
-      newOffset = _scrollOffset + itemDelta;
+      newOffset = _scrollOffset.value + itemDelta;
     }
 
-    if ((newOffset - _scrollOffset).abs() > 0.001) {
-      setState(() {
-        _scrollOffset = newOffset;
-        _isScrolling = true;
+    if ((newOffset - _scrollOffset.value).abs() > 0.001) {
+      _scrollOffset.value = newOffset;
+      if (!_isScrolling) {
+        setState(() {
+          _isScrolling = true;
+          _lastScrollTime = DateTime.now();
+        });
+      } else {
         _lastScrollTime = DateTime.now();
-      });
+      }
     }
   }
 
   void _onVerticalDragEnd(DragEndDetails details) {
-    // _dragStart = null; // This variable is not defined in the provided context. Removing it.
     final velocity = details.primaryVelocity ?? 0.0;
 
     // Dispatch end notification (idle)
@@ -231,7 +240,7 @@ class _OrbitScrollState extends State<OrbitScroll>
       metrics: FixedScrollMetrics(
         minScrollExtent: 0,
         maxScrollExtent: widget.songs.length.toDouble(),
-        pixels: _scrollOffset,
+        pixels: _scrollOffset.value,
         viewportDimension: 100,
         axisDirection: AxisDirection.down,
         devicePixelRatio: 1.0,
@@ -249,7 +258,7 @@ class _OrbitScrollState extends State<OrbitScroll>
     // We use a FrictionSimulation to see where it WOULD land.
     final simulation = FrictionSimulation(
       0.15, // Drag coefficient (higher = stops faster)
-      _scrollOffset,
+      _scrollOffset.value,
       velocityItemsPerSec,
     );
 
@@ -276,18 +285,25 @@ class _OrbitScrollState extends State<OrbitScroll>
 
     final simulation = SpringSimulation(
       description,
-      _scrollOffset,
+      _scrollOffset.value,
       target,
       velocity,
     );
 
     _controller.animateWith(simulation).whenComplete(() {
       // Ensure we explicitly set the final state to avoid micro-drifts
+      _scrollOffset.value = target;
       setState(() {
-        _scrollOffset = target;
         _isScrolling = false;
         _lastScrollTime = DateTime.now();
       });
+      // Clear caches after animation completes to prevent unbounded growth
+      if (_transformCache.length > _maxCacheSize) {
+        _transformCache.clear();
+      }
+      if (_positionCache.length > _maxCacheSize) {
+        _positionCache.clear();
+      }
       final finalIndex = target.round();
       if (finalIndex >= 0 && finalIndex < widget.songs.length) {
         if (_lastReportedIndex != finalIndex) {
@@ -327,8 +343,18 @@ class _OrbitScrollState extends State<OrbitScroll>
             // Path
             _buildOrbitPath(orbitCenterX, orbitCenterY, orbitRadius),
 
-            // Songs
-            ..._buildSongItems(orbitCenterX, orbitCenterY, orbitRadius),
+            // Songs — only rebuilds when scroll offset changes
+            ValueListenableBuilder<double>(
+              valueListenable: _scrollOffset,
+              builder: (context, _, __) {
+                return SizedBox.expand(
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: _buildSongItems(orbitCenterX, orbitCenterY, orbitRadius),
+                  ),
+                );
+              },
+            ),
           ],
         ),
       ),
@@ -376,14 +402,14 @@ class _OrbitScrollState extends State<OrbitScroll>
   List<Widget> _buildSongItems(double centerX, double centerY, double radius) {
     final List<Widget> items = [];
 
-    final centerIndex = _scrollOffset.round();
+    final centerIndex = _scrollOffset.value.round();
 
     for (final relativeIndex in _orderedIndices) {
       final actualIndex = centerIndex + relativeIndex;
 
       if (actualIndex < 0 || actualIndex >= widget.songs.length) continue;
 
-      final diff = actualIndex.toDouble() - _scrollOffset;
+      final diff = actualIndex.toDouble() - _scrollOffset.value;
 
       final cacheKey = (diff * 100).toInt();
       _ItemTransform? transform = _transformCache[cacheKey];
@@ -428,23 +454,21 @@ class _OrbitScrollState extends State<OrbitScroll>
           top: transform.position.y,
           child: FractionalTranslation(
             translation: const Offset(-0.5, -0.5),
-            child: RepaintBoundary(
-              child: SongCard(
-                song: widget.songs[actualIndex],
-                scale: transform.scale,
-                opacity: transform.opacity,
-                isSelected: transform.isSelected,
-                swipeActionsEnabled: widget.swipeActionsEnabled,
-                isSelectionMode: widget.isSelectionMode,
-                isMultiSelected: widget.selectedIds.contains(widget.songs[actualIndex].id),
-                onTap: () {
-                  AppHaptics.tap();
-                  _animateTo(actualIndex.toDouble());
-                  widget.onSongSelected?.call(actualIndex);
-                },
-                onSwipeLeft: () => widget.onSongSwipedLeft?.call(actualIndex),
-                onSwipeRight: () => widget.onSongSwipedRight?.call(actualIndex),
-              ),
+            child: SongCard(
+              song: widget.songs[actualIndex],
+              scale: transform.scale,
+              opacity: transform.opacity,
+              isSelected: transform.isSelected,
+              swipeActionsEnabled: widget.swipeActionsEnabled,
+              isSelectionMode: widget.isSelectionMode,
+              isMultiSelected: widget.selectedIds.contains(widget.songs[actualIndex].id),
+              onTap: () {
+                AppHaptics.tap();
+                _animateTo(actualIndex.toDouble());
+                widget.onSongSelected?.call(actualIndex);
+              },
+              onSwipeLeft: () => widget.onSongSwipedLeft?.call(actualIndex),
+              onSwipeRight: () => widget.onSongSwipedRight?.call(actualIndex),
             ),
           ),
         ),

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -62,6 +62,7 @@ class _SongCardState extends State<SongCard> {
   double _dragDx = 0;
   bool _queuedFlash = false;
   bool _favoriteFlash = false;
+  double? _cachedCardWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +70,8 @@ class _SongCardState extends State<SongCard> {
         ? AppConstants.songCardArtSizeLarge
         : AppConstants.songCardArtSize;
 
-    final cardWidth = MediaQuery.of(context).size.width * 0.68;
+    _cachedCardWidth ??= MediaQuery.of(context).size.width * 0.68;
+    final cardWidth = _cachedCardWidth!;
     const cardHeight = 130.0;
 
     final isSwiping = _dragDx.abs() > 0.001;
@@ -140,15 +142,15 @@ class _SongCardState extends State<SongCard> {
       };
     }
 
-    return RepaintBoundary(
-      child: GestureDetector(
-        onTap: () {
-          AppHaptics.tap();
-          widget.onTap?.call();
-        },
-        onHorizontalDragUpdate: dragUpdate,
-        onHorizontalDragEnd: dragEnd,
-        onHorizontalDragCancel: dragCancel,
+    return GestureDetector(
+      onTap: () {
+        AppHaptics.tap();
+        widget.onTap?.call();
+      },
+      onHorizontalDragUpdate: dragUpdate,
+      onHorizontalDragEnd: dragEnd,
+      onHorizontalDragCancel: dragCancel,
+      child: RepaintBoundary(
         child: Transform.scale(
           scale: widget.scale,
           child: Opacity(

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -326,6 +326,12 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     state = state.copyWith(rightActionButton: value);
     await ref.read(appPreferencesServiceProvider).setRightActionButton(value);
   }
+
+  Future<void> setWelcomeCardDismissed(bool value) async {
+    if (state.welcomeCardDismissed == value) return;
+    state = state.copyWith(welcomeCardDismissed: value);
+    await ref.read(appPreferencesServiceProvider).setWelcomeCardDismissed(value);
+  }
 }
 
 final appPreferencesProvider =

--- a/lib/providers/milestone_provider.dart
+++ b/lib/providers/milestone_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/milestone_service.dart';
+
+final milestoneServiceProvider = Provider<MilestoneService>((ref) {
+  return MilestoneService();
+});

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -21,3 +21,4 @@ export 'progress_bar_style_provider.dart';
 export 'album_color_provider.dart';
 export 'nav_bar_config_provider.dart';
 export 'update_check_provider.dart';
+export 'milestone_provider.dart';

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -44,6 +44,7 @@ class AppPreferences {
   final bool lyricsMatchAudioFilename;
   final String leftActionButton;
   final String rightActionButton;
+  final bool welcomeCardDismissed;
 
   const AppPreferences({
     this.animationsEnabled = true,
@@ -89,6 +90,7 @@ class AppPreferences {
     this.lyricsMatchAudioFilename = false,
     this.leftActionButton = 'lyrics',
     this.rightActionButton = 'favorites',
+    this.welcomeCardDismissed = false,
   });
 
   AppPreferences copyWith({
@@ -135,6 +137,7 @@ class AppPreferences {
     bool? lyricsMatchAudioFilename,
     String? leftActionButton,
     String? rightActionButton,
+    bool? welcomeCardDismissed,
   }) {
     return AppPreferences(
       animationsEnabled: animationsEnabled ?? this.animationsEnabled,
@@ -194,6 +197,7 @@ class AppPreferences {
           lyricsMatchAudioFilename ?? this.lyricsMatchAudioFilename,
       leftActionButton: leftActionButton ?? this.leftActionButton,
       rightActionButton: rightActionButton ?? this.rightActionButton,
+      welcomeCardDismissed: welcomeCardDismissed ?? this.welcomeCardDismissed,
     );
   }
 }
@@ -242,6 +246,7 @@ class AppPreferencesService {
   static const _lyricsMatchAudioFilenameKey = 'lyrics_match_audio_filename';
   static const _leftActionButtonKey = 'left_action_button';
   static const _rightActionButtonKey = 'right_action_button';
+  static const _welcomeCardDismissedKey = 'welcome_card_dismissed';
 
   Future<AppPreferences> getPreferences() async {
     final prefs = await SharedPreferences.getInstance();
@@ -307,6 +312,7 @@ class AppPreferencesService {
           prefs.getString(_leftActionButtonKey) ?? 'lyrics',
       rightActionButton:
           prefs.getString(_rightActionButtonKey) ?? 'favorites',
+      welcomeCardDismissed: prefs.getBool(_welcomeCardDismissedKey) ?? false,
     );
   }
 
@@ -688,5 +694,15 @@ class AppPreferencesService {
   Future<void> setRightActionButton(String value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_rightActionButtonKey, value);
+  }
+
+  Future<bool> getWelcomeCardDismissed() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_welcomeCardDismissedKey) ?? false;
+  }
+
+  Future<void> setWelcomeCardDismissed(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_welcomeCardDismissedKey, value);
   }
 }

--- a/lib/services/milestone_service.dart
+++ b/lib/services/milestone_service.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../data/repositories/recently_played_repository.dart';
+
+enum MilestoneType { songs100, songs500, songs1000, hours10, hours50 }
+
+extension MilestoneTypeX on MilestoneType {
+  String get id => name;
+
+  String get title {
+    return switch (this) {
+      MilestoneType.songs100 => '100 Songs',
+      MilestoneType.songs500 => '500 Songs',
+      MilestoneType.songs1000 => '1,000 Songs',
+      MilestoneType.hours10 => '10 Hours',
+      MilestoneType.hours50 => '50 Hours',
+    };
+  }
+
+  String get message {
+    return switch (this) {
+      MilestoneType.songs100 =>
+        "You've listened to 100 songs on Flick! If you're enjoying the app, a small donation helps keep the engine running and brings DSD playback closer.",
+      MilestoneType.songs500 =>
+        "500 songs and counting! Flick is built by a solo developer — consider fueling the next round of features on Ko-fi.",
+      MilestoneType.songs1000 =>
+        "1,000 songs deep in your Flick journey. Your support helps fund things like audio testing equipment and USB DAC improvements.",
+      MilestoneType.hours10 =>
+        "You've spent 10 hours with Flick. Time flies with great audio — if Flick adds value to your day, a donation helps keep it growing.",
+      MilestoneType.hours50 =>
+        "50 hours on Flick — that's some serious listening. Consider tipping the developer to help fund native DSD/DSF playback.",
+    };
+  }
+}
+
+class MilestoneRecord {
+  final MilestoneType type;
+  final DateTime achievedAt;
+
+  const MilestoneRecord({required this.type, required this.achievedAt});
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'achievedAt': achievedAt.toIso8601String(),
+      };
+
+  factory MilestoneRecord.fromJson(Map<String, dynamic> json) {
+    return MilestoneRecord(
+      type: MilestoneType.values.firstWhere((e) => e.name == json['type']),
+      achievedAt: DateTime.parse(json['achievedAt']),
+    );
+  }
+}
+
+class MilestoneService {
+  static const _shownMilestonesKey = 'shown_milestones';
+  static const _accumulatedListenSecondsKey = 'accumulated_listen_seconds';
+
+  final RecentlyPlayedRepository _repository = RecentlyPlayedRepository();
+
+  Future<int> getAccumulatedListenSeconds() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_accumulatedListenSecondsKey) ?? 0;
+  }
+
+  Future<void> addListenSeconds(int seconds) async {
+    final prefs = await SharedPreferences.getInstance();
+    final current = prefs.getInt(_accumulatedListenSecondsKey) ?? 0;
+    await prefs.setInt(_accumulatedListenSecondsKey, current + seconds);
+  }
+
+  Future<List<MilestoneRecord>> getShownMilestones() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_shownMilestonesKey);
+    if (raw == null) return [];
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      return list
+          .map((e) => MilestoneRecord.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  Future<void> markMilestoneShown(MilestoneType type) async {
+    final prefs = await SharedPreferences.getInstance();
+    final shown = await getShownMilestones();
+    shown.add(MilestoneRecord(type: type, achievedAt: DateTime.now()));
+    final raw = jsonEncode(shown.map((r) => r.toJson()).toList());
+    await prefs.setString(_shownMilestonesKey, raw);
+  }
+
+  Future<bool> isMilestoneShown(MilestoneType type) async {
+    final shown = await getShownMilestones();
+    return shown.any((r) => r.type == type);
+  }
+
+  Future<MilestoneType?> checkMilestones() async {
+    final playCount = await _repository.getHistoryCount();
+    final listenSeconds = await getAccumulatedListenSeconds();
+    final listenHours = listenSeconds ~/ 3600;
+
+    if (playCount >= 1000 && !await isMilestoneShown(MilestoneType.songs1000)) {
+      return MilestoneType.songs1000;
+    }
+    if (playCount >= 500 && !await isMilestoneShown(MilestoneType.songs500)) {
+      return MilestoneType.songs500;
+    }
+    if (playCount >= 100 && !await isMilestoneShown(MilestoneType.songs100)) {
+      return MilestoneType.songs100;
+    }
+    if (listenHours >= 50 && !await isMilestoneShown(MilestoneType.hours50)) {
+      return MilestoneType.hours50;
+    }
+    if (listenHours >= 10 && !await isMilestoneShown(MilestoneType.hours10)) {
+      return MilestoneType.hours10;
+    }
+    return null;
+  }
+}

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -19,6 +19,7 @@ import 'package:flick/services/last_played_service.dart';
 import 'package:flick/services/favorites_service.dart';
 import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/services/replay_play_tracker.dart';
+import 'package:flick/services/milestone_service.dart';
 import 'package:flick/services/android_audio_engine.dart';
 import 'package:flick/services/rust_audio_engine.dart';
 import 'package:flick/services/rust_audio_service.dart';
@@ -275,6 +276,9 @@ class PlayerService {
     false,
   );
   final ValueNotifier<bool> gaplessPlaybackEnabledNotifier = ValueNotifier(true);
+  final ValueNotifier<MilestoneType?> pendingMilestoneNotifier =
+      ValueNotifier(null);
+  final MilestoneService _milestoneService = MilestoneService();
   bool get _usingRustBackend => usingRustBackendNotifier.value;
   set _usingRustBackend(bool value) => usingRustBackendNotifier.value = value;
   bool _rustBackendAvailable = false;
@@ -1702,6 +1706,15 @@ class PlayerService {
     _replayPlayTracker.clear();
   }
 
+  Future<void> _trackMilestones(Song song) async {
+    await _milestoneService.addListenSeconds(song.duration.inSeconds);
+    final milestone = await _milestoneService.checkMilestones();
+    if (milestone != null) {
+      await _milestoneService.markMilestoneShown(milestone);
+      pendingMilestoneNotifier.value = milestone;
+    }
+  }
+
   void _trackReplayProgress(Duration position) {
     final song = currentSongNotifier.value;
     if (song == null) {
@@ -1720,6 +1733,7 @@ class PlayerService {
     );
     if (counted && _shouldPersistSong(song)) {
       unawaited(_recentlyPlayedRepository.recordPlay(song.id));
+      unawaited(_trackMilestones(song));
     }
   }
 


### PR DESCRIPTION
# Summary

- Add milestone tracking service for user achievements with Riverpod provider and player service integration
- Add support/donation screen with animated info tiles and pulsing heart icon in settings header
- Add animated welcome card to menu screen with dismiss functionality
- Replace external Ko-fi link with in-app support screen and Ko-fi button on recap screen
- Optimize song card rendering with cached width and remove `RepaintBoundary` wrapper

# Changes

## Milestone System

- Add `MilestoneService` with achievement tracking and milestone dialog triggers
- Add `MilestoneProvider` for Riverpod state management
- Add milestone tracking to player service (play count, song completions, etc.)
- Add milestone dialog to main app shell with conditional display
- Export milestone provider through providers barrel
- Add `welcomeCardDismissed` preference with provider and service methods

## Support/Donation

- Add Support Flick screen with animated info tiles and Ko-fi call-to-action
- Add pulsing heart icon with support button to settings header
- Replace Ko-fi link in app info screen with navigation to in-app support screen
- Add Ko-fi support button and credit line to listening recap screen

## Welcome Card

- Add animated welcome card to menu screen with dismiss button
- Welcome card respects `welcomeCardDismissed` preference

## Optimization

- Cache card width in song card widget to reduce layout calculations
- Remove `RepaintBoundary` wrapper from song card

## Files Changed

- `lib/services/milestone_service.dart`
- `lib/services/player_service.dart`
- `lib/services/app_preferences_service.dart`
- `lib/providers/milestone_provider.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/providers/providers.dart`
- `lib/app/app.dart`
- `lib/features/settings/screens/settings_screen.dart`
- `lib/features/settings/screens/support_flick_screen.dart`
- `lib/features/settings/screens/app_info_settings_screen.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/features/recap/screens/listening_recap_screen.dart`
- `lib/features/songs/widgets/song_card.dart`