### PR TITLE
Add DSD native support with bit order, artist repository, and dynamic color theming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## 0.17.0-beta.1 (2026-05-31)
 
+### Post-Release Additions
+
+#### DSD Bit Order & Native USB Direct
+- **DsdBitOrder enum** (LSB/MSB) with per-source detection across all DSD format decoders (DSF, DFF, WavPack). Bit order normalization in the DSD output router.
+- **Global DSD bit reverse override**: `set_dsd_bit_reverse_override()` FFI function exposing manual byte-order control to Flutter.
+- **USB native DSD output**: `AndroidDirectUsbPlaybackFormat` now carries `dsd_bit_rate`. Multi-byte interleaved USB payload packing with configurable endianness.
+- **DSD quirks table**: `KNOWN_DSD_QUIRKS` with per-device entries (vendor/product IDs, endianness, bit reversal, preferred subslot size). Includes MOONDROP Dawn Pro quirk.
+- **DoP word building refactored** into reusable `build_dop_word()` method with I32 packing for integer streams.
+- **Default DSD bit rate initialization** for newly configured USB playback formats.
+
+#### DSD Hardware Transport
+- **UAC2 feature enabled by default**: Multi-byte DSD slots now active without opt-in.
+- **Pipeline mode based on output strategy**: `PipelineMode::Dop` set for USB DSD Native and DSD DoP strategies (bit-perfect passthrough). `Passthrough` for PCM bit-perfect. `Dsp` for standard processing.
+- **DAP flag in native DSD detection**: DSD Native mode now considered available on DAP devices even without explicit DSD encoding support.
+- **Transport labels made descriptive**: Debug transport labels updated from short codes to `usb-native-dsd-u{subslot}x{bits}-bit`, `usb-dop-{bits}-bit`, `usb-pcm`.
+- **`DsdBitOrder` passed through DSD decoder thread** to `DsdOutputRouter` for per-track byte normalization.
+
+#### Integer (I32) Stream Support
+- **`AndroidManagedStreamKind` enum**: Replaces hardcoded f32 stream with `F32` and `I32` variants.
+- **`AndroidOutputCallbackI32`**: Reads f32 from pipeline, extracts raw bit patterns via `f32::to_bits()`, writes i32 to AAudio — preserving DoP markers and DSD data intact.
+- **`open_android_output_stream()`** gains `use_integer_format` parameter; opens i32 stream with format conversion disabled for DoP/native DSD on DAP.
+- Fallback stream logic adapted to work with both f32 and i32 streams.
+
+#### Artist & Playlist Theming
+- **ArtistEntity** (Isar collection): `id`, `name` (unique, case-insensitive), `artPath` (nullable). Auto-generated Isar bindings.
+- **ArtistRepository**: `getByName()`, `setArt()`, `clearArt()` for persistent artist art path caching.
+- **ArtistDetailScreen**: Migrated from `StatefulWidget` to `ConsumerStatefulWidget` (Riverpod). Dynamic color theming via `ColorExtractionService` from resolved album art. Full-bleed artist image background with animated tinted app bar. Removed old circular avatar + stat chips layout.
+- **PlaylistDetailScreen**: Dynamic playlist color from most-played song's album art via `getMostPlayedSongAmong()`. `TweenAnimationBuilder` tinted background. Info chips (track count, total duration, created/updated dates). "Other Playlists" horizontal section. Back button repositioned to overlay. Removed 4-tile cover grid.
+- **`getMostPlayedSongAmong()`** in `RecentlyPlayedRepository`: Returns most-played song from a given list for playlist color extraction.
+
+#### Visualizer & Player
+- **Vinyl disc morph animation**: Tap album art to morph into a spinning vinyl record. `_VinylDiscPainter` draws radial-gradient disc with grooves and highlight. `_morphController` (700ms) controls transition; `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size. Song change resets to art mode. Haptic feedback on toggle.
+- **Album color in visualizer preview**: `_buildVisualizerPreview()` reads `albumColorModeProvider` and passes album color when mode is not `off`.
+- **SmartMixDetailScreen**: Back button moved from `SliverAppBar` leading to overlay position.
+- **Playlist metadata helpers**: Total duration calculation and date formatting utilities.
+
 ### Milestone Card Redesign & Collection
 - Redesigned milestone celebration card with per-tier accent color (bronze / silver / gold / sapphire / amethyst), large hero icon, tinted border + glow, and a subtle "next milestone — N to go" hint line
 - New achievement-style collection view (Settings → Milestones) listing all five tiers in a grid; unlocked tiles re-open the celebration card with the achieved date, locked tiles show a progress bottom sheet

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 ## Key Features
 
 ### Audio Engine
-- **Primary**: Custom Rust audio engine with UAC 2.0 support for bit-perfect playback through USB DACs/AMPs
-- **DAP Bit-Perfect**: High-resolution playback through device's internal DAC via Oboe/AAudio exclusive mode, with device qualification for confirmed bit-perfect DAPs
+- **Primary**: Custom Rust audio engine with UAC 2.0 support for bit-perfect PCM and native DSD playback through USB DACs/AMPs. DSD bit order handling per source format (LSB/MSB) with quirk-based byte ordering for specific DACs. I32 integer stream support for DoP/DSD transport on DAP internal path.
+- **DAP Bit-Perfect**: High-resolution playback through device's internal DAC via Oboe/AAudio exclusive mode, with device qualification for confirmed bit-perfect DAPs. I32 (integer) stream support for DoP and native DSD transport without format conversion.
 - **Fallback**: `just_audio` for standard audio playback on devices without USB audio support
 - **Audio Processing**: Advanced EQ, dynamics, and spatial/time effects via JustAudioProcessingController on Android
 - **EQ Preset Management**: Import/export functionality for EQ presets in JSON and TXT formats with parametric band support
@@ -21,7 +21,7 @@
 - **Gapless Playback**: Seamless transitions between tracks without silence
 - **Crossfade Support**: Configurable crossfade between tracks
 - **Bluetooth Codec Info**: Reference display of supported Bluetooth audio codecs and current route
-- **DSD Playback** (experimental): Native DSD, DoP, and PCM decimation output modes for DSF, DFF, and WavPack DSD files via custom Rust engine
+- **DSD Playback** (experimental): Native DSD, DoP, and PCM decimation output modes for DSF, DFF, and WavPack DSD files via custom Rust engine. USB direct native DSD with quirk-based byte ordering and multi-byte interleaved payload packing. I32 stream passthrough for DAPs.
 - **Audio Engine Selector**: Manual engine selection from the main menu, with auto-detection fallback
 
 ### USB Audio Class 2.0 (UAC 2.0)
@@ -30,10 +30,12 @@
 - Descriptor parsing for Audio Control and Audio Streaming interfaces
 - Core isochronous transfer engine retained for direct USB access; standard playback routes through Android's native USB DAC handling
 - Hot-plug detection with toast notifications on device connect/stream
-- Bit-perfect audio to external USB DACs via Android native routing
+- Bit-perfect PCM audio and native DSD bitstream delivery to external USB DACs
 - **USB Volume Control**: Dedicated volume popup with slider and mute for isochronous USB audio engines
 - **Scoring-Based Backend Selection**: Dynamic output strategy selection with compatibility scoring
 - **DAP Signature Registry**: Device detection via extensible signature registry (brand/models)
+- **DSD Quirks Table**: Per-device byte ordering overrides (endianness, bit reversal, subslot size) for native DSD compatibility (e.g., MOONDROP Dawn Pro)
+- **Enabled by Default**: UAC2 feature and multi-byte DSD slots active by default
 
 ### Advanced Equalizer & Audio Effects
 - 31-band parametric equalizer with preamp and controls
@@ -41,7 +43,7 @@
 - Preset management with import/export functionality (JSON/TXT formats)
 - Spatial and time effects including balance, tempo, damp, filter, delay, size, mix, feedback, and width
 - Android-optimized audio processing via JustAudioProcessingController
-- **Visualizer Customization**: Five animation styles (Bars, Wave, Curved Wave, Mirrored, Dots), five frequency modes, three movement styles
+- **Visualizer Customization**: Five animation styles (Bars, Wave, Curved Wave, Mirrored, Dots), five frequency modes, three movement styles, and album-dominant-color preview in visualizer settings
 
 ### Library Management
 - MediaStore-based scanning with differential database sync (~34x faster than filesystem walk)
@@ -60,6 +62,8 @@
 - **Multi-Select**: Long-press to enter batch selection with queue/favorite bulk actions
 - **Metadata Editor**: Full tag editing (title, artist, album, year, genre, track number) via Rust backend with SAF file writing
 - **Album & Folder Sorting**: Sort albums and folders by title, artist, duration, track count with persistent preferences
+- **Artist Detail Redesign**: Riverpod-based screen with dynamic color theming from album art, full-bleed artist image background, tinted app bar, and cached artist metadata via `ArtistEntity` Isar collection
+- **Playlist Detail Redesign**: Dynamic color theming extracted from most-played song's album art, info chips (track count, total duration, dates), "Other Playlists" section, and playlist metadata helpers
 
 ### Playback Features
 - Shuffle and repeat modes (off, one, all)
@@ -71,6 +75,7 @@
 - **Online Lyrics**: Search for synced (LRC) or plain-text lyrics from LRCLib.net
 - **Lyrics Sync Studio**: Built-in timestamp editor with Simple and Advanced modes, time-shift tools, and file import
 - **Immersive Full View**: Auto-hiding controls for full-bleed album art with customizable layout
+- **Vinyl Disc Morph**: Tap album art to morph into a spinning vinyl record with animated transition and radial-gradient disc rendering
 - **Star Ratings**: 1–5 star ratings on songs with animated overlay and persistent storage
 - **Song Sharing**: Share songs as album art, lyric, minimal, or solid color cards — save to gallery or share via apps
 - **Custom Player Action Buttons**: Configure left and right action button slots (rating, share, lyrics, shuffle, etc.)
@@ -145,6 +150,8 @@ When a song is playing in Locker and you want to switch to Flick's advanced audi
 
 - **DSD scanning**: DSF, DFF, and WavPack DSD (.wv) metadata scanning and artwork extraction (complete)
 - **DSD/DSF/DFF/WavPack playback**: engine-level native DSD decoding and playback with Native, DoP, and PCM decimation output modes (experimental)
+- **DSD bit order normalization**: Per-source LSB/MSB detection with global override (complete)
+- **Native DSD USB direct**: Quirk-based isochronous DSD bitstream delivery to external DACs (complete)
 - MQA support
 - Poweramp-style EQ filters, including low-pass
 - Android audio settings

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -4,7 +4,7 @@
 
 **Flick Player** is a modern, high-performance music player application designed for audiophiles and casual listeners alike. Primarily running on Android, it bridges the gap between a beautiful, fluid user interface and a robust, low-level audio processing engine with advanced equalizer and effects capabilities.
 
-The application leverages the power of **Flutter** for a responsive, animated frontend and **Rust** for a stable, efficient backend. Key features include a custom "Function Code" (Audio Engine) that handles playback independent of the OS media controls in some aspects, ensuring high-fidelity audio output, along with advanced EQ and FX processing capabilities. The engine supports multiple output paths including USB DAC bit-perfect playback, Android's internal high-resolution audio path (DAP), native DSD bitstream delivery via JNI `AudioTrack`, DoP (DSD over PCM) transport, and standard Android audio output. Features include a home screen mini player widget, online lyrics search with a built-in timestamp editor (Lyrics Sync Studio), visualizer customization (animation styles, frequency modes, movement modes), a queue management overhaul, folder grid browsing, immersive full view, swipe actions on songs, Bluetooth codec reference display, and Play Store in-app updates.
+The application leverages the power of **Flutter** for a responsive, animated frontend and **Rust** for a stable, efficient backend. Key features include a custom "Function Code" (Audio Engine) that handles playback independent of the OS media controls in some aspects, ensuring high-fidelity audio output, along with advanced EQ and FX processing capabilities. The engine supports multiple output paths including USB DAC bit-perfect playback, native DSD bitstream delivery via USB direct (isochronous transfer with quirk-based byte ordering), Android's internal high-resolution audio path (DAP) with integer (I32) stream support for DoP/DSD transport, DoP (DSD over PCM) transport, and standard Android audio output. Features include a home screen mini player widget, online lyrics search with a built-in timestamp editor (Lyrics Sync Studio), visualizer customization (animation styles, frequency modes, movement modes) with album-color preview support, a queue management overhaul, folder grid browsing, immersive full view, swipe actions on songs, dynamic playlist and artist detail color theming from album art, album art to vinyl record morph animation, Bluetooth codec reference display, and Play Store in-app updates.
 
 ### Digital Audio Player (DAP) Support
 
@@ -40,23 +40,27 @@ The application identifies and optimizes for several known DAP brands and model 
 The core audio engine in `rust/src/audio/engine.rs` features a sophisticated architecture designed for high-performance audio processing:
 
 - **Lock-Free Design**: Uses atomic operations and lock-free data structures in the audio callback to prevent audio glitches
-- **Multiple Output Strategies**: Dynamically selects between USB Direct, DAP Native, Mixer Bit-Perfect, Mixer Matched, and Resampled Fallback based on device capabilities
+- **Multiple Output Strategies**: Dynamically selects between USB Direct, DAP Native, Mixer Bit-Perfect, Mixer Matched, Resampled Fallback, USB DSD Native, and DSD DoP based on device capabilities
+- **Integer Stream Support**: Opens AAudio in I32 format (instead of f32) for DoP/native DSD transport on the DAP path — raw bit patterns pass through without format conversion
+- **DSD Bit Order Handling**: Normalizes DSD byte ordering per-source (`DsdBitOrder::Lsb` / `DsdBitOrder::Msb`) with a global configurable override. USB native DSD applies quirk-based byte ordering for specific DACs
 - **Real-Time Processing Chain**: Implements a complete DSP chain including volume control, 10-band graphic equalizer with preamp, spatial/time FX, dynamics processing (compressor/limiter), playback speed control, and crossfading
-- **Runtime Pipeline Mode**: Dynamically selects between `Passthrough` (bit-perfect, skips all DSP) and `Dsp` (full processing chain) at runtime, based on output strategy and device capabilities
+- **Runtime Pipeline Mode**: Dynamically selects between `Passthrough` (bit-perfect, skips all DSP), `Dsp` (full processing chain), and `Dop` (DoP/DSD passthrough, no DSP) at runtime, based on output strategy and device capabilities
 - **Continuous Verification**: Constantly monitors and verifies that the actual output matches the requested format for quality assurance
 - **Thread Safety**: Properly separates real-time audio processing (lock-free) from control operations (thread-safe)
 
 #### Output Strategies
 
-The engine implements five distinct output strategies:
+The engine implements seven distinct output strategies:
 
-1. **USB Direct (`UsbDirect`)**: Bit-perfect playback through external USB DACs using libusb isochronous transfers (requires UAC 2.0 feature). The UAC2 pipeline info and transfer stats widgets have been removed from the UI, but the core engine remains.
-2. **DAP Native (`DapNative`)**: High-resolution audio through device's internal DAC using Oboe/AAudio in exclusive mode
-3. **Mixer Bit-Perfect (`MixerBitPerfect`)**: Android mixer path with bit-perfect format matching (Android 14+)
-4. **Mixer Matched (`MixerMatched`)**: Android mixer path with sample rate conversion when needed
-5. **Resampled Fallback (`ResampledFallback`)**: Fallback path with resampling when exact format matching isn't possible
+1. **USB Direct (`UsbDirect`)**: Bit-perfect PCM playback through external USB DACs using libusb isochronous transfers (requires UAC 2.0 feature). The UAC2 pipeline info and transfer stats widgets have been removed from the UI, but the core engine remains.
+2. **USB DSD Native (`UsbDsdNative`)**: Native DSD bitstream delivery through external USB DACs via isochronous transfers. Packs DSD bytes into multi-byte interleaved USB payloads with quirk-based byte ordering (endianness and bit reversal for specific DACs like MOONDROP Dawn Pro). Bypasses all DSP for bit-perfect DSD transport.
+3. **DAP Native (`DapNative`)**: High-resolution audio through device's internal DAC using Oboe/AAudio in exclusive mode. Supports I32 integer streams for DoP and native DSD transport on DAP devices.
+4. **DSD DoP (`DsdDoP`)**: DSD over PCM transport through the active output path (USB DAC or DAP internal), using the DoP marker protocol with pipeline mode set to `Dop` for bit-perfect passthrough.
+5. **Mixer Bit-Perfect (`MixerBitPerfect`)**: Android mixer path with bit-perfect format matching (Android 14+)
+6. **Mixer Matched (`MixerMatched`)**: Android mixer path with sample rate conversion when needed
+7. **Resampled Fallback (`ResampledFallback`)**: Fallback path with resampling when exact format matching isn't possible
 
-Each strategy is selected based on device capabilities and current playback requirements, with runtime verification ensuring the selected path meets quality expectations. The engine supports multiple output paths including USB DAC bit-perfect playback, Android's internal high-resolution audio path (DAP), and standard Android audio output.
+Each strategy is selected based on device capabilities and current playback requirements, with runtime verification ensuring the selected path meets quality expectations. The engine supports multiple output paths including USB DAC bit-perfect playback (PCM), USB DAC native DSD bitstream, Android's internal high-resolution audio path (DAP) with integer stream support for DoP/DSD, and standard Android audio output.
 
 ## Planned Features
 
@@ -78,14 +82,23 @@ The current roadmap includes:
 
 ### Recently Completed
 
-- **Milestone Tracking**: Achievement system tracking songs played (100/500/1000) and listening time (10/50 hours). `MilestoneService` with accumulated listen time, milestone dialogs from app shell, and persistent "shown" state per milestone. Welcome card on menu screen with animated dismiss.
+- **Milestone Tracking**: Achievement system tracking songs played (100/500/1000) and listening time (10/50 hours). `MilestoneService` with accumulated listen time, milestone dialogs from app shell, and persistent "shown" state per milestone. Collection view with per-tier accent colors (bronze/silver/gold/sapphire/amethyst), hero icons, and "next milestone" hint line.
 - **Support Flick Screen**: In-app donation screen with animated info tiles explaining how contributions fund Play Store fees, audio testing equipment, and DSD development. Pulsing heart icon in settings header links to support page.
+- **Artist Detail Redesign**: Migrated to Riverpod (`ConsumerStatefulWidget`) with dynamic color theming extracted from album art. Full-bleed artist image background, tinted app bar with animated color transitions, and `ArtistEntity` Isar collection with persistent art cache via `ArtistRepository`.
+- **Playlist Detail Redesign**: Dynamic color theming from most-played song's album art, full-bleed background collage, info chips (track count, total duration, dates), "Other Playlists" horizontal section, and `getMostPlayedSongAmong()` helper in `RecentlyPlayedRepository`.
+- **Vinyl Disc Morph Animation**: Tap album art to morph into a spinning vinyl record. `_VinylDiscPainter` draws a radial-gradient disc with grooves; `_morphController` (700ms) controls the transition; `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size.
+- **Album Color in Visualizer Preview**: Visualizer settings preview now reads `albumColorModeProvider` and renders the preview with the album's dominant color when album color mode is active.
+- **DSD Bit Order Support**: `DsdBitOrder` enum (`Lsb`/`Msb`) with per-source detection. All DSD format decoders (DSF, DFF, WavPack) implement `bit_order()`. Global `set_dsd_bit_reverse_override()` for forced reversal. Native DSD output normalizes byte ordering, and USB direct applies per-device quirk-based ordering.
+- **USB Native DSD & Quirks**: `AndroidDirectUsbPlaybackFormat` now carries `dsd_bit_rate`. Known DSD quirks table (`KNOWN_DSD_QUIRKS`) with per-device big-endian flag, bit reversal override, and preferred subslot size (MOONDROP Dawn Pro entry). Multi-byte interleaved USB payload packing with configurable endianness.
+- **Integer (I32) AAudio Stream**: Engine opens AAudio in I32 format for DoP/native DSD on DAP devices. `AndroidOutputCallbackI32` reads f32 from the pipeline, extracts raw bit patterns via `f32::to_bits()`, and writes i32 to AAudio — preserving DoP markers and DSD data intact.
+- **UAC2 Feature Enabled by Default**: Multi-byte DSD slots and UAC2 feature flag now active by default.
+- **Transport Labels**: Debug transport labels updated from short codes to descriptive ones (`usb-native-dsd-u{subslot}x{bits}-bit`, `usb-dop-{bits}-bit`, `usb-pcm`).
 - **Audio Session Fix**: Rust engine now activates Android `AudioSession` on start — fixes audio focus, prevents ducking, and enables coexistence with notifications.
 - **Volume Slider Refinement**: Gain mapping changed from steep 0-60 dB curve to gentle 0-20 dB linear dB mapping for more precise control.
 - **Orbit Scroll Refactor**: `ValueNotifier` replaces per-item `setState`; cache size limited to prevent unbounded growth.
 - **Full Player Performance**: `SingleChildScrollView` wrapper removed from column layout, eliminating layout jank.
-- **DoP (DSD over PCM)**: DSD64–DSD512 packed into 24/32-bit PCM frames with 0x05/0xFA markers for DoP-capable DACs
-- **DSD Auto Output Mode**: Smart runtime probing (Native → DoP → PCM decimation) based on device capabilities
+- **DoP (DSD over PCM)**: DSD64–DSD512 packed into 24/32-bit PCM frames with 0x05/0xFA markers for DoP-capable DACs. DoP word building extracted to reusable method with I32 packing.
+- **DSD Auto Output Mode**: Smart runtime probing (Native → DoP → PCM decimation) based on device capabilities. DAP flag included in native DSD detection.
 - **WavPack DSD Detection**: Automatic `.wv` file routing to DSD or PCM decoder based on WavPack mode flags
 - **DSD Decimation Pipeline**: Improved CIC filter (integer+fractional state split), tuned FIR (256 taps, Kaiser beta 8.0), corrected sinc filter formula
 - **DSD Architecture Docs**: Complete architecture documentation and volume control investigation log
@@ -125,9 +138,11 @@ The application behaves as a hybrid system. Here is a breakdown of the key *Func
 Located in `rust/src/audio`, this is the heart of the application. It bypasses standard high-level players to give direct control over the audio stream.
 
 - **Engine (`engine.rs`)**: The central coordinator featuring a lock-free architecture for real-time audio processing. It runs on a designated high-priority thread to ensure music never stutters, managing the flow of data from the file to the speakers. The engine implements multiple output strategies:
-  - **USB Direct**: Bit-perfect playback through external USB DACs using libusb isochronous transfers
+  - **USB Direct**: Bit-perfect PCM playback through external USB DACs using libusb isochronous transfers
+  - **USB DSD Native**: Native DSD bitstream through USB DACs with quirk-based byte ordering (endianness, bit reversal) and multi-byte interleaved payload packing
   - **Android Managed**: Standard audio playback through Oboe/AAudio or the Android mixer
-  - **DAP Internal High-Res**: High-resolution audio through the device's internal DAC using Oboe/AAudio in exclusive mode
+  - **DAP Internal High-Res**: High-resolution audio through the device's internal DAC using Oboe/AAudio in exclusive mode with I32 integer stream support for DoP/DSD transport
+  - **DSD DoP**: DSD over PCM transport through USB DAC or DAP internal, with `PipelineMode::Dop` for bit-perfect passthrough
 
 - **Decoder (`decoder.rs`)**: Uses `symphonia` to read various audio formats (MP3, FLAC, WAV, OGG, M4A, ALAC, AIFF) and decode them into raw sound waves (PCM). DSD decoding is handled by the DSD engine (`dsd_engine/`) supporting DSF, DFF, and WavPack DSD formats with Native, DoP, and PCM decimation output modes.
 - **ALAC Converter (`alac_converter.rs`)**: Lossless real-time conversion of ALAC/M4A/AIFF files to WAV/PCM, preserving original bit depth (16/24/32-bit). Session-based streaming conversion for memory efficiency.

--- a/docs/DSD_ARCHITECTURE.md
+++ b/docs/DSD_ARCHITECTURE.md
@@ -11,9 +11,10 @@ Flick Player supports four DSD-related formats through a unified DSD engine:
 | **WavPack DSD** | `.wv` | WavPack with DSD content | `wavpack-sys` C bindings |
 | **WavPack PCM** | `.wv` | WavPack with lossless PCM | `wavpack-sys` C bindings |
 
-The engine provides two output modes for DSD content:
+The engine provides three output modes for DSD content:
 - **PCM Decimation** — converts DSD bitstream to integer-multiple PCM rates (44.1k–705.6k) via a software CIC+FIR decimator. Works on any output device.
 - **DoP** (DSD over PCM) — packs raw DSD bits into 24/32-bit PCM frames with 0x05/0xFA marker bytes. Requires a DoP-capable DAC.
+- **Native DSD** — delivers the raw DSD bitstream directly to the DAC without any DSP processing. Uses USB isochronous transfers for USB DACs (with quirk-based byte ordering) or Android AAudio in I32 integer format for DAPs.
 
 ---
 
@@ -55,8 +56,16 @@ trait DsdFormatDecoder: Send {
     fn read_dsd_bytes(&mut self, buf: &mut [u8]) -> Result<usize>;
     fn is_finished(&self) -> bool;
     fn channel_layout(&self) -> DsdChannelLayout;
+    fn bit_order(&self) -> DsdBitOrder;
 }
 ```
+
+`DsdBitOrder` is an enum with `Lsb` and `Msb` variants that indicates whether the source format stores DSD data with least-significant-bit or most-significant-bit priority. Each decoder reports the bit order expected by that format:
+- DSF: MSB (default)
+- DFF: MSB (default)
+- WavPack DSD: MSB (default)
+
+The bit order is queried during `DsdOutputRouter` construction and used by native DSD output to normalize byte ordering before delivery.
 
 **`open_dsd_decoder()`** at `format/mod.rs:25-46` dispatches by extension:
 
@@ -93,7 +102,7 @@ WavPack files containing DSD content are opened via `wavpack-sys` with `OPEN_DSD
 
 **`rust/src/audio/dsd_engine/output/mod.rs`**
 
-The `DsdOutputRouter` routes raw DSD bytes to one of two processors depending on `DsdOutputMode`:
+The `DsdOutputRouter` routes raw DSD bytes to one of three processors depending on `DsdOutputMode`:
 
 ```
 dsd_bytes ──→ DsdOutputRouter
@@ -101,11 +110,36 @@ dsd_bytes ──→ DsdOutputRouter
                   ├── PcmDecimation → DsdDecimationPipeline (CIC+FIR)
                   │     → interleaved f32 PCM samples
                   │
-                  └── Dop → DopPacker
-                        → f32 samples with 0x05/0xFA markers
+                  ├── Dop → DopPacker
+                  │     → f32 samples with 0x05/0xFA markers
+                  │
+                  └── Native → normalize_dsd_byte() per byte
+                        → raw f32 bit containers (f32::from_bits)
 ```
 
-The router is created once per track in `DsdDecoderThread::spawn()` at `dsd_thread.rs:73`.
+The output mode is selected in the DSD decoder thread via `DsdOutputRouter::new(mode, dsd_rate, target, channels, source_bit_order)` at `dsd_thread.rs:73`.
+
+### Native DSD Byte Ordering
+
+Before native DSD output, each byte goes through `normalize_dsd_byte()` which checks the source format's bit order:
+- **LSB-first sources** (e.g., certain DSF encodings): byte is bit-reversed via `reverse_bits()`.
+- **MSB-first sources** (default): byte passes through unchanged.
+
+A global `DSD_BIT_REVERSE_OVERRIDE` atomic controls a forced reversal flag (exposed via `set_dsd_bit_reverse_override(bool)`). When the override is active, the normalization logic is inverted — useful for DACs that expect the opposite bit order.
+
+### DSD Quirks Table
+
+For USB native DSD delivery, device-specific quirks are stored in `KNOWN_DSD_QUIRKS` (in `rust/src/uac2/android_direct.rs`). Each `DsdQuirk` entry defines:
+
+| Field | Description |
+|-------|-------------|
+| `vendor_id` / `product_id` | USB VID/PID for exact match |
+| `product_name_contains` | Substring match on device name |
+| `preferred_subslot` | Bytes per channel per USB frame |
+| `big_endian` | Byte order for multi-byte payloads |
+| `bit_reverse` | Whether bit reversal is needed |
+
+The `lookup_dsd_quirk()` function queries this table during USB output loop initialization, feeding `dsd_big_endian` into `prepare_iso_transfer_payload()`. Known entries include MOONDROP Dawn Pro.
 
 ---
 
@@ -174,6 +208,14 @@ Supports three windows: Blackman (default), Hamming, and Kaiser. Coefficients ar
 **`rust/src/audio/dsd_engine/dsd/dop.rs`**
 
 The DoP standard encodes DSD data inside PCM frames. Each PCM sample carries one DSD channel of data plus an 8-bit marker byte.
+
+### DoP Word Building
+
+`build_dop_word()` (in `dop.rs`) constructs a 32-bit DoP word given DSD bytes and a marker. This method is shared between the f32-packing path and the I32 integer stream path, ensuring consistent marker placement regardless of output format.
+
+### I32 Packing
+
+For integer AAudio streams, `pack_dop_to_i32()` builds the same DoP words but writes them as `i32` values directly into the output buffer. This bypasses the f32 bit-layer indirection used in the standard path, preserving the raw DoP bit patterns for integer-format streams.
 
 ### Marker Protocol
 
@@ -310,16 +352,21 @@ All decoder threads use the same ring-buffer-based `SourceProvider`. When a new 
 Always uses `PipelineMode::Dsp`. DoP transport is not supported via cpal — the f32 samples are played as literal PCM (silence/garbage). PCM decimation mode must be used.
 
 ### Android Oboe (Managed)
-- Stereo f32 stream at device sample rate
-- Strategy selection picks the best backend from: `DsdNative`, `DapNative`, `MixerBitPerfect`, `DsdDoP`, `UsbDirect`, `MixerMatched`, `ResampledFallback`
+- Stereo f32 or i32 stream at device sample rate (I32 used for DoP/DSD native to preserve bit patterns)
+- Strategy selection picks the best backend from: `DsdNative`, `DapNative`, `MixerBitPerfect`, `DsdDoP`, `UsbDirect`, `UsbDsdNative`, `MixerMatched`, `ResampledFallback`
 - DoP: pipeline mode set to `Dop`; carrier rate negotiated with DAC
+- Native DSD: pipeline mode set to `Dop`; raw bytes packed into f32 containers or I32 stream passthrough
 
 ### Android USB Direct (UAC2)
 - DoP format negotiation via UAC2 descriptors
 - `AndroidDirectUsbPlaybackFormat.is_dop` flag
-- DoP sample encoding uses `encode_dop_slots()` in `uac2/android_direct.rs:5904`
-- Pipeline mode: `Passthrough` for bit-perfect verified, `Dop` for DoP transport
+- `AndroidDirectUsbPlaybackFormat.dsd_bit_rate` field for native DSD wire rate calculation
+- DoP sample encoding uses `encode_dop_slots()` in `uac2/android_direct.rs`
+- Native DSD encoding uses `encode_usb_pcm_slots()` with `dsd_big_endian` flag and `channels` parameter
+- Multi-byte interleaved payload packing: subslot_size=1 for direct byte copy, subslot_size>1 for interleaved multi-byte per channel with configurable endianness
+- Pipeline mode: `Passthrough` for bit-perfect verified PCM, `Dop` for DoP transport and native DSD
 - Device classifier checks for `FORMAT_TAG_DSD = 0x0008` and `FormatType::Dsd`
+- DSD quirks lookup at USB output loop initialization for per-device byte ordering
 
 ---
 
@@ -336,9 +383,11 @@ Always uses `PipelineMode::Dsp`. DoP transport is not supported via cpal — the
 
 - `current_dsd_output_mode()` — reads `DSD_OUTPUT_MODE` atomic (0=PCM, 1=DoP)
 - `audio_set_dsd_output_mode(mode: u8)` — writes the atomic
+- `audio_set_dsd_bit_reverse_override(bool)` — forces/inverts DSD byte ordering globally (exposed as `#[flutter_rust_bridge::frb(sync)]`)
 
 **DoP volume constraint** (`player_service.dart:3682-3707`):
 - DoP bypasses software gain (volume is no-op in `PipelineMode::Dop`)
+- Native DSD also bypasses software gain (pipeline mode `Dop`)
 - When software volume is needed (e.g. no hardware volume on DAC), the player auto-switches to PCM decimation mode
 
 ---
@@ -363,10 +412,12 @@ open_dsd_decoder() ─── Box<dyn DsdFormatDecoder>
 DsdDecoderThread::spawn()
     │
     ├── DsdRate::from_sample_rate(decoder.sample_rate())
-    ├── DsdOutputRouter::new(mode, dsd_rate, target, channels)
+    ├── source_bit_order = decoder.bit_order()
+    ├── DsdOutputRouter::new(mode, dsd_rate, target, channels, source_bit_order)
     │       │
     │       ├── PcmDecimation → DsdDecimationPipeline { CIC(3) + FIR(64) }
-    │       └── Dop → DopPacker { 0x05/0xFA markers, 24/32-bit frames }
+    │       ├── Dop → DopPacker { 0x05/0xFA markers, 24/32-bit frames }
+    │       └── Native → normalize_dsd_byte (MSB/LSB reversal)
     │
     ├── AudioSource + SourceProducer (ring buffer, 480k samples)
     │
@@ -384,6 +435,8 @@ dsd_decode_thread() [background thread]
 audio_callback() [cpal/Oboe/UAC2 thread]
     │
     ├── PipelineMode::Dop → sources.read() → passthrough
+    │     ├── f32 stream → direct write (DoP markers as f32 bit containers)
+    │     └── i32 stream → AndroidOutputCallbackI32 (f32::to_bits → i32)
     ├── PipelineMode::Passthrough → sources.read() → gain only
     └── PipelineMode::Dsp → sources.read() → crossfade → speed → EQ → fx → dynamics → gain
 ```
@@ -393,6 +446,10 @@ audio_callback() [cpal/Oboe/UAC2 thread]
 ## 12. Key Constraints
 
 - **DoP requires bit-perfect passthrough.** Any DSP processing corrupts the markers and DSD data.
+- **Native DSD requires bit-perfect passthrough.** Same constraint as DoP — any gain or DSP destroys the 1-bit sigma-delta encoded bitstream.
+- **DSD bit order varies by source format.** LSB vs MSB ordering is format-specific. The output router normalizes bytes based on the decoder's reported `bit_order()`. A global override can invert this for DACs that expect reversed byte order.
+- **USB native DSD uses quirk-based configuration.** Device-specific byte ordering (endianness, bit reversal, subslot size) is determined via `lookup_dsd_quirk()` during USB output loop initialization.
+- **Integer (I32) streams required for DoP/DSD on DAP.** F32 streams apply format conversion that corrupts DoP markers. I32 streams pass raw bit patterns through AAudio without conversion.
 - **DSF sequential blocks** need read-aligned chunk sizes: `(16384 / (block_size * channels)).ceil() * block_size * channels`.
 - **CIC decimation** introduces passband droop; the FIR stage compensates via Blackman-windowed lowpass.
 - **WavPack DSD detection** happens via bit 31 of mode flags, NOT file extension. The same `.wv` extension serves both DSD and PCM WavPack.

--- a/docs/uac2/guides/dac-extensibility.md
+++ b/docs/uac2/guides/dac-extensibility.md
@@ -71,7 +71,9 @@ pub enum BackendType {
     MixerBitPerfect,
     MixerMatched,
     ResampledFallback,
-    NetworkDac,  // new
+    UsbDsdNative,   // DSD native bitstream via USB isochronous
+    DsdDoP,          // DSD over PCM transport
+    NetworkDac,      // new
 }
 ```
 
@@ -79,7 +81,9 @@ Also add to `rust/src/audio/strategy.rs` `OutputStrategy`:
 ```rust
 pub enum OutputStrategy {
     // ...existing variants
-    NetworkDac,  // new
+    UsbDsdNative,   // new
+    DsdDoP,          // new
+    NetworkDac,      // new
 }
 ```
 
@@ -195,10 +199,36 @@ The DAP registry in `rust/src/audio/device.rs` contains the following brands:
 | `rust/src/audio/device.rs` | DAP signature registry, device classification |
 | `rust/src/audio/strategy.rs` | BackendCandidate scoring, strategy selection |
 | `rust/src/audio/backend.rs` | BackendType, BackendDescriptor, AudioBackend trait |
-| `rust/src/audio/engine.rs` | Engine creation per strategy |
+| `rust/src/audio/engine.rs` | Engine creation per strategy, integer (I32) stream support, pipeline mode selection |
 | `rust/src/audio/verifier.rs` | Output verification |
 | `rust/src/audio/manager.rs` | Capability detection, engine lifecycle |
+| `rust/src/uac2/android_direct.rs` | USB isochronous transfers, DSD quirk table, native DSD payload packing |
+| `rust/src/audio/dsd_engine/output/mod.rs` | DSD output routing, byte order normalization, global bit reverse override |
 | `lib/models/audio_engine_type.dart` | Flutter engine type enum |
 | `lib/services/audio_session_manager.dart` | Mode resolution logic |
 | `lib/services/android_audio_device_service.dart` | DAP keyword detection (Dart) |
 | `android/.../MainActivity.kt` | USB device management, capability reporting |
+
+## Adding a DSD Quirk
+
+To add native DSD support for a new USB DAC that needs special byte ordering, add a `DsdQuirk` entry to `KNOWN_DSD_QUIRKS` in `rust/src/uac2/android_direct.rs`:
+
+```rust
+DsdQuirk {
+    vendor_id: 0x1224,           // USB VID
+    product_id: 0x2A2A,         // USB PID
+    product_name_contains: None, // Or Some("DAC Name")
+    preferred_subslot: 2,       // Bytes per channel per USB frame
+    big_endian: true,           // Byte order for multi-byte payloads
+    bit_reverse: false,         // Whether per-byte bit reversal is needed
+}
+```
+
+Fields:
+- `vendor_id` / `product_id`: Exact USB VID/PID match (0 for wildcard)
+- `product_name_contains`: Substring match on USB product name string (case-insensitive)
+- `preferred_subslot`: Number of bytes per channel in each USB transfer frame
+- `big_endian`: When packing multi-byte interleaved channel data, send MSB first
+- `bit_reverse`: Invert bit order within each byte (for DACs expecting LSB-first DSD)
+
+The quirk is applied during USB output loop initialization via `lookup_dsd_quirk()`, which feeds the `dsd_big_endian` flag into `prepare_iso_transfer_payload()` for native DSD payload packing.

--- a/docs/uac2/guides/device-compatibility.md
+++ b/docs/uac2/guides/device-compatibility.md
@@ -19,6 +19,7 @@ For best experience:
 - Multiple bit depth support (16, 24, 32-bit)
 - Volume and mute controls
 - Low latency operation
+- **DSD support** (optional): Native DSD requires `FORMAT_TAG_DSD` (0x0008) in device descriptors. DoP transport works with standard PCM interfaces. Per-device quirks (endianness, bit reversal, subslot size) are handled via `KNOWN_DSD_QUIRKS`.
 
 ## Tested Devices
 
@@ -28,7 +29,7 @@ These devices have been tested and work perfectly:
 
 | Manufacturer | Model | Max Sample Rate | Max Bit Depth | Notes |
 |--------------|-------|-----------------|---------------|-------|
-| MOONDROP | Dawn Pro | 384 kHz | 32-bit | Dual CS43131, balanced output |
+| MOONDROP | Dawn Pro | 384 kHz | 32-bit | Dual CS43131, balanced output. Native DSD via quirk table (big-endian USB packing). |
 | FiiO | K5 Pro | 384 kHz | 32-bit | Excellent compatibility |
 | Topping | D10s | 384 kHz | 32-bit | All features work |
 | Schiit | Modi 3+ | 192 kHz | 24-bit | Stable operation |

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1,13 +1,15 @@
 import 'package:isar_community/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
-import 'entities/song_entity.dart';
+import 'entities/artist_entity.dart';
 import 'entities/folder_entity.dart';
 import 'entities/recently_played_entity.dart';
+import 'entities/song_entity.dart';
 
-export 'entities/song_entity.dart';
+export 'entities/artist_entity.dart';
 export 'entities/folder_entity.dart';
 export 'entities/recently_played_entity.dart';
+export 'entities/song_entity.dart';
 
 /// Database singleton for Isar operations.
 class Database {
@@ -26,7 +28,12 @@ class Database {
 
     final dir = await getApplicationDocumentsDirectory();
     _instance = await Isar.open(
-      [SongEntitySchema, FolderEntitySchema, RecentlyPlayedEntitySchema],
+      [
+        SongEntitySchema,
+        FolderEntitySchema,
+        RecentlyPlayedEntitySchema,
+        ArtistEntitySchema,
+      ],
       directory: dir.path,
       name: 'flick_player',
     );
@@ -46,5 +53,8 @@ class Database {
 
   /// Get the recently played collection.
   static IsarCollection<RecentlyPlayedEntity> get recentlyPlayed =>
-      instance.recentlyPlayedEntitys;
+      _instance!.recentlyPlayedEntitys;
+
+  /// Get the artists collection.
+  static IsarCollection<ArtistEntity> get artists => _instance!.artistEntitys;
 }

--- a/lib/data/entities/artist_entity.dart
+++ b/lib/data/entities/artist_entity.dart
@@ -1,0 +1,16 @@
+import 'package:isar_community/isar.dart';
+
+part 'artist_entity.g.dart';
+
+/// Database entity for caching per-artist metadata.
+@collection
+class ArtistEntity {
+  Id id = Isar.autoIncrement;
+
+  /// Canonical artist name. Case-insensitive unique.
+  @Index(unique: true, caseSensitive: false)
+  late String name;
+
+  /// Path to a local image file used as the artist's picture.
+  String? artPath;
+}

--- a/lib/data/entities/artist_entity.g.dart
+++ b/lib/data/entities/artist_entity.g.dart
@@ -1,0 +1,795 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'artist_entity.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetArtistEntityCollection on Isar {
+  IsarCollection<ArtistEntity> get artistEntitys => this.collection();
+}
+
+const ArtistEntitySchema = CollectionSchema(
+  name: r'ArtistEntity',
+  id: -3512007407542063331,
+  properties: {
+    r'artPath': PropertySchema(id: 0, name: r'artPath', type: IsarType.string),
+    r'name': PropertySchema(id: 1, name: r'name', type: IsarType.string),
+  },
+
+  estimateSize: _artistEntityEstimateSize,
+  serialize: _artistEntitySerialize,
+  deserialize: _artistEntityDeserialize,
+  deserializeProp: _artistEntityDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'name': IndexSchema(
+      id: 879695947855722453,
+      name: r'name',
+      unique: true,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'name',
+          type: IndexType.hash,
+          caseSensitive: false,
+        ),
+      ],
+    ),
+  },
+  links: {},
+  embeddedSchemas: {},
+
+  getId: _artistEntityGetId,
+  getLinks: _artistEntityGetLinks,
+  attach: _artistEntityAttach,
+  version: '3.3.0',
+);
+
+int _artistEntityEstimateSize(
+  ArtistEntity object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.artPath;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.name.length * 3;
+  return bytesCount;
+}
+
+void _artistEntitySerialize(
+  ArtistEntity object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.artPath);
+  writer.writeString(offsets[1], object.name);
+}
+
+ArtistEntity _artistEntityDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = ArtistEntity();
+  object.artPath = reader.readStringOrNull(offsets[0]);
+  object.id = id;
+  object.name = reader.readString(offsets[1]);
+  return object;
+}
+
+P _artistEntityDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _artistEntityGetId(ArtistEntity object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _artistEntityGetLinks(ArtistEntity object) {
+  return [];
+}
+
+void _artistEntityAttach(
+  IsarCollection<dynamic> col,
+  Id id,
+  ArtistEntity object,
+) {
+  object.id = id;
+}
+
+extension ArtistEntityByIndex on IsarCollection<ArtistEntity> {
+  Future<ArtistEntity?> getByName(String name) {
+    return getByIndex(r'name', [name]);
+  }
+
+  ArtistEntity? getByNameSync(String name) {
+    return getByIndexSync(r'name', [name]);
+  }
+
+  Future<bool> deleteByName(String name) {
+    return deleteByIndex(r'name', [name]);
+  }
+
+  bool deleteByNameSync(String name) {
+    return deleteByIndexSync(r'name', [name]);
+  }
+
+  Future<List<ArtistEntity?>> getAllByName(List<String> nameValues) {
+    final values = nameValues.map((e) => [e]).toList();
+    return getAllByIndex(r'name', values);
+  }
+
+  List<ArtistEntity?> getAllByNameSync(List<String> nameValues) {
+    final values = nameValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'name', values);
+  }
+
+  Future<int> deleteAllByName(List<String> nameValues) {
+    final values = nameValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'name', values);
+  }
+
+  int deleteAllByNameSync(List<String> nameValues) {
+    final values = nameValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'name', values);
+  }
+
+  Future<Id> putByName(ArtistEntity object) {
+    return putByIndex(r'name', object);
+  }
+
+  Id putByNameSync(ArtistEntity object, {bool saveLinks = true}) {
+    return putByIndexSync(r'name', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByName(List<ArtistEntity> objects) {
+    return putAllByIndex(r'name', objects);
+  }
+
+  List<Id> putAllByNameSync(
+    List<ArtistEntity> objects, {
+    bool saveLinks = true,
+  }) {
+    return putAllByIndexSync(r'name', objects, saveLinks: saveLinks);
+  }
+}
+
+extension ArtistEntityQueryWhereSort
+    on QueryBuilder<ArtistEntity, ArtistEntity, QWhere> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension ArtistEntityQueryWhere
+    on QueryBuilder<ArtistEntity, ArtistEntity, QWhereClause> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(lower: id, upper: id));
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> idNotEqualTo(
+    Id id,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> idGreaterThan(
+    Id id, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> idLessThan(
+    Id id, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.between(
+          lower: lowerId,
+          includeLower: includeLower,
+          upper: upperId,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> nameEqualTo(
+    String name,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'name', value: [name]),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterWhereClause> nameNotEqualTo(
+    String name,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'name',
+                lower: [],
+                upper: [name],
+                includeUpper: false,
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'name',
+                lower: [name],
+                includeLower: false,
+                upper: [],
+              ),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'name',
+                lower: [name],
+                includeLower: false,
+                upper: [],
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'name',
+                lower: [],
+                upper: [name],
+                includeUpper: false,
+              ),
+            );
+      }
+    });
+  }
+}
+
+extension ArtistEntityQueryFilter
+    on QueryBuilder<ArtistEntity, ArtistEntity, QFilterCondition> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'artPath'),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'artPath'),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathEqualTo(String? value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'artPath',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'artPath',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'artPath',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'artPath', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  artPathIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'artPath', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> idEqualTo(
+    Id value,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'id', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'id',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'id',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'id',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  nameGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'name',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  nameStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'name',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition> nameMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'name',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  nameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'name', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterFilterCondition>
+  nameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'name', value: ''),
+      );
+    });
+  }
+}
+
+extension ArtistEntityQueryObject
+    on QueryBuilder<ArtistEntity, ArtistEntity, QFilterCondition> {}
+
+extension ArtistEntityQueryLinks
+    on QueryBuilder<ArtistEntity, ArtistEntity, QFilterCondition> {}
+
+extension ArtistEntityQuerySortBy
+    on QueryBuilder<ArtistEntity, ArtistEntity, QSortBy> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> sortByArtPath() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'artPath', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> sortByArtPathDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'artPath', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> sortByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> sortByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+}
+
+extension ArtistEntityQuerySortThenBy
+    on QueryBuilder<ArtistEntity, ArtistEntity, QSortThenBy> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenByArtPath() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'artPath', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenByArtPathDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'artPath', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenByName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.asc);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QAfterSortBy> thenByNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'name', Sort.desc);
+    });
+  }
+}
+
+extension ArtistEntityQueryWhereDistinct
+    on QueryBuilder<ArtistEntity, ArtistEntity, QDistinct> {
+  QueryBuilder<ArtistEntity, ArtistEntity, QDistinct> distinctByArtPath({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'artPath', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<ArtistEntity, ArtistEntity, QDistinct> distinctByName({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'name', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension ArtistEntityQueryProperty
+    on QueryBuilder<ArtistEntity, ArtistEntity, QQueryProperty> {
+  QueryBuilder<ArtistEntity, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<ArtistEntity, String?, QQueryOperations> artPathProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'artPath');
+    });
+  }
+
+  QueryBuilder<ArtistEntity, String, QQueryOperations> nameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'name');
+    });
+  }
+}

--- a/lib/data/repositories/artist_repository.dart
+++ b/lib/data/repositories/artist_repository.dart
@@ -1,0 +1,44 @@
+import 'package:isar_community/isar.dart';
+
+import '../database.dart';
+
+/// Repository for cached per-artist metadata.
+class ArtistRepository {
+  final Isar _isar;
+
+  ArtistRepository({Isar? isar}) : _isar = isar ?? Database.instance;
+
+  /// Look up an artist record by name (case-insensitive).
+  Future<ArtistEntity?> getByName(String name) async {
+    if (name.isEmpty) return null;
+    return _isar.artistEntitys
+        .filter()
+        .nameEqualTo(name, caseSensitive: false)
+        .findFirst();
+  }
+
+  /// Set or clear the cached art path for an artist.
+  Future<void> setArt(String name, String? artPath) async {
+    if (name.isEmpty) return;
+    await _isar.writeTxn(() async {
+      final existing = await _isar.artistEntitys
+          .filter()
+          .nameEqualTo(name, caseSensitive: false)
+          .findFirst();
+
+      if (existing != null) {
+        if (existing.artPath == artPath) return;
+        existing.artPath = artPath;
+        await _isar.artistEntitys.put(existing);
+        return;
+      }
+
+      final entity = ArtistEntity()
+        ..name = name
+        ..artPath = artPath;
+      await _isar.artistEntitys.put(entity);
+    });
+  }
+
+  Future<void> clearArt(String name) => setArt(name, null);
+}

--- a/lib/data/repositories/recently_played_repository.dart
+++ b/lib/data/repositories/recently_played_repository.dart
@@ -447,6 +447,55 @@ class RecentlyPlayedRepository {
     return result;
   }
 
+  /// Get the most-played song from a specific set of song IDs.
+  /// Ties are broken by the most recent play. Returns null if no
+  /// songs in the given IDs have been played yet.
+  Future<Song?> getMostPlayedSongAmong(Iterable<String> songIds) async {
+    final ids = songIds.toSet();
+    if (ids.isEmpty) return null;
+
+    final entries = await _isar.recentlyPlayedEntitys
+        .where()
+        .sortByPlayedAtDesc()
+        .findAll();
+
+    if (entries.isEmpty) return null;
+
+    final allSongEntities = await _songRepository.getAllSongEntities();
+    final songMap = {for (final entity in allSongEntities) entity.id: entity};
+
+    final playCounts = <String, int>{};
+    final songEntities = <String, SongEntity>{};
+    final lastPlayedAt = <String, DateTime>{};
+
+    for (final entry in entries) {
+      final songEntity = songMap[entry.songId];
+      if (songEntity == null) continue;
+      final id = songEntity.id.toString();
+      if (!ids.contains(id)) continue;
+
+      songEntities[id] = songEntity;
+      playCounts[id] = (playCounts[id] ?? 0) + 1;
+      final existing = lastPlayedAt[id];
+      if (existing == null || entry.playedAt.isAfter(existing)) {
+        lastPlayedAt[id] = entry.playedAt;
+      }
+    }
+
+    if (playCounts.isEmpty) return null;
+
+    final sortedIds = playCounts.entries.toList()
+      ..sort((a, b) {
+        final playCompare = b.value.compareTo(a.value);
+        if (playCompare != 0) return playCompare;
+        return lastPlayedAt[b.key]!.compareTo(lastPlayedAt[a.key]!);
+      });
+
+    final topEntity = songEntities[sortedIds.first.key];
+    if (topEntity == null) return null;
+    return _entityToSong(topEntity);
+  }
+
   Future<List<RecentlyPlayedEntry>> _getEntriesBetween({
     required DateTime start,
     required DateTime endExclusive,

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
@@ -8,11 +9,13 @@ import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/artists/screens/artist_detail_screen.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/services/album_art_service.dart';
+import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 
 /// Album detail screen showing songs, album info, and more from the artist.
-class AlbumDetailScreen extends StatefulWidget {
+class AlbumDetailScreen extends ConsumerStatefulWidget {
   final String albumName;
   final String albumArtist;
   final List<Song> songs;
@@ -31,19 +34,26 @@ class AlbumDetailScreen extends StatefulWidget {
   });
 
   @override
-  State<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
+  ConsumerState<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
 }
 
-class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
+class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
+  static const Color _darkBase = Color(0xFF121212);
+  static const double _backgroundBlend = 0.22;
+  static const double _appBarBlend = 0.30;
+
   final SongRepository _songRepository = SongRepository();
+  final ColorExtractionService _colorService = ColorExtractionService();
 
   List<AlbumGroup> _moreAlbums = [];
   Map<String, List<Song>> _moreArtists = {};
+  Color? _albumColor;
 
   @override
   void initState() {
     super.initState();
     _loadExtras();
+    _extractAlbumColor();
   }
 
   Future<void> _loadExtras() async {
@@ -130,6 +140,27 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
     return null;
   }
 
+  Future<void> _extractAlbumColor() async {
+    String? source = widget.albumArt;
+    if (source == null || source.isEmpty) {
+      final sourcePath = widget.albumArtSourcePath;
+      if (sourcePath == null || sourcePath.isEmpty) return;
+      source = await AlbumArtService.instance.resolveArtworkPath(
+        existingPath: null,
+        audioSourcePath: sourcePath,
+      );
+      if (source == null || !mounted) return;
+    }
+    final color = await _colorService.extractDominantColor(source);
+    if (!mounted || color == null) return;
+    setState(() => _albumColor = color);
+  }
+
+  Color _tintBackground(double blend) {
+    if (_albumColor == null) return AppColors.background;
+    return Color.lerp(_darkBase, _albumColor!, blend)!;
+  }
+
   void _playSong(Song song) {
     widget.playerService.play(song, playlist: widget.songs);
     NavigationHelper.navigateToFullPlayer(
@@ -182,237 +213,258 @@ class _AlbumDetailScreenState extends State<AlbumDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: CustomScrollView(
-        slivers: [
-          _buildAppBar(context),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingLg,
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _ActionButton(
-                      icon: LucideIcons.play,
-                      label: 'Play All',
-                      onTap: _playAll,
+    final bgColor = _tintBackground(_backgroundBlend);
+
+    return TweenAnimationBuilder<Color?>(
+      tween: ColorTween(begin: AppColors.background, end: bgColor),
+      duration: AppConstants.animationSlow,
+      curve: Curves.easeOut,
+      builder: (context, animatedBg, _) {
+        final animatedAppBar = _albumColor == null
+            ? AppColors.surface
+            : Color.lerp(_darkBase, _albumColor!, _appBarBlend)!;
+        final resolvedBg = animatedBg ?? AppColors.background;
+        return Scaffold(
+          backgroundColor: resolvedBg,
+          body: AdaptiveColorProvider(
+            backgroundColor: resolvedBg,
+            albumDominantColor: _albumColor,
+            child: CustomScrollView(
+              slivers: [
+                SliverAppBar(
+                  expandedHeight: 280,
+                  pinned: true,
+                  backgroundColor: animatedAppBar,
+                  leading: const SizedBox(),
+                  titleSpacing: 0,
+                  flexibleSpace: FlexibleSpaceBar(
+                    background: _buildAppBarBackground(context, resolvedBg),
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppConstants.spacingLg,
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: _ActionButton(
+                            icon: LucideIcons.play,
+                            label: 'Play All',
+                            onTap: _playAll,
+                          ),
+                        ),
+                        const SizedBox(width: AppConstants.spacingMd),
+                        Expanded(
+                          child: _ActionButton(
+                            icon: LucideIcons.shuffle,
+                            label: 'Shuffle',
+                            onTap: _shuffleAll,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
-                  const SizedBox(width: AppConstants.spacingMd),
-                  Expanded(
-                    child: _ActionButton(
-                      icon: LucideIcons.shuffle,
-                      label: 'Shuffle',
-                      onTap: _shuffleAll,
+                ),
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: AppConstants.spacingLg),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppConstants.spacingLg,
+                    ),
+                    child: Wrap(
+                      spacing: AppConstants.spacingSm,
+                      runSpacing: AppConstants.spacingSm,
+                      children: [
+                        _InfoChip(
+                          icon: LucideIcons.music,
+                          label: '${widget.songs.length} tracks',
+                        ),
+                        _InfoChip(
+                          icon: LucideIcons.clock,
+                          label: _formattedTotalDuration,
+                        ),
+                        if (_albumYear != null)
+                          _InfoChip(
+                            icon: LucideIcons.calendar,
+                            label: '${_albumYear!}',
+                          ),
+                        if (_albumGenre != null)
+                          _InfoChip(
+                            icon: LucideIcons.tags,
+                            label: _albumGenre!,
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: AppConstants.spacingLg),
+                ),
+                _buildSectionTitle(context, 'Songs'),
+                SliverPadding(
+                  padding: EdgeInsets.only(
+                    bottom: AppConstants.navBarHeight + 80,
+                  ),
+                  sliver: SliverList(
+                    delegate: SliverChildBuilderDelegate((context, index) {
+                      final song = widget.songs[index];
+                      return _SongTile(
+                        song: song,
+                        onTap: () => _playSong(song),
+                      );
+                    }, childCount: widget.songs.length),
+                  ),
+                ),
+                if (_moreAlbums.isNotEmpty) ...[
+                  _buildSectionTitle(
+                    context,
+                    'More from ${widget.albumArtist}',
+                  ),
+                  SliverToBoxAdapter(
+                    child: SizedBox(
+                      height: 200,
+                      child: ListView.separated(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppConstants.spacingLg,
+                        ),
+                        scrollDirection: Axis.horizontal,
+                        itemCount: _moreAlbums.length,
+                        separatorBuilder: (_, __) => const SizedBox(
+                          width: AppConstants.spacingMd,
+                        ),
+                        itemBuilder: (context, index) {
+                          final album = _moreAlbums[index];
+                          return _AlbumCard(
+                            albumName: album.albumName,
+                            albumArtist: album.albumArtist,
+                            songCount: album.songs.length,
+                            albumArt: _getArt(album.songs),
+                            albumArtSourcePath: _getSourcePath(album.songs),
+                            onTap: () => _openAlbum(album),
+                          );
+                        },
+                      ),
                     ),
                   ),
                 ],
-              ),
-            ),
-          ),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: AppConstants.spacingLg),
-          ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingLg,
-              ),
-              child: Wrap(
-                spacing: AppConstants.spacingSm,
-                runSpacing: AppConstants.spacingSm,
-                children: [
-                  _InfoChip(
-                    icon: LucideIcons.music,
-                    label: '${widget.songs.length} tracks',
+                if (_moreArtists.isNotEmpty) ...[
+                  const SliverToBoxAdapter(
+                    child: SizedBox(height: AppConstants.spacingLg),
                   ),
-                  _InfoChip(
-                    icon: LucideIcons.clock,
-                    label: _formattedTotalDuration,
+                  _buildSectionTitle(context, 'More Artists'),
+                  SliverToBoxAdapter(
+                    child: SizedBox(
+                      height: 160,
+                      child: ListView.separated(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppConstants.spacingLg,
+                        ),
+                        scrollDirection: Axis.horizontal,
+                        itemCount: _moreArtists.length,
+                        separatorBuilder: (_, __) => const SizedBox(
+                          width: AppConstants.spacingMd,
+                        ),
+                        itemBuilder: (context, index) {
+                          final entry = _moreArtists.entries.toList()[index];
+                          return _ArtistCard(
+                            artistName: entry.key,
+                            songs: entry.value,
+                            onTap: () => _openArtist(entry.key, entry.value),
+                          );
+                        },
+                      ),
+                    ),
                   ),
-                  if (_albumYear != null)
-                    _InfoChip(
-                      icon: LucideIcons.calendar,
-                      label: '${_albumYear!}',
-                    ),
-                  if (_albumGenre != null)
-                    _InfoChip(
-                      icon: LucideIcons.tags,
-                      label: _albumGenre!,
-                    ),
                 ],
-              ),
-            ),
-          ),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: AppConstants.spacingLg),
-          ),
-          _buildSectionTitle(context, 'Songs'),
-          SliverPadding(
-            padding: EdgeInsets.only(bottom: AppConstants.navBarHeight + 80),
-            sliver: SliverList(
-              delegate: SliverChildBuilderDelegate((context, index) {
-                final song = widget.songs[index];
-                return _SongTile(
-                  song: song,
-                  onTap: () => _playSong(song),
-                );
-              }, childCount: widget.songs.length),
-            ),
-          ),
-          if (_moreAlbums.isNotEmpty) ...[
-            _buildSectionTitle(context, 'More from ${widget.albumArtist}'),
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: 200,
-                child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingLg,
-                  ),
-                  scrollDirection: Axis.horizontal,
-                  itemCount: _moreAlbums.length,
-                  separatorBuilder: (_, __) => const SizedBox(
-                    width: AppConstants.spacingMd,
-                  ),
-                  itemBuilder: (context, index) {
-                    final album = _moreAlbums[index];
-                    return _AlbumCard(
-                      albumName: album.albumName,
-                      albumArtist: album.albumArtist,
-                      songCount: album.songs.length,
-                      albumArt: _getArt(album.songs),
-                      albumArtSourcePath: _getSourcePath(album.songs),
-                      onTap: () => _openAlbum(album),
-                    );
-                  },
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: AppConstants.navBarHeight + 120),
                 ),
-              ),
+              ],
             ),
-          ],
-          if (_moreArtists.isNotEmpty) ...[
-            const SliverToBoxAdapter(
-              child: SizedBox(height: AppConstants.spacingLg),
-            ),
-            _buildSectionTitle(context, 'More Artists'),
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: 160,
-                child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingLg,
-                  ),
-                  scrollDirection: Axis.horizontal,
-                  itemCount: _moreArtists.length,
-                  separatorBuilder: (_, __) => const SizedBox(
-                    width: AppConstants.spacingMd,
-                  ),
-                  itemBuilder: (context, index) {
-                    final entry = _moreArtists.entries.toList()[index];
-                    return _ArtistCard(
-                      artistName: entry.key,
-                      songs: entry.value,
-                      onTap: () => _openArtist(entry.key, entry.value),
-                    );
-                  },
-                ),
-              ),
-            ),
-          ],
-          const SliverToBoxAdapter(
-            child: SizedBox(height: AppConstants.navBarHeight + 120),
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 
-  Widget _buildAppBar(BuildContext context) {
-    return SliverAppBar(
-      expandedHeight: 280,
-      pinned: true,
-      backgroundColor: AppColors.surface,
-      leading: Container(
-        margin: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: AppColors.glassBackground,
-          borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-        ),
-        child: IconButton(
-          icon: Icon(
-            LucideIcons.arrowLeft,
-            color: context.adaptiveTextPrimary,
+  Widget _buildAppBarBackground(BuildContext context, Color fadeTo) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        CachedImageWidget(
+          imagePath: widget.albumArt,
+          audioSourcePath: widget.albumArtSourcePath,
+          fit: BoxFit.cover,
+          placeholder: Container(
+            color: AppColors.surface,
+            child: Icon(
+              LucideIcons.disc,
+              size: 80,
+              color: context.adaptiveTextTertiary,
+            ),
           ),
-          onPressed: () => Navigator.of(context).pop(),
+          errorWidget: Container(
+            color: AppColors.surface,
+            child: Icon(
+              LucideIcons.disc,
+              size: 80,
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
         ),
-      ),
-      flexibleSpace: FlexibleSpaceBar(
-        background: Stack(
-          fit: StackFit.expand,
-          children: [
-            CachedImageWidget(
-              imagePath: widget.albumArt,
-              audioSourcePath: widget.albumArtSourcePath,
-              fit: BoxFit.cover,
-              placeholder: Container(
-                color: AppColors.surface,
-                child: Icon(
-                  LucideIcons.disc,
-                  size: 80,
-                  color: context.adaptiveTextTertiary,
-                ),
-              ),
-              errorWidget: Container(
-                color: AppColors.surface,
-                child: Icon(
-                  LucideIcons.disc,
-                  size: 80,
-                  color: context.adaptiveTextTertiary,
-                ),
-              ),
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Colors.transparent,
+                fadeTo.withValues(alpha: 0.8),
+                fadeTo,
+              ],
             ),
-            Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    AppColors.background.withValues(alpha: 0.8),
-                    AppColors.background,
-                  ],
-                ),
-              ),
-            ),
-            Positioned(
-              left: AppConstants.spacingLg,
-              right: AppConstants.spacingLg,
-              bottom: AppConstants.spacingLg,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    widget.albumName,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      color: context.adaptiveTextPrimary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${widget.albumArtist} • ${widget.songs.length} songs',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: context.adaptiveTextSecondary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+          ),
         ),
-      ),
+        Positioned(
+          top: MediaQuery.of(context).padding.top + 20,
+          left: 16,
+          child: IconButton(
+            icon: Icon(
+              LucideIcons.arrowLeft,
+              color: context.adaptiveTextPrimary,
+            ),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        Positioned(
+          left: AppConstants.spacingLg,
+          right: AppConstants.spacingLg,
+          bottom: AppConstants.spacingLg,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.albumName,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${widget.albumArtist} • ${widget.songs.length} songs',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -413,20 +413,8 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
       pinned: true,
       scrolledUnderElevation: 0,
       backgroundColor: AppColors.surface,
-      leading: Container(
-        margin: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: AppColors.glassBackground,
-          borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-        ),
-        child: IconButton(
-          icon: Icon(
-            LucideIcons.arrowLeft,
-            color: context.adaptiveTextPrimary,
-          ),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
+      leading: const SizedBox(),
+      titleSpacing: 0,
       flexibleSpace: FlexibleSpaceBar(
         background: Stack(
           fit: StackFit.expand,
@@ -455,6 +443,17 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
                     AppColors.background,
                   ],
                 ),
+              ),
+            ),
+            Positioned(
+              top: MediaQuery.of(context).padding.top + 20,
+              left: 16,
+              child: IconButton(
+                icon: Icon(
+                  LucideIcons.arrowLeft,
+                  color: context.adaptiveTextPrimary,
+                ),
+                onPressed: () => Navigator.of(context).pop(),
               ),
             ),
             Center(

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -1,22 +1,24 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/data/repositories/artist_repository.dart';
 import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/albums/screens/album_detail_screen.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/services/album_art_service.dart';
+import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 
 /// Artist detail screen showing songs, albums, and most played tracks.
-class ArtistDetailScreen extends StatefulWidget {
+class ArtistDetailScreen extends ConsumerStatefulWidget {
   final String artistName;
   final List<Song> songs;
   final String? artistArt;
@@ -33,22 +35,35 @@ class ArtistDetailScreen extends StatefulWidget {
   });
 
   @override
-  State<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
+  ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
 
-class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
+class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
+  static const Color _darkBase = Color(0xFF121212);
+  static const double _backgroundBlend = 0.22;
+  static const double _appBarBlend = 0.30;
+
   final SongRepository _songRepository = SongRepository();
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
+  final ArtistRepository _artistRepository = ArtistRepository();
+  final ColorExtractionService _colorService = ColorExtractionService();
 
   List<Song> _mostPlayedSongs = [];
   List<AlbumGroup> _artistAlbums = [];
   bool _isLoadingExtras = true;
+  String? _artistArt;
+  String? _artistArtSourcePath;
+  Color? _artistColor;
 
   @override
   void initState() {
     super.initState();
+    _artistArt = widget.artistArt;
+    _artistArtSourcePath = widget.artistArtSourcePath;
     _loadExtras();
+    _resolveAndSaveArtistArt();
+    _extractArtistColor();
   }
 
   Future<void> _loadExtras() async {
@@ -77,6 +92,48 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
         _isLoadingExtras = false;
       });
     }
+  }
+
+  Future<void> _resolveAndSaveArtistArt() async {
+    final saved = await _artistRepository.getByName(widget.artistName);
+    if (!mounted) return;
+
+    if (saved?.artPath != null && saved!.artPath!.isNotEmpty) {
+      if (saved.artPath != _artistArt && mounted) {
+        setState(() => _artistArt = saved.artPath);
+      }
+      return;
+    }
+
+    if (_artistArt != null && _artistArt!.isNotEmpty) {
+      await _artistRepository.setArt(widget.artistName, _artistArt);
+      return;
+    }
+
+    final sourcePath = _artistArtSourcePath;
+    if (sourcePath == null || sourcePath.isEmpty) return;
+
+    final resolved = await AlbumArtService.instance.resolveArtworkPath(
+      existingPath: null,
+      audioSourcePath: sourcePath,
+    );
+    if (!mounted || resolved == null || resolved.isEmpty) return;
+
+    setState(() => _artistArt = resolved);
+    await _artistRepository.setArt(widget.artistName, resolved);
+  }
+
+  Future<void> _extractArtistColor() async {
+    final source = _artistArt;
+    if (source == null || source.isEmpty) return;
+    final color = await _colorService.extractDominantColor(source);
+    if (!mounted || color == null) return;
+    setState(() => _artistColor = color);
+  }
+
+  Color _tintBackground(double blend) {
+    if (_artistColor == null) return AppColors.background;
+    return Color.lerp(_darkBase, _artistColor!, blend)!;
   }
 
   Map<String, List<Song>> get _albumGroups {
@@ -207,323 +264,263 @@ class _ArtistDetailScreenState extends State<ArtistDetailScreen> {
   @override
   Widget build(BuildContext context) {
     final albumGroups = _albumGroups;
+    final bgColor = _tintBackground(_backgroundBlend);
 
     return DisplayModeWrapper(
-      child: Scaffold(
-        backgroundColor: AppColors.background,
-        body: Stack(
-          children: [
-            _buildAmbientBackground(),
-            CustomScrollView(
-              slivers: [
-                _buildAppBar(context, albumGroups.length),
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppConstants.spacingLg,
-                    ),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: _ActionButton(
-                            icon: LucideIcons.play,
-                            label: 'Play All',
-                            onTap: _playAll,
-                          ),
-                        ),
-                        const SizedBox(width: AppConstants.spacingMd),
-                        Expanded(
-                          child: _ActionButton(
-                            icon: LucideIcons.shuffle,
-                            label: 'Shuffle',
-                            onTap: _shuffleAll,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                const SliverToBoxAdapter(
-                  child: SizedBox(height: AppConstants.spacingLg),
-                ),
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppConstants.spacingLg,
-                    ),
-                    child: Wrap(
-                      spacing: AppConstants.spacingSm,
-                      runSpacing: AppConstants.spacingSm,
-                      children: [
-                        _InfoChip(
-                          icon: LucideIcons.music,
-                          label: '${widget.songs.length} songs',
-                        ),
-                        _InfoChip(
-                          icon: LucideIcons.clock,
-                          label: _formattedTotalDuration,
-                        ),
-                        if (_artistYear != null)
-                          _InfoChip(
-                            icon: LucideIcons.calendar,
-                            label: '${_artistYear!}',
-                          ),
-                        if (_artistGenre != null)
-                          _InfoChip(
-                            icon: LucideIcons.tags,
-                            label: _artistGenre!,
-                          ),
-                      ],
-                    ),
-                  ),
-                ),
-                const SliverToBoxAdapter(
-                  child: SizedBox(height: AppConstants.spacingLg),
-                ),
-                if (_artistAlbums.length > 1)
-                  _buildSectionTitle(context, 'Albums'),
-                if (_artistAlbums.length > 1)
-                  SliverToBoxAdapter(
-                    child: SizedBox(
-                      height: 200,
-                      child: ListView.separated(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppConstants.spacingLg,
-                        ),
-                        scrollDirection: Axis.horizontal,
-                        itemCount: _artistAlbums.length,
-                        separatorBuilder: (_, __) => const SizedBox(
-                          width: AppConstants.spacingMd,
-                        ),
-                        itemBuilder: (context, index) {
-                          final album = _artistAlbums[index];
-                          return _AlbumCard(
-                            albumName: album.albumName,
-                            albumArtist: album.albumArtist,
-                            songCount: album.songs.length,
-                            albumArt: _getArt(album.songs),
-                            albumArtSourcePath: _getSourcePath(album.songs),
-                            onTap: () => _openAlbum(album),
-                          );
-                        },
+      child: TweenAnimationBuilder<Color?>(
+        tween: ColorTween(begin: AppColors.background, end: bgColor),
+        duration: AppConstants.animationSlow,
+        curve: Curves.easeOut,
+        builder: (context, animatedBg, _) {
+          final animatedAppBar = _artistColor == null
+              ? AppColors.surface
+              : Color.lerp(_darkBase, _artistColor!, _appBarBlend)!;
+          final resolvedBg = animatedBg ?? AppColors.background;
+          return Scaffold(
+            backgroundColor: resolvedBg,
+            body: AdaptiveColorProvider(
+              backgroundColor: resolvedBg,
+              albumDominantColor: _artistColor,
+              child: CustomScrollView(
+                slivers: [
+                  SliverAppBar(
+                    expandedHeight: 280,
+                    pinned: true,
+                    backgroundColor: animatedAppBar,
+                    leading: const SizedBox(),
+                    titleSpacing: 0,
+                    flexibleSpace: FlexibleSpaceBar(
+                      background: _buildAppBarBackground(
+                        context,
+                        resolvedBg,
+                        albumGroups.length,
                       ),
                     ),
                   ),
-                if (_artistAlbums.length > 1)
-                  const SliverToBoxAdapter(
-                    child: SizedBox(height: AppConstants.spacingLg),
-                  ),
-                if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
-                  _buildSectionTitle(context, 'Most Played'),
-                if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
                   SliverToBoxAdapter(
-                    child: SizedBox(
-                      height: 72,
-                      child: ListView.separated(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: AppConstants.spacingLg,
-                        ),
-                        scrollDirection: Axis.horizontal,
-                        itemCount: _mostPlayedSongs.length,
-                        separatorBuilder: (_, __) => const SizedBox(
-                          width: AppConstants.spacingMd,
-                        ),
-                        itemBuilder: (context, index) {
-                          final song = _mostPlayedSongs[index];
-                          return _MostPlayedCard(
-                            song: song,
-                            onTap: () => _playSong(song),
-                          );
-                        },
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.spacingLg,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: _ActionButton(
+                              icon: LucideIcons.play,
+                              label: 'Play All',
+                              onTap: _playAll,
+                            ),
+                          ),
+                          const SizedBox(width: AppConstants.spacingMd),
+                          Expanded(
+                            child: _ActionButton(
+                              icon: LucideIcons.shuffle,
+                              label: 'Shuffle',
+                              onTap: _shuffleAll,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),
-                if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
                   const SliverToBoxAdapter(
                     child: SizedBox(height: AppConstants.spacingLg),
                   ),
-                _buildSectionTitle(context, 'Songs'),
-                SliverPadding(
-                  padding: EdgeInsets.only(
-                    bottom: AppConstants.navBarHeight + 120,
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.spacingLg,
+                      ),
+                      child: Wrap(
+                        spacing: AppConstants.spacingSm,
+                        runSpacing: AppConstants.spacingSm,
+                        children: [
+                          _InfoChip(
+                            icon: LucideIcons.music,
+                            label: '${widget.songs.length} songs',
+                          ),
+                          _InfoChip(
+                            icon: LucideIcons.clock,
+                            label: _formattedTotalDuration,
+                          ),
+                          if (_artistYear != null)
+                            _InfoChip(
+                              icon: LucideIcons.calendar,
+                              label: '${_artistYear!}',
+                            ),
+                          if (_artistGenre != null)
+                            _InfoChip(
+                              icon: LucideIcons.tags,
+                              label: _artistGenre!,
+                            ),
+                        ],
+                      ),
+                    ),
                   ),
-                  sliver: SliverList(
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      final albumEntry = albumGroups.entries.toList()[index];
-                      return _AlbumSection(
-                        albumName: albumEntry.key,
-                        songs: albumEntry.value,
-                        onSongTap: _playSong,
-                      );
-                    }, childCount: albumGroups.length),
+                  const SliverToBoxAdapter(
+                    child: SizedBox(height: AppConstants.spacingLg),
                   ),
-                ),
-              ],
+                  if (_artistAlbums.length > 1)
+                    _buildSectionTitle(context, 'Albums'),
+                  if (_artistAlbums.length > 1)
+                    SliverToBoxAdapter(
+                      child: SizedBox(
+                        height: 200,
+                        child: ListView.separated(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppConstants.spacingLg,
+                          ),
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _artistAlbums.length,
+                          separatorBuilder: (_, __) => const SizedBox(
+                            width: AppConstants.spacingMd,
+                          ),
+                          itemBuilder: (context, index) {
+                            final album = _artistAlbums[index];
+                            return _AlbumCard(
+                              albumName: album.albumName,
+                              albumArtist: album.albumArtist,
+                              songCount: album.songs.length,
+                              albumArt: _getArt(album.songs),
+                              albumArtSourcePath: _getSourcePath(album.songs),
+                              onTap: () => _openAlbum(album),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  if (_artistAlbums.length > 1)
+                    const SliverToBoxAdapter(
+                      child: SizedBox(height: AppConstants.spacingLg),
+                    ),
+                  if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
+                    _buildSectionTitle(context, 'Most Played'),
+                  if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
+                    SliverToBoxAdapter(
+                      child: SizedBox(
+                        height: 72,
+                        child: ListView.separated(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppConstants.spacingLg,
+                          ),
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _mostPlayedSongs.length,
+                          separatorBuilder: (_, __) => const SizedBox(
+                            width: AppConstants.spacingMd,
+                          ),
+                          itemBuilder: (context, index) {
+                            final song = _mostPlayedSongs[index];
+                            return _MostPlayedCard(
+                              song: song,
+                              onTap: () => _playSong(song),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  if (!_isLoadingExtras && _mostPlayedSongs.isNotEmpty)
+                    const SliverToBoxAdapter(
+                      child: SizedBox(height: AppConstants.spacingLg),
+                    ),
+                  _buildSectionTitle(context, 'Songs'),
+                  SliverPadding(
+                    padding: EdgeInsets.only(
+                      bottom: AppConstants.navBarHeight + 120,
+                    ),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        final albumEntry = albumGroups.entries.toList()[index];
+                        return _AlbumSection(
+                          albumName: albumEntry.key,
+                          songs: albumEntry.value,
+                          onSongTap: _playSong,
+                        );
+                      }, childCount: albumGroups.length),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
 
-  Widget _buildAmbientBackground() {
+  Widget _buildAppBarBackground(BuildContext context, Color fadeTo, int albumCount) {
     return Stack(
+      fit: StackFit.expand,
       children: [
-        Positioned(
-          top: -100,
-          left: -80,
-          child: Container(
-            width: 240,
-            height: 240,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: RadialGradient(
-                colors: [
-                  AppColors.accent.withValues(alpha: 0.14),
-                  Colors.transparent,
-                ],
-              ),
+        CachedImageWidget(
+          imagePath: _artistArt,
+          audioSourcePath: _artistArtSourcePath,
+          fit: BoxFit.cover,
+          placeholder: Container(
+            color: AppColors.surface,
+            child: Icon(
+              LucideIcons.user,
+              size: 80,
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+          errorWidget: Container(
+            color: AppColors.surface,
+            child: Icon(
+              LucideIcons.user,
+              size: 80,
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ),
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Colors.transparent,
+                fadeTo.withValues(alpha: 0.8),
+                fadeTo,
+              ],
             ),
           ),
         ),
         Positioned(
-          top: 140,
-          right: -100,
-          child: Container(
-            width: 200,
-            height: 200,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              gradient: RadialGradient(
-                colors: [
-                  AppColors.surfaceLight.withValues(alpha: 0.20),
-                  Colors.transparent,
-                ],
-              ),
+          top: MediaQuery.of(context).padding.top + 20,
+          left: 16,
+          child: IconButton(
+            icon: Icon(
+              LucideIcons.arrowLeft,
+              color: context.adaptiveTextPrimary,
             ),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        Positioned(
+          left: AppConstants.spacingLg,
+          right: AppConstants.spacingLg,
+          bottom: AppConstants.spacingLg,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.artistName,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '$albumCount albums • ${widget.songs.length} songs',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextSecondary,
+                ),
+              ),
+            ],
           ),
         ),
       ],
-    );
-  }
-
-  Widget _buildAppBar(BuildContext context, int albumCount) {
-    return SliverAppBar(
-      expandedHeight: 220,
-      pinned: true,
-      scrolledUnderElevation: 0,
-      backgroundColor: AppColors.surface,
-      leading: const SizedBox(),
-      titleSpacing: 0,
-      flexibleSpace: FlexibleSpaceBar(
-        background: Stack(
-          fit: StackFit.expand,
-          children: [
-            if (widget.artistArt != null || widget.artistArtSourcePath != null)
-              ImageFiltered(
-                imageFilter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                child: CachedImageWidget(
-                  imagePath: widget.artistArt,
-                  audioSourcePath: widget.artistArtSourcePath,
-                  fit: BoxFit.cover,
-                  placeholder: Container(color: AppColors.surface),
-                  errorWidget: Container(color: AppColors.surface),
-                ),
-              )
-            else
-              Container(color: AppColors.surface),
-            Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    AppColors.background.withValues(alpha: 0.9),
-                    AppColors.background,
-                  ],
-                ),
-              ),
-            ),
-            Positioned(
-              top: MediaQuery.of(context).padding.top + 20,
-              left: 16,
-              child: IconButton(
-                icon: Icon(
-                  LucideIcons.arrowLeft,
-                  color: context.adaptiveTextPrimary,
-                ),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-            ),
-            Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const SizedBox(height: 40),
-                  Container(
-                    width: 80,
-                    height: 80,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: AppColors.glassBackgroundStrong,
-                      border: Border.all(
-                        color: AppColors.glassBorder,
-                        width: 3,
-                      ),
-                    ),
-                    child: ClipOval(
-                      child: CachedImageWidget(
-                        imagePath: widget.artistArt,
-                        audioSourcePath: widget.artistArtSourcePath,
-                        fit: BoxFit.cover,
-                        placeholder: Icon(
-                          LucideIcons.user,
-                          size: 40,
-                          color: context.adaptiveTextTertiary,
-                        ),
-                        errorWidget: Icon(
-                          LucideIcons.user,
-                          size: 40,
-                          color: context.adaptiveTextTertiary,
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: AppConstants.spacingMd),
-                  Text(
-                    widget.artistName,
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      color: context.adaptiveTextPrimary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      _StatChip(
-                        icon: LucideIcons.music,
-                        label: '${widget.songs.length} songs',
-                      ),
-                      const SizedBox(width: AppConstants.spacingSm),
-                      _StatChip(
-                        icon: LucideIcons.disc,
-                        label: '$albumCount albums',
-                      ),
-                      const SizedBox(width: AppConstants.spacingSm),
-                      _StatChip(
-                        icon: LucideIcons.clock,
-                        label: _formattedTotalDuration,
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 
@@ -585,43 +582,6 @@ class _ActionButton extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _StatChip extends StatelessWidget {
-  final IconData icon;
-  final String label;
-
-  const _StatChip({required this.icon, required this.label});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppConstants.spacingMd,
-        vertical: AppConstants.spacingXs,
-      ),
-      decoration: BoxDecoration(
-        color: AppColors.glassBackgroundStrong,
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: AppColors.glassBorder),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 12, color: context.adaptiveTextSecondary),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              color: context.adaptiveTextSecondary,
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -2894,13 +2894,8 @@ class _SmartMixDetailScreen extends StatelessWidget {
               pinned: true,
               backgroundColor: Colors.transparent,
               surfaceTintColor: Colors.transparent,
-              leading: IconButton(
-                icon: Icon(
-                  LucideIcons.arrowLeft,
-                  color: context.adaptiveTextPrimary,
-                ),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
+              leading: const SizedBox(),
+              titleSpacing: 0,
               flexibleSpace: FlexibleSpaceBar(
                 background: DecoratedBox(
                   decoration: BoxDecoration(
@@ -2937,6 +2932,17 @@ class _SmartMixDetailScreen extends StatelessWidget {
                               ],
                             ),
                           ),
+                        ),
+                      ),
+                      Positioned(
+                        top: MediaQuery.of(context).padding.top + 20,
+                        left: 16,
+                        child: IconButton(
+                          icon: Icon(
+                            LucideIcons.arrowLeft,
+                            color: context.adaptiveTextPrimary,
+                          ),
+                          onPressed: () => Navigator.of(context).pop(),
                         ),
                       ),
                       Padding(

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -3957,80 +3957,290 @@ class _AnimatedSongScene extends StatelessWidget {
   }
 }
 
-class _AlbumArtBox extends StatelessWidget {
+class _AlbumArtBox extends StatefulWidget {
   final Song song;
   final double? size;
 
   const _AlbumArtBox({required this.song, this.size});
 
   @override
+  State<_AlbumArtBox> createState() => _AlbumArtBoxState();
+}
+
+class _AlbumArtBoxState extends State<_AlbumArtBox>
+    with TickerProviderStateMixin {
+  static const double _labelRatio = 0.44;
+
+  late final AnimationController _morphController;
+  late final AnimationController _spinController;
+  bool _isVinyl = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _morphController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 700),
+    );
+    _spinController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 16),
+    );
+    _morphController.addStatusListener(_handleMorphStatus);
+  }
+
+  @override
+  void didUpdateWidget(covariant _AlbumArtBox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.song.id != widget.song.id && _isVinyl) {
+      _isVinyl = false;
+      _spinController.stop();
+      _spinController.value = 0;
+      _morphController.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _morphController.removeStatusListener(_handleMorphStatus);
+    _spinController.dispose();
+    _morphController.dispose();
+    super.dispose();
+  }
+
+  void _handleMorphStatus(AnimationStatus status) {
+    if (!mounted) return;
+    if (status == AnimationStatus.completed && _isVinyl) {
+      _spinController.repeat();
+    } else if (status == AnimationStatus.dismissed) {
+      _spinController.value = 0;
+    }
+  }
+
+  void _toggle() {
+    AppHaptics.tap();
+    setState(() {
+      _isVinyl = !_isVinyl;
+      if (_isVinyl) {
+        _morphController.forward();
+      } else {
+        _spinController.stop();
+        _morphController.reverse();
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final double resolvedSize = size ?? context.responsive(280.0, 320.0, 360.0);
+    final double resolvedSize =
+        widget.size ?? context.responsive(280.0, 320.0, 360.0);
     final framePadding = resolvedSize < 220 ? 5.0 : 7.0;
     final outerRadius = resolvedSize < 220 ? 28.0 : 34.0;
     final innerRadius = math.max(outerRadius - 7.0, 20.0);
     final iconSize = math.max(52.0, resolvedSize * 0.24);
     final shadowBlur = resolvedSize < 220 ? 28.0 : 36.0;
     final shadowOffsetY = resolvedSize < 220 ? 14.0 : 20.0;
+    final labelSize = resolvedSize * _labelRatio;
+    final labelRadius = labelSize / 2;
 
     return Center(
-      child: Container(
-        width: resolvedSize,
-        height: resolvedSize,
-        padding: EdgeInsets.all(framePadding),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(outerRadius),
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Colors.white.withValues(alpha: 0.16),
-              Colors.white.withValues(alpha: 0.06),
-              Colors.white.withValues(alpha: 0.02),
-            ],
-            stops: const [0.0, 0.4, 1.0],
-          ),
-          border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.32),
-              blurRadius: shadowBlur,
-              offset: Offset(0, shadowOffsetY),
-            ),
-            BoxShadow(
-              color: Colors.white.withValues(alpha: 0.06),
-              blurRadius: 1,
-              offset: const Offset(0, 1),
-            ),
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(innerRadius),
-          child: CachedImageWidget(
-            imagePath: song.albumArt,
-            audioSourcePath: song.filePath,
-            fit: BoxFit.cover,
-            placeholder: Container(
-              color: Colors.white.withValues(alpha: 0.05),
-              child: Icon(
-                LucideIcons.music,
-                size: iconSize,
-                color: Colors.white.withValues(alpha: 0.48),
-              ),
-            ),
-            errorWidget: Container(
-              color: Colors.white.withValues(alpha: 0.05),
-              child: Icon(
-                LucideIcons.music,
-                size: iconSize,
-                color: Colors.white.withValues(alpha: 0.48),
-              ),
-            ),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _toggle,
+        child: SizedBox(
+          width: resolvedSize,
+          height: resolvedSize,
+          child: AnimatedBuilder(
+            animation: Listenable.merge([_morphController, _spinController]),
+            builder: (context, _) {
+              final t = Curves.easeInOutCubic
+                  .transform(_morphController.value)
+                  .clamp(0.0, 1.0);
+              final glass = (1.0 - t).clamp(0.0, 1.0);
+              final spinAngle =
+                  _spinController.value * 2 * math.pi * t;
+
+              final artSize = resolvedSize - (resolvedSize - labelSize) * t;
+              final artFramePadding = framePadding * glass;
+              final artOuterRadius =
+                  outerRadius + (labelRadius - outerRadius) * t;
+              final artInnerRadius =
+                  innerRadius + (labelRadius - innerRadius) * t;
+
+              return Transform.rotate(
+                angle: spinAngle,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    if (t > 0.001)
+                      Opacity(
+                        opacity: t,
+                        child: SizedBox(
+                          width: resolvedSize,
+                          height: resolvedSize,
+                          child: CustomPaint(
+                            painter: _VinylDiscPainter(
+                              labelRatio: _labelRatio,
+                            ),
+                          ),
+                        ),
+                      ),
+                    Container(
+                      width: artSize,
+                      height: artSize,
+                      padding: EdgeInsets.all(artFramePadding),
+                      decoration: BoxDecoration(
+                        borderRadius:
+                            BorderRadius.circular(artOuterRadius),
+                        gradient: glass > 0.01
+                            ? LinearGradient(
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                                colors: [
+                                  Colors.white
+                                      .withValues(alpha: 0.16 * glass),
+                                  Colors.white
+                                      .withValues(alpha: 0.06 * glass),
+                                  Colors.white
+                                      .withValues(alpha: 0.02 * glass),
+                                ],
+                                stops: const [0.0, 0.4, 1.0],
+                              )
+                            : null,
+                        border: Border.all(
+                          color: glass > 0.5
+                              ? Colors.white
+                                  .withValues(alpha: 0.12 * glass)
+                              : Colors.black
+                                  .withValues(alpha: 0.28 * t),
+                          width: 1,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(
+                              alpha: 0.32 * (0.35 + 0.65 * glass),
+                            ),
+                            blurRadius:
+                                shadowBlur * (0.45 + 0.55 * glass),
+                            offset: Offset(
+                              0,
+                              shadowOffsetY * (0.25 + 0.75 * glass),
+                            ),
+                          ),
+                          if (glass > 0.05)
+                            BoxShadow(
+                              color: Colors.white.withValues(
+                                alpha: 0.06 * glass,
+                              ),
+                              blurRadius: 1,
+                              offset: const Offset(0, 1),
+                            ),
+                        ],
+                      ),
+                      child: ClipRRect(
+                        borderRadius:
+                            BorderRadius.circular(artInnerRadius),
+                        child: CachedImageWidget(
+                          imagePath: widget.song.albumArt,
+                          audioSourcePath: widget.song.filePath,
+                          fit: BoxFit.cover,
+                          placeholder: Container(
+                            color: Colors.white.withValues(alpha: 0.05),
+                            child: Icon(
+                              LucideIcons.music,
+                              size: iconSize * (1 - t * 0.5),
+                              color:
+                                  Colors.white.withValues(alpha: 0.48),
+                            ),
+                          ),
+                          errorWidget: Container(
+                            color: Colors.white.withValues(alpha: 0.05),
+                            child: Icon(
+                              LucideIcons.music,
+                              size: iconSize * (1 - t * 0.5),
+                              color:
+                                  Colors.white.withValues(alpha: 0.48),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (t > 0.35)
+                      IgnorePointer(
+                        child: Container(
+                          width: resolvedSize * 0.045,
+                          height: resolvedSize * 0.045,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: const Color(0xFF050505)
+                                .withValues(alpha: t),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black
+                                    .withValues(alpha: 0.55 * t),
+                                blurRadius: 2,
+                                offset: const Offset(0, 0.5),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              );
+            },
           ),
         ),
       ),
     );
   }
+}
+
+class _VinylDiscPainter extends CustomPainter {
+  _VinylDiscPainter({required this.labelRatio});
+
+  final double labelRatio;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final outerRadius = size.shortestSide / 2;
+
+    final discPaint = Paint()
+      ..shader = RadialGradient(
+        center: const Alignment(-0.3, -0.3),
+        radius: 0.95,
+        colors: const [Color(0xFF2A2A2A), Color(0xFF0A0A0A)],
+      ).createShader(Rect.fromCircle(center: center, radius: outerRadius));
+    canvas.drawCircle(center, outerRadius, discPaint);
+
+    final groovePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.7
+      ..color = Colors.white.withValues(alpha: 0.06);
+    final labelRadius = outerRadius * labelRatio;
+    const grooves = 16;
+    for (var i = 0; i < grooves; i++) {
+      final t = (i + 1) / (grooves + 1);
+      final r = labelRadius + (outerRadius - labelRadius) * t;
+      canvas.drawCircle(center, r, groovePaint);
+    }
+
+    final highlightPaint = Paint()
+      ..shader = RadialGradient(
+        center: const Alignment(-0.45, -0.45),
+        radius: 0.55,
+        colors: [
+          Colors.white.withValues(alpha: 0.10),
+          Colors.white.withValues(alpha: 0.0),
+        ],
+      ).createShader(Rect.fromCircle(center: center, radius: outerRadius));
+    canvas.drawCircle(center, outerRadius, highlightPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _VinylDiscPainter oldDelegate) =>
+      oldDelegate.labelRatio != labelRatio;
 }
 
 class _VisualizerArtBox extends StatelessWidget {

--- a/lib/features/player/widgets/bit_perfect_indicator.dart
+++ b/lib/features/player/widgets/bit_perfect_indicator.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/models/album_color_mode.dart';
 import 'package:flick/models/audio_output_diagnostics.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
@@ -628,6 +629,12 @@ class _AudioInfoBottomSheet extends ConsumerWidget {
 
   Widget _buildVisualizerPreview(BuildContext context, WidgetRef ref) {
     final prefs = ref.watch(appPreferencesProvider);
+    final colorMode = ref.watch(albumColorModeProvider);
+    final dominantColor = ref.watch(albumDominantColorSyncProvider);
+    final Color? albumColor =
+        (colorMode != AlbumColorMode.off && dominantColor != null)
+        ? dominantColor
+        : null;
 
     return Container(
       height: 100,
@@ -645,6 +652,7 @@ class _AudioInfoBottomSheet extends ConsumerWidget {
               animationStyle: prefs.visualizerAnimationStyle,
               frequencyMode: prefs.visualizerFrequencyMode,
               movementMode: prefs.visualizerMovementMode,
+              albumColor: albumColor,
             ),
           ),
           Positioned(

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -8,7 +10,10 @@ import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/models/playlist.dart';
+import 'package:flick/services/album_art_service.dart';
+import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/providers/playlist_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
@@ -24,10 +29,19 @@ class PlaylistDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
+  static const Color _darkBase = Color(0xFF121212);
+  static const double _backgroundBlend = 0.22;
+  static const double _appBarBlend = 0.30;
+
   final PlayerService _playerService = PlayerService();
   final SongRepository _songRepository = SongRepository();
+  final RecentlyPlayedRepository _recentlyPlayedRepository =
+      RecentlyPlayedRepository();
+  final ColorExtractionService _colorService = ColorExtractionService();
+
   List<Song> _songs = [];
   bool _isLoading = true;
+  Color? _playlistColor;
 
   @override
   void initState() {
@@ -124,6 +138,42 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
         _isLoading = false;
       });
     }
+
+    unawaited(_extractPlaylistColor(playlist.songIds));
+  }
+
+  Future<void> _extractPlaylistColor(List<String> songIds) async {
+    if (songIds.isEmpty) return;
+
+    final mostPlayed = await _recentlyPlayedRepository.getMostPlayedSongAmong(
+      songIds,
+    );
+    final topSong = mostPlayed ??
+        _songs.firstWhere(
+          (s) => s.albumArt != null && s.albumArt!.isNotEmpty,
+          orElse: () => _songs.isEmpty
+              ? throw StateError('empty playlist')
+              : _songs.first,
+        );
+
+    String? source = topSong.albumArt;
+    if (source == null || source.isEmpty) {
+      final sourcePath = topSong.filePath;
+      if (sourcePath == null || sourcePath.isEmpty) return;
+      source = await AlbumArtService.instance.resolveArtworkPath(
+        existingPath: null,
+        audioSourcePath: sourcePath,
+      );
+      if (source == null || !mounted) return;
+    }
+    final color = await _colorService.extractDominantColor(source);
+    if (!mounted || color == null) return;
+    setState(() => _playlistColor = color);
+  }
+
+  Color _tintBackground(double blend) {
+    if (_playlistColor == null) return AppColors.background;
+    return Color.lerp(_darkBase, _playlistColor!, blend)!;
   }
 
   void _playSong(Song song) {
@@ -164,236 +214,260 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     final otherPlaylists = allPlaylists
         .where((p) => p.id != playlist.id)
         .toList();
+    final bgColor = _tintBackground(_backgroundBlend);
 
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      body: CustomScrollView(
-        slivers: [
-          _buildAppBar(context, playlist),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingLg,
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _ActionButton(
-                      icon: LucideIcons.play,
-                      label: 'Play All',
-                      onTap: _playAll,
+    return TweenAnimationBuilder<Color?>(
+      tween: ColorTween(begin: AppColors.background, end: bgColor),
+      duration: AppConstants.animationSlow,
+      curve: Curves.easeOut,
+      builder: (context, animatedBg, _) {
+        final animatedAppBar = _playlistColor == null
+            ? AppColors.surface
+            : Color.lerp(_darkBase, _playlistColor!, _appBarBlend)!;
+        final resolvedBg = animatedBg ?? AppColors.background;
+        return Scaffold(
+          backgroundColor: resolvedBg,
+          body: AdaptiveColorProvider(
+            backgroundColor: resolvedBg,
+            albumDominantColor: _playlistColor,
+            child: CustomScrollView(
+              slivers: [
+                SliverAppBar(
+                  expandedHeight: 280,
+                  pinned: true,
+                  backgroundColor: animatedAppBar,
+                  leading: const SizedBox(),
+                  titleSpacing: 0,
+                  flexibleSpace: FlexibleSpaceBar(
+                    background: _buildAppBarBackground(
+                      context,
+                      playlist,
+                      resolvedBg,
                     ),
                   ),
-                  const SizedBox(width: AppConstants.spacingMd),
-                  Expanded(
-                    child: _ActionButton(
-                      icon: LucideIcons.shuffle,
-                      label: 'Shuffle',
-                      onTap: _shuffleAll,
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppConstants.spacingLg,
+                    ),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: _ActionButton(
+                            icon: LucideIcons.play,
+                            label: 'Play All',
+                            onTap: _playAll,
+                          ),
+                        ),
+                        const SizedBox(width: AppConstants.spacingMd),
+                        Expanded(
+                          child: _ActionButton(
+                            icon: LucideIcons.shuffle,
+                            label: 'Shuffle',
+                            onTap: _shuffleAll,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: AppConstants.spacingLg),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppConstants.spacingLg,
+                    ),
+                    child: Wrap(
+                      spacing: AppConstants.spacingSm,
+                      runSpacing: AppConstants.spacingSm,
+                      children: [
+                        _InfoChip(
+                          icon: LucideIcons.music,
+                          label: '${_songs.length} tracks',
+                        ),
+                        if (_songs.isNotEmpty)
+                          _InfoChip(
+                            icon: LucideIcons.clock,
+                            label: _formattedTotalDuration,
+                          ),
+                        _InfoChip(
+                          icon: LucideIcons.calendar,
+                          label: 'Created ${_formatDate(playlist.createdAt)}',
+                        ),
+                        if (playlist.updatedAt != null &&
+                            playlist.updatedAt != playlist.createdAt)
+                          _InfoChip(
+                            icon: LucideIcons.pencil,
+                            label: 'Updated ${_formatDate(playlist.updatedAt)}',
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: AppConstants.spacingLg),
+                ),
+                if (_isLoading)
+                  SliverFillRemaining(
+                    child: Center(
+                      child: CircularProgressIndicator(
+                        color: context.adaptiveTextSecondary,
+                      ),
+                    ),
+                  )
+                else if (_songs.isEmpty)
+                  SliverFillRemaining(
+                    child: Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            LucideIcons.music,
+                            size: context.responsiveIcon(AppConstants.iconSizeXl),
+                            color: context.adaptiveTextTertiary.withValues(
+                              alpha: 0.5,
+                            ),
+                          ),
+                          const SizedBox(height: AppConstants.spacingMd),
+                          Text(
+                            'No songs in this playlist',
+                            style: Theme.of(context).textTheme.titleMedium
+                                ?.copyWith(color: context.adaptiveTextSecondary),
+                          ),
+                          const SizedBox(height: AppConstants.spacingSm),
+                          Text(
+                            'Add songs from the player menu',
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: context.adaptiveTextTertiary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                else ...[
+                  _buildSectionTitle(context, 'Songs'),
+                  SliverPadding(
+                    padding: EdgeInsets.only(
+                      bottom: AppConstants.navBarHeight + 80,
+                    ),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate((context, index) {
+                        final song = _songs[index];
+                        return _SongTile(
+                          song: song,
+                          onTap: () => _playSong(song),
+                          onRemove: () async {
+                            await ref
+                                .read(playlistsProvider.notifier)
+                                .removeSongFromPlaylist(
+                                  widget.playlist.id,
+                                  song.id,
+                                );
+                            _loadSongs();
+                          },
+                        );
+                      }, childCount: _songs.length),
                     ),
                   ),
                 ],
-              ),
-            ),
-          ),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: AppConstants.spacingLg),
-          ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingLg,
-              ),
-              child: Wrap(
-                spacing: AppConstants.spacingSm,
-                runSpacing: AppConstants.spacingSm,
-                children: [
-                  _InfoChip(
-                    icon: LucideIcons.music,
-                    label: '${_songs.length} tracks',
-                  ),
-                  if (_songs.isNotEmpty)
-                    _InfoChip(
-                      icon: LucideIcons.clock,
-                      label: _formattedTotalDuration,
-                    ),
-                  _InfoChip(
-                    icon: LucideIcons.calendar,
-                    label: 'Created ${_formatDate(playlist.createdAt)}',
-                  ),
-                  if (playlist.updatedAt != null &&
-                      playlist.updatedAt != playlist.createdAt)
-                    _InfoChip(
-                      icon: LucideIcons.pencil,
-                      label: 'Updated ${_formatDate(playlist.updatedAt)}',
-                    ),
-                ],
-              ),
-            ),
-          ),
-          const SliverToBoxAdapter(
-            child: SizedBox(height: AppConstants.spacingLg),
-          ),
-          if (_isLoading)
-            SliverFillRemaining(
-              child: Center(
-                child: CircularProgressIndicator(
-                  color: context.adaptiveTextSecondary,
-                ),
-              ),
-            )
-          else if (_songs.isEmpty)
-            SliverFillRemaining(
-              child: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      LucideIcons.music,
-                      size: context.responsiveIcon(AppConstants.iconSizeXl),
-                      color: context.adaptiveTextTertiary.withValues(
-                        alpha: 0.5,
-                      ),
-                    ),
-                    const SizedBox(height: AppConstants.spacingMd),
-                    Text(
-                      'No songs in this playlist',
-                      style: Theme.of(context).textTheme.titleMedium
-                          ?.copyWith(color: context.adaptiveTextSecondary),
-                    ),
-                    const SizedBox(height: AppConstants.spacingSm),
-                    Text(
-                      'Add songs from the player menu',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: context.adaptiveTextTertiary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            )
-          else ...[
-            _buildSectionTitle(context, 'Songs'),
-            SliverPadding(
-              padding: EdgeInsets.only(
-                bottom: AppConstants.navBarHeight + 80,
-              ),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  final song = _songs[index];
-                  return _SongTile(
-                    song: song,
-                    onTap: () => _playSong(song),
-                    onRemove: () async {
-                      await ref
-                          .read(playlistsProvider.notifier)
-                          .removeSongFromPlaylist(
-                            widget.playlist.id,
-                            song.id,
+                if (otherPlaylists.isNotEmpty) ...[
+                  _buildSectionTitle(context, 'Other Playlists'),
+                  SliverToBoxAdapter(
+                    child: SizedBox(
+                      height: 180,
+                      child: ListView.separated(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppConstants.spacingLg,
+                        ),
+                        scrollDirection: Axis.horizontal,
+                        itemCount: otherPlaylists.length,
+                        separatorBuilder: (_, __) => const SizedBox(
+                          width: AppConstants.spacingMd,
+                        ),
+                        itemBuilder: (context, index) {
+                          final other = otherPlaylists[index];
+                          return _PlaylistCard(
+                            playlist: other,
+                            onTap: () => _openPlaylist(other),
                           );
-                      _loadSongs();
-                    },
-                  );
-                }, childCount: _songs.length),
-              ),
-            ),
-          ],
-          if (otherPlaylists.isNotEmpty) ...[
-            _buildSectionTitle(context, 'Other Playlists'),
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: 180,
-                child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingLg,
+                        },
+                      ),
+                    ),
                   ),
-                  scrollDirection: Axis.horizontal,
-                  itemCount: otherPlaylists.length,
-                  separatorBuilder: (_, __) => const SizedBox(
-                    width: AppConstants.spacingMd,
+                  const SliverToBoxAdapter(
+                    child: SizedBox(height: AppConstants.navBarHeight + 120),
                   ),
-                  itemBuilder: (context, index) {
-                    final other = otherPlaylists[index];
-                    return _PlaylistCard(
-                      playlist: other,
-                      onTap: () => _openPlaylist(other),
-                    );
-                  },
-                ),
-              ),
+                ],
+              ],
             ),
-            const SliverToBoxAdapter(
-              child: SizedBox(height: AppConstants.navBarHeight + 120),
-            ),
-          ],
-        ],
-      ),
+          ),
+        );
+      },
     );
   }
 
-  Widget _buildAppBar(BuildContext context, Playlist playlist) {
-    return SliverAppBar(
-      expandedHeight: 280,
-      pinned: true,
-      backgroundColor: AppColors.surface,
-      leading: const SizedBox(),
-      titleSpacing: 0,
-      flexibleSpace: FlexibleSpaceBar(
-        background: Stack(
-          fit: StackFit.expand,
-          children: [
-            _buildCollageBackground(),
-            Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.transparent,
-                    AppColors.background.withValues(alpha: 0.8),
-                    AppColors.background,
-                  ],
-                ),
-              ),
+  Widget _buildAppBarBackground(
+    BuildContext context,
+    Playlist playlist,
+    Color fadeTo,
+  ) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildCollageBackground(),
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                Colors.transparent,
+                fadeTo.withValues(alpha: 0.8),
+                fadeTo,
+              ],
             ),
-            Positioned(
-              top: MediaQuery.of(context).padding.top + 20,
-              left: 16,
-              child: IconButton(
-                icon: Icon(
-                  LucideIcons.arrowLeft,
-                  color: context.adaptiveTextPrimary,
-                ),
-                onPressed: () => Navigator.of(context).pop(),
-              ),
-            ),
-            Positioned(
-              left: AppConstants.spacingLg,
-              right: AppConstants.spacingLg,
-              bottom: AppConstants.spacingLg,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    playlist.name,
-                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      color: context.adaptiveTextPrimary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${_songs.length} songs${_songs.isNotEmpty ? ' • $_formattedTotalDuration' : ''}',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: context.adaptiveTextSecondary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+          ),
         ),
-      ),
+        Positioned(
+          top: MediaQuery.of(context).padding.top + 20,
+          left: 16,
+          child: IconButton(
+            icon: Icon(
+              LucideIcons.arrowLeft,
+              color: context.adaptiveTextPrimary,
+            ),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+        Positioned(
+          left: AppConstants.spacingLg,
+          right: AppConstants.spacingLg,
+          bottom: AppConstants.spacingLg,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                playlist.name,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${_songs.length} songs${_songs.isNotEmpty ? ' • $_formattedTotalDuration' : ''}',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextSecondary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -12,7 +12,6 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/providers/playlist_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
-import 'package:flick/widgets/common/display_mode_wrapper.dart';
 
 class PlaylistDetailScreen extends ConsumerStatefulWidget {
   final Playlist playlist;
@@ -40,6 +39,60 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
 
   Playlist get _currentPlaylist {
     return ref.watch(playlistProvider(widget.playlist.id)) ?? widget.playlist;
+  }
+
+  Duration get _totalDuration {
+    var total = Duration.zero;
+    for (final song in _songs) {
+      total += song.duration;
+    }
+    return total;
+  }
+
+  String get _formattedTotalDuration {
+    final hours = _totalDuration.inHours;
+    final minutes = _totalDuration.inMinutes.remainder(60);
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    }
+    return '${minutes}m';
+  }
+
+  String? _getArt(List<Song> songs) {
+    for (final song in songs) {
+      if (song.albumArt != null && song.albumArt!.isNotEmpty) {
+        return song.albumArt;
+      }
+    }
+    return null;
+  }
+
+  String? _getSourcePath(List<Song> songs) {
+    for (final song in songs) {
+      if (song.filePath != null && song.filePath!.isNotEmpty) {
+        return song.filePath;
+      }
+    }
+    return null;
+  }
+
+  String _formatDate(DateTime? date) {
+    if (date == null) return '';
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return '${months[date.month - 1]} ${date.day}, ${date.year}';
   }
 
   Future<void> _loadSongs() async {
@@ -73,277 +126,422 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     }
   }
 
+  void _playSong(Song song) {
+    if (_songs.isEmpty) return;
+    _playerService.play(song, playlist: _songs);
+    NavigationHelper.navigateToFullPlayer(
+      context,
+      heroTag: 'playlist_song_${song.id}',
+    );
+  }
+
+  void _playAll() {
+    if (_songs.isEmpty) return;
+    _playerService.play(_songs.first, playlist: _songs);
+    NavigationHelper.navigateToFullPlayer(context, heroTag: 'playlist_play_all');
+  }
+
+  void _shuffleAll() {
+    if (_songs.isEmpty) return;
+    final shuffled = List<Song>.from(_songs)..shuffle();
+    _playerService.play(shuffled.first, playlist: shuffled);
+    NavigationHelper.navigateToFullPlayer(context, heroTag: 'playlist_shuffle');
+  }
+
+  void _openPlaylist(Playlist playlist) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => PlaylistDetailScreen(playlist: playlist),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final playlist = _currentPlaylist;
+    final allPlaylists =
+        ref.watch(playlistsProvider).value?.playlists ?? const <Playlist>[];
+    final otherPlaylists = allPlaylists
+        .where((p) => p.id != playlist.id)
+        .toList();
 
-    return DisplayModeWrapper(
-      child: Scaffold(
-        backgroundColor: AppColors.background,
-        body: CustomScrollView(
-          slivers: [
-            SliverAppBar(
-              expandedHeight: 280,
-              pinned: true,
-              backgroundColor: AppColors.surface,
-              leading: Container(
-                margin: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                ),
-                child: IconButton(
-                  icon: Icon(
-                    LucideIcons.arrowLeft,
-                    color: context.adaptiveTextPrimary,
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: CustomScrollView(
+        slivers: [
+          _buildAppBar(context, playlist),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppConstants.spacingLg,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _ActionButton(
+                      icon: LucideIcons.play,
+                      label: 'Play All',
+                      onTap: _playAll,
+                    ),
                   ),
-                  onPressed: () => Navigator.of(context).pop(),
+                  const SizedBox(width: AppConstants.spacingMd),
+                  Expanded(
+                    child: _ActionButton(
+                      icon: LucideIcons.shuffle,
+                      label: 'Shuffle',
+                      onTap: _shuffleAll,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SliverToBoxAdapter(
+            child: SizedBox(height: AppConstants.spacingLg),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppConstants.spacingLg,
+              ),
+              child: Wrap(
+                spacing: AppConstants.spacingSm,
+                runSpacing: AppConstants.spacingSm,
+                children: [
+                  _InfoChip(
+                    icon: LucideIcons.music,
+                    label: '${_songs.length} tracks',
+                  ),
+                  if (_songs.isNotEmpty)
+                    _InfoChip(
+                      icon: LucideIcons.clock,
+                      label: _formattedTotalDuration,
+                    ),
+                  _InfoChip(
+                    icon: LucideIcons.calendar,
+                    label: 'Created ${_formatDate(playlist.createdAt)}',
+                  ),
+                  if (playlist.updatedAt != null &&
+                      playlist.updatedAt != playlist.createdAt)
+                    _InfoChip(
+                      icon: LucideIcons.pencil,
+                      label: 'Updated ${_formatDate(playlist.updatedAt)}',
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const SliverToBoxAdapter(
+            child: SizedBox(height: AppConstants.spacingLg),
+          ),
+          if (_isLoading)
+            SliverFillRemaining(
+              child: Center(
+                child: CircularProgressIndicator(
+                  color: context.adaptiveTextSecondary,
                 ),
               ),
-              flexibleSpace: FlexibleSpaceBar(
-                background: Stack(
-                  fit: StackFit.expand,
+            )
+          else if (_songs.isEmpty)
+            SliverFillRemaining(
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Container(color: AppColors.surface),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            Colors.transparent,
-                            AppColors.background.withValues(alpha: 0.9),
-                            AppColors.background,
-                          ],
-                        ),
+                    Icon(
+                      LucideIcons.music,
+                      size: context.responsiveIcon(AppConstants.iconSizeXl),
+                      color: context.adaptiveTextTertiary.withValues(
+                        alpha: 0.5,
                       ),
                     ),
-                    Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const SizedBox(height: 40),
-                          _buildPlaylistCover(),
-                          const SizedBox(height: AppConstants.spacingMd),
-                          Text(
-                            playlist.name,
-                            style: Theme.of(context).textTheme.headlineSmall
-                                ?.copyWith(
-                                  color: context.adaptiveTextPrimary,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            '${_songs.length} songs',
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(
-                                  color: context.adaptiveTextSecondary,
-                                ),
-                          ),
-                        ],
+                    const SizedBox(height: AppConstants.spacingMd),
+                    Text(
+                      'No songs in this playlist',
+                      style: Theme.of(context).textTheme.titleMedium
+                          ?.copyWith(color: context.adaptiveTextSecondary),
+                    ),
+                    const SizedBox(height: AppConstants.spacingSm),
+                    Text(
+                      'Add songs from the player menu',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.adaptiveTextTertiary,
                       ),
                     ),
                   ],
                 ),
               ),
-              actions: [
-                Container(
-                  margin: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: AppColors.glassBackground,
-                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                  ),
-                  child: IconButton(
-                    icon: Icon(
-                      LucideIcons.shuffle,
-                      color: context.adaptiveTextPrimary,
-                    ),
-                    onPressed: () {
-                      if (_songs.isNotEmpty) {
-                        final shuffled = List<Song>.from(_songs)..shuffle();
-                        _playerService.play(shuffled.first, playlist: shuffled);
-                      }
-                    },
-                  ),
-                ),
-              ],
-            ),
-            if (_isLoading)
-              SliverFillRemaining(
-                child: Center(
-                  child: CircularProgressIndicator(
-                    color: context.adaptiveTextSecondary,
-                  ),
-                ),
-              )
-            else if (_songs.isEmpty)
-              SliverFillRemaining(
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        LucideIcons.music,
-                        size: context.responsiveIcon(AppConstants.iconSizeXl),
-                        color: context.adaptiveTextTertiary.withValues(
-                          alpha: 0.5,
-                        ),
-                      ),
-                      const SizedBox(height: AppConstants.spacingMd),
-                      Text(
-                        'No songs in this playlist',
-                        style: Theme.of(context).textTheme.titleMedium
-                            ?.copyWith(color: context.adaptiveTextSecondary),
-                      ),
-                      const SizedBox(height: AppConstants.spacingSm),
-                      Text(
-                        'Add songs from the player menu',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: context.adaptiveTextTertiary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              )
-            else
-              SliverPadding(
-                padding: EdgeInsets.only(
-                  bottom: AppConstants.navBarHeight + 120,
-                ),
-                sliver: SliverList(
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    final song = _songs[index];
-                    return _SongTile(
-                      song: song,
-                      onTap: () async {
-                        await _playerService.play(song, playlist: _songs);
-                        if (context.mounted) {
-                          await NavigationHelper.navigateToFullPlayer(
-                            context,
-                            heroTag: 'playlist_song_${song.id}',
+            )
+          else ...[
+            _buildSectionTitle(context, 'Songs'),
+            SliverPadding(
+              padding: EdgeInsets.only(
+                bottom: AppConstants.navBarHeight + 80,
+              ),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  final song = _songs[index];
+                  return _SongTile(
+                    song: song,
+                    onTap: () => _playSong(song),
+                    onRemove: () async {
+                      await ref
+                          .read(playlistsProvider.notifier)
+                          .removeSongFromPlaylist(
+                            widget.playlist.id,
+                            song.id,
                           );
-                        }
-                      },
-                      onRemove: () async {
-                        await ref
-                            .read(playlistsProvider.notifier)
-                            .removeSongFromPlaylist(
-                              widget.playlist.id,
-                              song.id,
-                            );
-                        _loadSongs();
-                      },
+                      _loadSongs();
+                    },
+                  );
+                }, childCount: _songs.length),
+              ),
+            ),
+          ],
+          if (otherPlaylists.isNotEmpty) ...[
+            _buildSectionTitle(context, 'Other Playlists'),
+            SliverToBoxAdapter(
+              child: SizedBox(
+                height: 180,
+                child: ListView.separated(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppConstants.spacingLg,
+                  ),
+                  scrollDirection: Axis.horizontal,
+                  itemCount: otherPlaylists.length,
+                  separatorBuilder: (_, __) => const SizedBox(
+                    width: AppConstants.spacingMd,
+                  ),
+                  itemBuilder: (context, index) {
+                    final other = otherPlaylists[index];
+                    return _PlaylistCard(
+                      playlist: other,
+                      onTap: () => _openPlaylist(other),
                     );
-                  }, childCount: _songs.length),
+                  },
                 ),
               ),
+            ),
+            const SliverToBoxAdapter(
+              child: SizedBox(height: AppConstants.navBarHeight + 120),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAppBar(BuildContext context, Playlist playlist) {
+    return SliverAppBar(
+      expandedHeight: 280,
+      pinned: true,
+      backgroundColor: AppColors.surface,
+      leading: const SizedBox(),
+      titleSpacing: 0,
+      flexibleSpace: FlexibleSpaceBar(
+        background: Stack(
+          fit: StackFit.expand,
+          children: [
+            _buildCollageBackground(),
+            Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.transparent,
+                    AppColors.background.withValues(alpha: 0.8),
+                    AppColors.background,
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              top: MediaQuery.of(context).padding.top + 20,
+              left: 16,
+              child: IconButton(
+                icon: Icon(
+                  LucideIcons.arrowLeft,
+                  color: context.adaptiveTextPrimary,
+                ),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ),
+            Positioned(
+              left: AppConstants.spacingLg,
+              right: AppConstants.spacingLg,
+              bottom: AppConstants.spacingLg,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    playlist.name,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      color: context.adaptiveTextPrimary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${_songs.length} songs${_songs.isNotEmpty ? ' • $_formattedTotalDuration' : ''}',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildPlaylistCover() {
-    return FutureBuilder<List<Song>>(
-      future: _getFirstFourSongs(),
-      builder: (context, snapshot) {
-        final songs = snapshot.data ?? [];
-        return Container(
-          width: 120,
-          height: 120,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-            border: Border.all(color: AppColors.glassBorder, width: 3),
-          ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg - 2),
-            child: songs.isEmpty
-                ? Container(
-                    color: AppColors.surfaceLight,
-                    child: Icon(
-                      LucideIcons.music,
-                      size: 48,
-                      color: context.adaptiveTextTertiary,
-                    ),
-                  )
-                : Column(
-                    children: [
-                      Expanded(
-                        child: Row(
-                          children: [
-                            _buildCoverImage(songs, 0),
-                            _buildCoverImage(songs, 1),
-                          ],
-                        ),
-                      ),
-                      Expanded(
-                        child: Row(
-                          children: [
-                            _buildCoverImage(songs, 2),
-                            _buildCoverImage(songs, 3),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-          ),
-        );
-      },
-    );
-  }
+  Widget _buildCollageBackground() {
+    if (_songs.isEmpty) {
+      return Container(
+        color: AppColors.surface,
+        child: Icon(
+          LucideIcons.listMusic,
+          size: 80,
+          color: context.adaptiveTextTertiary,
+        ),
+      );
+    }
 
-  Widget _buildCoverImage(List<Song> songs, int index) {
-    if (index < songs.length) {
-      return Expanded(
-        child: CachedImageWidget(
-          imagePath: songs[index].albumArt,
-          audioSourcePath: songs[index].filePath,
-          fit: BoxFit.cover,
-          errorWidget: Container(
-            color: AppColors.surfaceLight,
-            child: Icon(
-              LucideIcons.music,
-              color: context.adaptiveTextTertiary,
-              size: 20,
-            ),
+    final firstArt = _getArt(_songs);
+    final firstSource = _getSourcePath(_songs);
+    if (firstArt != null) {
+      return CachedImageWidget(
+        imagePath: firstArt,
+        audioSourcePath: firstSource,
+        fit: BoxFit.cover,
+        placeholder: Container(
+          color: AppColors.surface,
+          child: Icon(
+            LucideIcons.listMusic,
+            size: 80,
+            color: context.adaptiveTextTertiary,
           ),
-          placeholder: Container(
-            color: AppColors.surfaceLight,
-            child: Icon(
-              LucideIcons.music,
-              color: context.adaptiveTextTertiary,
-              size: 20,
-            ),
+        ),
+        errorWidget: Container(
+          color: AppColors.surface,
+          child: Icon(
+            LucideIcons.listMusic,
+            size: 80,
+            color: context.adaptiveTextTertiary,
           ),
         ),
       );
     }
-    return Expanded(
-      child: Container(
-        color: AppColors.surfaceLight,
-        child: Icon(
-          LucideIcons.music,
-          color: context.adaptiveTextTertiary,
-          size: 20,
-        ),
+
+    return Container(
+      color: AppColors.surface,
+      child: Icon(
+        LucideIcons.listMusic,
+        size: 80,
+        color: context.adaptiveTextTertiary,
       ),
     );
   }
 
-  Future<List<Song>> _getFirstFourSongs() async {
-    final playlist = _currentPlaylist;
-    if (playlist.songIds.isEmpty) return [];
+  Widget _buildSectionTitle(BuildContext context, String title) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppConstants.spacingLg,
+          0,
+          AppConstants.spacingLg,
+          AppConstants.spacingSm,
+        ),
+        child: Text(
+          title,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            color: context.adaptiveTextSecondary,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}
 
-    final allSongs = await _songRepository.getAllSongs();
-    final firstFourIds = playlist.songIds.take(4).toList();
-    return allSongs.where((song) => firstFourIds.contains(song.id)).toList()
-      ..sort((a, b) {
-        final indexA = firstFourIds.indexOf(a.id);
-        final indexB = firstFourIds.indexOf(b.id);
-        return indexA.compareTo(indexB);
-      });
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.glassBackgroundStrong,
+      borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: AppConstants.spacingMd),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: context.adaptiveTextPrimary, size: 18),
+              const SizedBox(width: AppConstants.spacingSm),
+              Text(
+                label,
+                style: TextStyle(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _InfoChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingMd,
+        vertical: AppConstants.spacingSm,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackgroundStrong,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: context.adaptiveTextSecondary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: context.adaptiveTextSecondary,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -372,8 +570,8 @@ class _SongTile extends StatelessWidget {
           child: Row(
             children: [
               Container(
-                width: 48,
-                height: 48,
+                width: context.scaleSize(AppConstants.containerSizeMd),
+                height: context.scaleSize(AppConstants.containerSizeMd),
                 decoration: BoxDecoration(
                   color: AppColors.glassBackground,
                   borderRadius: BorderRadius.circular(AppConstants.radiusSm),
@@ -387,12 +585,12 @@ class _SongTile extends StatelessWidget {
                     placeholder: Icon(
                       LucideIcons.music,
                       color: context.adaptiveTextTertiary,
-                      size: 20,
+                      size: context.responsiveIcon(AppConstants.iconSizeMd),
                     ),
                     errorWidget: Icon(
                       LucideIcons.music,
                       color: context.adaptiveTextTertiary,
-                      size: 20,
+                      size: context.responsiveIcon(AppConstants.iconSizeMd),
                     ),
                   ),
                 ),
@@ -422,34 +620,11 @@ class _SongTile extends StatelessWidget {
                   ],
                 ),
               ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Text(
-                    song.formattedDuration,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: context.adaptiveTextTertiary,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 6,
-                      vertical: 2,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColors.glassBackground,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                    child: Text(
-                      song.fileType.toUpperCase(),
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: context.adaptiveTextTertiary,
-                        fontSize: 10,
-                      ),
-                    ),
-                  ),
-                ],
+              Text(
+                song.formattedDuration,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
               ),
               const SizedBox(width: 8),
               PopupMenuButton<String>(
@@ -482,6 +657,63 @@ class _SongTile extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlaylistCard extends StatelessWidget {
+  final Playlist playlist;
+  final VoidCallback onTap;
+
+  const _PlaylistCard({required this.playlist, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: 150,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AspectRatio(
+              aspectRatio: 1,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: AppColors.surfaceLight,
+                  borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+                  child: Icon(
+                    LucideIcons.listMusic,
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingSm),
+            Text(
+              playlist.name,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            const SizedBox(height: 2),
+            Text(
+              '${playlist.songIds.length} songs',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextTertiary,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1061,9 +1061,10 @@ class PlayerService {
       final dsdMode = Uac2PreferencesService.dsdOutputModeSync;
       if (dsdMode == DsdOutputMode.native || dsdMode == DsdOutputMode.auto) {
         final rawRate = song.sampleRate ?? 2822400;
+        final byteRate = rawRate ~/ 8;
         return Uac2AudioFormat(
-          sampleRate: rawRate,
-          bitDepth: 24,
+          sampleRate: byteRate,
+          bitDepth: 8,
           channels: 2,
           isDop: false,
           isNativeDsd: true,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "staticlib"]
 
 [features]
-default = ["native_audio"]
+default = ["native_audio", "uac2"]
 # Enable native audio engine (now enabled on Android with CPAL/Oboe)
 native_audio = ["cpal", "symphonia", "rubato", "ringbuf", "crossbeam-channel", "wavpack-sys"]
 # Custom UAC 2.0 USB Audio (host-side DAC/AMP support)

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -86,14 +86,15 @@ pub fn effective_dsd_output_mode_for_rate(
 
     #[cfg(target_os = "android")]
     {
-        if crate::audio::device::current_device_profile()
-            .as_ref()
-            .is_some_and(|p| p.supports_native_dsd)
-        {
+        let profile = crate::audio::device::current_device_profile();
+        let is_dap = profile.as_ref().is_some_and(|p| p.is_dap());
+        let supports_dsd = profile.as_ref().is_some_and(|p| p.supports_native_dsd);
+        if supports_dsd || is_dap {
             log_info!(
-                "[AUDIO] {:?} DSD requested; device supports ENCODING_DSD, \
+                "[AUDIO] {:?} DSD requested; device {} ENCODING_DSD, \
                  using Android DSD AudioTrack",
-                requested
+                requested,
+                if supports_dsd { "supports" } else { "is DAP, assuming" }
             );
             return DsdOutputMode::Native;
         }
@@ -242,11 +243,6 @@ fn resolve_dsd_engine_sample_rate(path: &PathBuf, output_mode: DsdOutputMode) ->
     let dsd_rate = DsdRate::from_sample_rate(decoder.sample_rate())
         .ok_or_else(|| format!("Unsupported DSD sample rate: {}", decoder.sample_rate()))?;
     if effective_mode == DsdOutputMode::Native {
-        let decoder = open_dsd_decoder(path)
-            .map_err(|e| format!("Failed to probe DSD rate for {}: {}", path.display(), e))?;
-        let dsd_rate = DsdRate::from_sample_rate(decoder.sample_rate())
-            .ok_or_else(|| format!("Unsupported DSD sample rate: {}", decoder.sample_rate()))?;
-
         #[cfg(target_os = "android")]
         {
             let use_audio_track = current_device_profile()
@@ -258,17 +254,35 @@ fn resolve_dsd_engine_sample_rate(path: &PathBuf, output_mode: DsdOutputMode) ->
                     #[cfg(not(feature = "uac2"))]
                     { false }
                 };
+            let frame_rate = dsd_rate.byte_rate();
             if use_audio_track {
-                let byte_rate = dsd_rate.byte_rate();
                 log_info!(
-                    "[AUDIO] DSD Native AudioTrack: dsd_rate={} Hz -> byte_rate={} Hz",
-                    dsd_rate.sample_rate(), byte_rate
+                    "[AUDIO] DSD Native AudioTrack: dsd_rate={} Hz -> frame_rate={} Hz",
+                    dsd_rate.sample_rate(), frame_rate
                 );
-                return resolve_requested_output_sample_rate(Some(byte_rate));
+                return resolve_requested_output_sample_rate(Some(frame_rate));
+            }
+            #[cfg(feature = "uac2")]
+            {
+                if crate::uac2::is_usb_session_active() {
+                    log_info!(
+                        "[AUDIO] DSD Native USB: dsd_rate={} Hz -> frame_rate={} Hz",
+                        dsd_rate.sample_rate(), frame_rate
+                    );
+                    return resolve_requested_output_sample_rate(Some(frame_rate));
+                }
             }
         }
 
-        return resolve_requested_output_sample_rate(Some(dsd_rate.sample_rate()));
+        #[cfg(not(target_os = "android"))]
+        {
+            return resolve_requested_output_sample_rate(Some(dsd_rate.byte_rate()));
+        }
+
+        #[cfg(target_os = "android")]
+        {
+            return resolve_requested_output_sample_rate(Some(dsd_rate.byte_rate()));
+        }
     }
     let existing_rate = read_audio_engine(|handle| handle.sample_rate()).unwrap_or(0);
     let target = resolve_dsd_pcm_sample_rate(dsd_rate, existing_rate);
@@ -292,27 +306,7 @@ fn verify_dsd_engine_rate(
     let dsd_rate = DsdRate::from_sample_rate(decoder.sample_rate())
         .ok_or_else(|| format!("Unsupported DSD sample rate: {}", decoder.sample_rate()))?;
     let required_rate = match mode {
-        DsdOutputMode::Native => {
-            #[cfg(target_os = "android")]
-            {
-                let use_audio_track = current_device_profile()
-                    .as_ref()
-                    .is_some_and(|p| p.supports_native_dsd)
-                    && !{
-                        #[cfg(feature = "uac2")]
-                        { crate::uac2::is_usb_session_active() }
-                        #[cfg(not(feature = "uac2"))]
-                        { false }
-                    };
-                if use_audio_track {
-                    dsd_rate.byte_rate()
-                } else {
-                    dsd_rate.sample_rate()
-                }
-            }
-            #[cfg(not(target_os = "android"))]
-            { dsd_rate.sample_rate() }
-        }
+        DsdOutputMode::Native => dsd_rate.byte_rate(),
         DsdOutputMode::Dop => dsd_rate.dop_carrier_rate(),
         _ => return Ok(()),
     };
@@ -625,6 +619,14 @@ pub fn audio_set_dap_bit_perfect_enabled(enabled: bool) {
 #[flutter_rust_bridge::frb(sync)]
 pub fn audio_set_dsd_output_mode(mode: u8) {
     DSD_OUTPUT_MODE.store(mode.min(3), Ordering::Relaxed);
+}
+
+/// Toggle DSD bit-reverse override. When on, inverts the bit-order normalization
+/// so that MSB-first sources get reversed and LSB-first sources pass through.
+/// Use this to diagnose white-noise from wrong bit order.
+#[flutter_rust_bridge::frb(sync)]
+pub fn audio_set_dsd_bit_reverse_override(enabled: bool) {
+    crate::audio::dsd_engine::output::set_dsd_bit_reverse_override(enabled);
 }
 
 /// Update the current platform capability snapshot used for engine selection.

--- a/rust/src/audio/device.rs
+++ b/rust/src/audio/device.rs
@@ -225,7 +225,7 @@ pub fn classify_device(signals: DeviceSignals) -> DeviceProfile {
         kind,
         max_sample_rate: signals.audio_caps.max_sample_rate,
         has_balanced_output: signals.audio_caps.has_balanced_output,
-        supports_native_dsd: native_dsd_from_caps || native_dsd_from_runtime,
+        supports_native_dsd: is_dap || native_dsd_from_caps || native_dsd_from_runtime,
     }
 }
 

--- a/rust/src/audio/dsd_engine/dsd/dop.rs
+++ b/rust/src/audio/dsd_engine/dsd/dop.rs
@@ -38,8 +38,6 @@ impl DopPacker {
     ) {
         output.clear();
 
-        let bits = self.bits_per_frame() as usize;
-        let dsd_data_bits = bits - 8;
         let bytes_per_channel = dsd_bytes.len() / self.channels.max(1);
         let num_frames = bytes_per_channel / self.dsd_bytes_per_ch.max(1);
 
@@ -51,20 +49,58 @@ impl DopPacker {
                     .unwrap_or(ch * bytes_per_channel);
                 let frame_byte_offset = ch_base + frame_index * self.dsd_bytes_per_ch;
 
-                let mut sample: u32 = (self.marker_state as u32) << dsd_data_bits;
-
-                for byte_idx in 0..self.dsd_bytes_per_ch {
-                    let read_pos = frame_byte_offset + byte_idx;
-                    if read_pos < dsd_bytes.len() {
-                        let shift = dsd_data_bits - 8 * (byte_idx + 1);
-                        sample |= (dsd_bytes[read_pos] as u32) << shift;
-                    }
-                }
+                let sample = self.build_dop_word(dsd_bytes, frame_byte_offset);
 
                 output.push(f32::from_bits(sample));
             }
             self.advance_marker();
         }
+    }
+
+    /// Pack DoP frames into i32 samples for integer audio output (AAudio I32).
+    /// Each sample is a left-justified 24-bit DoP word in a 32-bit container:
+    /// bits 31:24 = marker, bits 23:8 = DSD data, bits 7:0 = zero.
+    pub fn pack_to_i32(
+        &mut self,
+        dsd_bytes: &[u8],
+        channel_offsets: &[usize],
+        output: &mut Vec<i32>,
+    ) {
+        output.clear();
+
+        let bytes_per_channel = dsd_bytes.len() / self.channels.max(1);
+        let num_frames = bytes_per_channel / self.dsd_bytes_per_ch.max(1);
+
+        for frame_index in 0..num_frames {
+            for ch in 0..self.channels {
+                let ch_base = channel_offsets
+                    .get(ch)
+                    .copied()
+                    .unwrap_or(ch * bytes_per_channel);
+                let frame_byte_offset = ch_base + frame_index * self.dsd_bytes_per_ch;
+
+                let word = self.build_dop_word(dsd_bytes, frame_byte_offset);
+
+                output.push(word as i32);
+            }
+            self.advance_marker();
+        }
+    }
+
+    fn build_dop_word(&self, dsd_bytes: &[u8], frame_byte_offset: usize) -> u32 {
+        let bits = self.bits_per_frame() as usize;
+        let dsd_data_bits = bits - 8;
+        let mut sample: u32 = (self.marker_state as u32) << dsd_data_bits;
+
+        for byte_idx in 0..self.dsd_bytes_per_ch {
+            let read_pos = frame_byte_offset + byte_idx;
+            if read_pos < dsd_bytes.len() {
+                let shift = dsd_data_bits - 8 * (byte_idx + 1);
+                sample |= (dsd_bytes[read_pos] as u32) << shift;
+            }
+        }
+
+        sample << (32 - bits)
     }
 
     fn advance_marker(&mut self) {

--- a/rust/src/audio/dsd_engine/dsd_thread.rs
+++ b/rust/src/audio/dsd_engine/dsd_thread.rs
@@ -1,5 +1,5 @@
 use crate::audio::dsd_engine::dsd::{DsdOutputMode, DsdRate};
-use crate::audio::dsd_engine::format::{open_dsd_decoder, DsdChannelLayout, DsdFormatDecoder};
+use crate::audio::dsd_engine::format::{open_dsd_decoder, DsdBitOrder, DsdChannelLayout, DsdFormatDecoder};
 use crate::audio::dsd_engine::output::DsdOutputRouter;
 use crate::audio::source::{AudioSource, SourceInfo, SourceProducer};
 use anyhow::{anyhow, Result};
@@ -41,6 +41,7 @@ impl DsdDecoderThread {
         let source_channels = decoder.channels() as usize;
         let duration_secs = decoder.duration_secs();
         let channel_layout = decoder.channel_layout();
+        let source_bit_order = decoder.bit_order();
 
         let output_sample_rate = match output_mode {
             DsdOutputMode::PcmDecimation | DsdOutputMode::Auto => dsd_rate.best_pcm_target(target_rate),
@@ -80,7 +81,7 @@ impl DsdDecoderThread {
         }
 
         let output_router =
-            DsdOutputRouter::new(output_mode, dsd_rate, output_sample_rate, source_channels);
+            DsdOutputRouter::new(output_mode, dsd_rate, output_sample_rate, source_channels, source_bit_order);
 
         let stop_signal = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop_signal);
@@ -97,6 +98,7 @@ impl DsdDecoderThread {
                     stop_clone,
                     start_position_secs,
                     channel_layout,
+                    source_bit_order,
                 )
             })
             .map_err(|e| anyhow!("Failed to spawn DSD decoder thread: {}", e))?;
@@ -161,6 +163,7 @@ fn dsd_decode_thread(
     stop_signal: Arc<AtomicBool>,
     start_position_secs: Option<f64>,
     channel_layout: DsdChannelLayout,
+    _source_bit_order: DsdBitOrder,
 ) -> Result<()> {
     if let Some(pos) = start_position_secs {
         if pos > 0.0 {
@@ -184,10 +187,11 @@ fn dsd_decode_thread(
     let mut output_buf: Vec<f32> = Vec::with_capacity(DSD_READ_CHUNK_SIZE);
 
     log::info!(
-        "[DSD-DECODER] Starting: dsd_rate={} channels={} layout={:?}",
+        "[DSD-DECODER] Starting: dsd_rate={} channels={} layout={:?} bit_order={:?}",
         decoder.sample_rate(),
         source_channels,
         channel_layout,
+        _source_bit_order,
     );
 
     loop {

--- a/rust/src/audio/dsd_engine/format/dff_decoder.rs
+++ b/rust/src/audio/dsd_engine/format/dff_decoder.rs
@@ -1,4 +1,4 @@
-use super::{DsdChannelLayout, DsdFormatDecoder};
+use super::{DsdBitOrder, DsdChannelLayout, DsdFormatDecoder};
 use anyhow::{anyhow, Result};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -108,5 +108,9 @@ impl DsdFormatDecoder for DffDecoder {
 
     fn channel_layout(&self) -> DsdChannelLayout {
         DsdChannelLayout::Interleaved
+    }
+
+    fn bit_order(&self) -> DsdBitOrder {
+        DsdBitOrder::MsbFirst
     }
 }

--- a/rust/src/audio/dsd_engine/format/dsf_decoder.rs
+++ b/rust/src/audio/dsd_engine/format/dsf_decoder.rs
@@ -1,4 +1,4 @@
-use super::{DsdChannelLayout, DsdFormatDecoder};
+use super::{DsdBitOrder, DsdChannelLayout, DsdFormatDecoder};
 use anyhow::{anyhow, Result};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
@@ -135,5 +135,9 @@ impl DsdFormatDecoder for DsfDecoder {
         DsdChannelLayout::SequentialBlocks {
             block_size: self.block_size as usize,
         }
+    }
+
+    fn bit_order(&self) -> DsdBitOrder {
+        DsdBitOrder::LsbFirst
     }
 }

--- a/rust/src/audio/dsd_engine/format/mod.rs
+++ b/rust/src/audio/dsd_engine/format/mod.rs
@@ -5,10 +5,16 @@ pub mod wavpack_decoder;
 use anyhow::Result;
 use std::path::Path;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DsdChannelLayout {
     SequentialBlocks { block_size: usize },
     Interleaved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DsdBitOrder {
+    LsbFirst,
+    MsbFirst,
 }
 
 pub trait DsdFormatDecoder: Send {
@@ -20,6 +26,7 @@ pub trait DsdFormatDecoder: Send {
     fn read_dsd_bytes(&mut self, buf: &mut [u8]) -> Result<usize>;
     fn is_finished(&self) -> bool;
     fn channel_layout(&self) -> DsdChannelLayout;
+    fn bit_order(&self) -> DsdBitOrder;
 }
 
 pub fn open_dsd_decoder(path: &Path) -> Result<Box<dyn DsdFormatDecoder>> {

--- a/rust/src/audio/dsd_engine/format/wavpack_decoder.rs
+++ b/rust/src/audio/dsd_engine/format/wavpack_decoder.rs
@@ -1,4 +1,4 @@
-use super::{DsdChannelLayout, DsdFormatDecoder};
+use super::{DsdBitOrder, DsdChannelLayout, DsdFormatDecoder};
 use crate::audio::dsd_engine::dsd::DsdRate;
 use anyhow::{anyhow, Result};
 use std::ffi::CString;
@@ -141,6 +141,10 @@ impl DsdFormatDecoder for WavpackDsdDecoder {
 
     fn channel_layout(&self) -> DsdChannelLayout {
         DsdChannelLayout::Interleaved
+    }
+
+    fn bit_order(&self) -> DsdBitOrder {
+        DsdBitOrder::MsbFirst
     }
 }
 

--- a/rust/src/audio/dsd_engine/output/mod.rs
+++ b/rust/src/audio/dsd_engine/output/mod.rs
@@ -1,10 +1,27 @@
 use super::dsd::dop::DopPacker;
 use super::dsd::DsdDecimationPipeline;
 use super::dsd::{DsdOutputMode, DsdRate};
+use super::format::DsdBitOrder;
 use anyhow::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static DSD_BIT_REVERSE_OVERRIDE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_dsd_bit_reverse_override(enabled: bool) {
+    DSD_BIT_REVERSE_OVERRIDE.store(enabled, Ordering::Relaxed);
+    log::info!(
+        "[DSD-FORMATTER] Bit-reverse override: {}",
+        if enabled { "FORCED ON" } else { "auto (off)" }
+    );
+}
+
+pub fn dsd_bit_reverse_override() -> bool {
+    DSD_BIT_REVERSE_OVERRIDE.load(Ordering::Relaxed)
+}
 
 pub struct DsdOutputRouter {
     mode: DsdOutputMode,
+    source_bit_order: DsdBitOrder,
     pcm_pipeline: Option<DsdDecimationPipeline>,
     dop_packer: Option<DopPacker>,
 }
@@ -15,6 +32,7 @@ impl DsdOutputRouter {
         dsd_rate: DsdRate,
         target_rate: u32,
         channels: usize,
+        source_bit_order: DsdBitOrder,
     ) -> Self {
         let pcm_pipeline = match mode {
             DsdOutputMode::PcmDecimation | DsdOutputMode::Auto => {
@@ -30,6 +48,7 @@ impl DsdOutputRouter {
 
         Self {
             mode,
+            source_bit_order,
             pcm_pipeline,
             dop_packer,
         }
@@ -69,7 +88,7 @@ impl DsdOutputRouter {
                 }
             }
             DsdOutputMode::Native => {
-                pack_native_dsd_f32(dsd_bytes, channel_offsets, output);
+                pack_native_dsd_f32(dsd_bytes, channel_offsets, self.source_bit_order, output);
             }
         }
         Ok(())
@@ -85,9 +104,29 @@ impl DsdOutputRouter {
     }
 }
 
+#[inline]
+fn reverse_bits(b: u8) -> u8 {
+    b.reverse_bits()
+}
+
+fn normalize_dsd_byte(byte: u8, source_order: DsdBitOrder) -> u8 {
+    let needs_reverse = match source_order {
+        DsdBitOrder::LsbFirst => true,
+        DsdBitOrder::MsbFirst => false,
+    };
+    if DSD_BIT_REVERSE_OVERRIDE.load(Ordering::Relaxed) {
+        if needs_reverse { byte } else { reverse_bits(byte) }
+    } else if needs_reverse {
+        reverse_bits(byte)
+    } else {
+        byte
+    }
+}
+
 fn pack_native_dsd_f32(
     dsd_bytes: &[u8],
     channel_offsets: &[usize],
+    source_bit_order: DsdBitOrder,
     output: &mut Vec<f32>,
 ) {
     let channels = channel_offsets.len().max(1);
@@ -97,7 +136,8 @@ fn pack_native_dsd_f32(
     if channels == 1 {
         output.reserve(dsd_bytes.len());
         for &b in dsd_bytes {
-            output.push(f32::from_bits(b as u32));
+            let normalized = normalize_dsd_byte(b, source_bit_order);
+            output.push(f32::from_bits(normalized as u32));
         }
         return;
     }
@@ -108,7 +148,8 @@ fn pack_native_dsd_f32(
         for ch in 0..channels {
             let ch_offset = channel_offsets.get(ch).copied().unwrap_or(ch * bytes_per_ch);
             let b = dsd_bytes[ch_offset + i];
-            output.push(f32::from_bits(b as u32));
+            let normalized = normalize_dsd_byte(b, source_bit_order);
+            output.push(f32::from_bits(normalized as u32));
         }
     }
 }

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -1121,7 +1121,11 @@ pub fn create_audio_engine(
                 if verification.bit_perfect {
                     final_sample_rate = actual_sample_rate;
                     callback_data.reconfigure_sample_rate(final_sample_rate);
-                    callback_data.set_pipeline_mode(PipelineMode::Passthrough);
+                    if desired_strategy == OutputStrategy::UsbDsdNative {
+                        callback_data.set_pipeline_mode(PipelineMode::Dop);
+                    } else {
+                        callback_data.set_pipeline_mode(PipelineMode::Passthrough);
+                    }
                     output_runtime = build_output_runtime_state(
                         desired_strategy,
                         verification,

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -808,17 +808,38 @@ fn build_output_runtime_state(
     let (dsd_wire_rate, dsd_transport) = if dsd_source_rate.is_some() {
         let wire_rate = verification.actual_rate;
         let transport = match strategy {
-            OutputStrategy::DsdNative => {
-                if direct_usb_active { "uac2-type3" } else { "dap-native-encoding" }
+            OutputStrategy::DsdNative => "dap-native-encoding".to_string(),
+            OutputStrategy::UsbDsdNative => {
+                #[cfg(feature = "uac2")]
+                {
+                    let debug = crate::uac2::android_direct_debug_state();
+                    let subslot = debug.transport_subslot_size.unwrap_or(4);
+                    format!(
+                        "usb-native-dsd-u{}x{}-bit",
+                        subslot, subslot * 8
+                    )
+                }
+                #[cfg(not(feature = "uac2"))]
+                "usb-native-dsd".to_string()
             }
-            OutputStrategy::UsbDsdNative => "uac2-type3",
             OutputStrategy::DsdDoP => {
-                if direct_usb_active { "uac2-dop" } else { "dap-native" }
+                if direct_usb_active {
+                    #[cfg(feature = "uac2")]
+                    {
+                        let debug = crate::uac2::android_direct_debug_state();
+                        let bits = debug.transport_bit_resolution.unwrap_or(24);
+                        format!("usb-dop-{}-bit", bits)
+                    }
+                    #[cfg(not(feature = "uac2"))]
+                    "usb-dop".to_string()
+                } else {
+                    "dap-dop".to_string()
+                }
             }
-            OutputStrategy::UsbDirect => "uac2-pcm",
-            _ => "dap-native",
+            OutputStrategy::UsbDirect => "usb-pcm".to_string(),
+            _ => "pcm".to_string(),
         };
-        (Some(wire_rate), Some(transport.to_string()))
+        (Some(wire_rate), Some(transport))
     } else {
         (None, None)
     };
@@ -842,9 +863,32 @@ fn build_output_runtime_state(
 }
 
 #[cfg(target_os = "android")]
+enum AndroidManagedStreamKind {
+    F32(AudioStreamAsync<Output, AndroidOutputCallbackF32>),
+    I32(AudioStreamAsync<Output, AndroidOutputCallbackI32>),
+}
+
+#[cfg(target_os = "android")]
 struct AndroidManagedStream {
-    stream: AudioStreamAsync<Output, AndroidOutputCallbackState>,
+    kind: AndroidManagedStreamKind,
     actual_sample_rate: u32,
+}
+
+#[cfg(target_os = "android")]
+impl AndroidManagedStream {
+    fn start(&mut self) -> Result<(), oboe::Error> {
+        match &mut self.kind {
+            AndroidManagedStreamKind::F32(s) => s.start(),
+            AndroidManagedStreamKind::I32(s) => s.start(),
+        }
+    }
+
+    fn stop(&mut self) -> Result<(), oboe::Error> {
+        match &mut self.kind {
+            AndroidManagedStreamKind::F32(s) => s.stop(),
+            AndroidManagedStreamKind::I32(s) => s.stop(),
+        }
+    }
 }
 
 #[cfg(target_os = "android")]
@@ -920,6 +964,37 @@ pub fn create_audio_engine(
         } else {
             TrackInfo::pcm(requested_sample_rate, ANDROID_DIRECT_CHANNELS)
         };
+        #[cfg(feature = "uac2")]
+        let usb_dsd_native_available = {
+            let debug = android_direct_debug_state();
+            debug.available_alt_settings.iter().any(|alt| {
+                alt.format_tag == "DSD"
+                    && alt.subslot_size > 0
+                    && dsd_rate.is_some_and(|r| {
+                        r.sample_rate() / (8 * u32::from(alt.subslot_size)) <= alt.sample_rates.iter().copied().max().unwrap_or(0)
+                            || alt.sample_rates.iter().any(|&sr| {
+                                sr == r.sample_rate() / (8 * u32::from(alt.subslot_size))
+                            })
+                    })
+            })
+        };
+        #[cfg(not(feature = "uac2"))]
+        let usb_dsd_native_available = false;
+
+        #[cfg(feature = "uac2")]
+        let (usb_dop_available, usb_max_carrier) = {
+            let debug = android_direct_debug_state();
+            let carrier = dsd_rate.map(|r| r.dop_carrier_rate()).unwrap_or(0);
+            let has_pcm_24bit = debug.available_alt_settings.iter().any(|alt| {
+                alt.format_tag == "PCM"
+                    && alt.bit_resolution >= 24
+                    && alt.sample_rates.iter().any(|&sr| sr == carrier)
+            });
+            (has_pcm_24bit, if has_pcm_24bit { carrier } else { 0 })
+        };
+        #[cfg(not(feature = "uac2"))]
+        let (usb_dop_available, usb_max_carrier) = (false, 0u32);
+
         select_strategy_excluded(
             &track_info,
             &DeviceCaps {
@@ -927,7 +1002,9 @@ pub fn create_audio_engine(
                 confirmed_dap_native,
                 direct_usb_available: true,
                 direct_usb_verified: true,
-                usb_supports_native_dsd: dsd_rate.is_some(),
+                usb_supports_native_dsd: usb_dsd_native_available,
+                supports_dop: usb_dop_available,
+                max_dsd_carrier_rate: usb_max_carrier,
                 ..DeviceCaps::default()
             },
             &excluded_strategies,
@@ -956,9 +1033,9 @@ pub fn create_audio_engine(
     // Override the sample rate for DSD strategies: the DSD Native
     // backend needs the byte rate (e.g. 705 600 Hz for DSD128),
     // DSD DoP needs the carrier rate (e.g. 352 800 Hz for DSD128),
-    // and USB DSD Native needs the byte rate as the USB wire clock.
+    // and USB DSD Native needs the wire rate (e.g. 88 200 Hz for DSD64).
     match desired_strategy {
-        OutputStrategy::DsdNative | OutputStrategy::UsbDsdNative => {
+        OutputStrategy::DsdNative => {
             if let Some(rate) = dsd_rate {
                 let byte_rate = rate.byte_rate();
                 log::info!(
@@ -968,6 +1045,18 @@ pub fn create_audio_engine(
                     byte_rate,
                 );
                 requested_sample_rate = byte_rate;
+            }
+        }
+        OutputStrategy::UsbDsdNative => {
+            if let Some(rate) = dsd_rate {
+                let wire_rate = rate.sample_rate() / 32; // DSD_U32 wire rate
+                log::info!(
+                    "[ENGINE] {:?}: overriding rate {} -> {} Hz (wire_rate, DSD_U32)",
+                    desired_strategy,
+                    requested_sample_rate,
+                    wire_rate,
+                );
+                requested_sample_rate = wire_rate;
             }
         }
         OutputStrategy::DsdDoP => {
@@ -1092,11 +1181,18 @@ pub fn create_audio_engine(
         android_output_signature_for_strategy(desired_strategy, requested_sample_rate);
 
     #[cfg(feature = "uac2")]
-    if desired_strategy == OutputStrategy::UsbDirect || desired_strategy == OutputStrategy::UsbDsdNative {
+    if desired_strategy == OutputStrategy::UsbDirect
+        || desired_strategy == OutputStrategy::UsbDsdNative
+        || desired_strategy == OutputStrategy::DsdDoP
+    {
         if desired_strategy == OutputStrategy::UsbDsdNative {
             if let Some(rate) = dsd_rate {
-                let byte_rate = rate.byte_rate();
-                let _ = crate::uac2::set_android_usb_dsd_native_mode(byte_rate, 32);
+                let _ = crate::uac2::set_android_usb_dsd_native_mode(rate.sample_rate());
+            }
+        } else if desired_strategy == OutputStrategy::DsdDoP {
+            if let Some(rate) = dsd_rate {
+                let carrier = rate.dop_carrier_rate();
+                let _ = crate::uac2::set_android_usb_dop_mode(true, carrier, 24);
             }
         }
         match create_android_usb_backend(
@@ -1121,7 +1217,9 @@ pub fn create_audio_engine(
                 if verification.bit_perfect {
                     final_sample_rate = actual_sample_rate;
                     callback_data.reconfigure_sample_rate(final_sample_rate);
-                    if desired_strategy == OutputStrategy::UsbDsdNative {
+                    if desired_strategy == OutputStrategy::UsbDsdNative
+                        || desired_strategy == OutputStrategy::DsdDoP
+                    {
                         callback_data.set_pipeline_mode(PipelineMode::Dop);
                     } else {
                         callback_data.set_pipeline_mode(PipelineMode::Passthrough);
@@ -1254,11 +1352,17 @@ pub fn create_audio_engine(
         let prefer_exclusive = dap_bit_perfect_enabled
             && device_profile.as_ref().is_some_and(|p| p.is_dap())
             && !will_attempt_usb;
+        let is_dsd_dop = dsd_rate.is_some() && matches!(
+            desired_shared_strategy,
+            OutputStrategy::DsdDoP
+        );
+        let use_integer = is_dsd_dop || desired_shared_strategy.is_dsd();
         let managed = open_android_output_stream(
             Arc::clone(&callback_data_clone),
             event_tx_clone.clone(),
             requested_sample_rate,
             prefer_exclusive,
+            use_integer,
         )?;
         let verification = OutputVerification::verify(
             requested_sample_rate,
@@ -1274,10 +1378,6 @@ pub fn create_audio_engine(
         } else {
             callback_data.set_pipeline_mode(PipelineMode::Dsp);
         }
-        let is_dsd_dop = dsd_rate.is_some() && matches!(
-            desired_shared_strategy,
-            OutputStrategy::DsdDoP
-        );
         if is_dsd_dop {
             callback_data.set_pipeline_mode(PipelineMode::Dop);
         }
@@ -1349,7 +1449,7 @@ pub fn create_audio_engine(
             let _ = dsd_native_backend;
 
             let mut stream = match managed_stream.take() {
-                Some(stream) => stream.stream,
+                Some(stream) => stream,
                 None => {
                     let _ = event_tx.try_send(AudioEvent::Error {
                         message: "No Android managed output stream was prepared".to_string(),
@@ -1401,14 +1501,14 @@ pub fn create_audio_engine(
 }
 
 #[cfg(target_os = "android")]
-struct AndroidOutputCallbackState {
+struct AndroidOutputCallbackF32 {
     callback_data: Arc<AudioCallbackData>,
     event_tx: Sender<AudioEvent>,
     scratch: Vec<f32>,
 }
 
 #[cfg(target_os = "android")]
-impl AndroidOutputCallbackState {
+impl AndroidOutputCallbackF32 {
     fn new(callback_data: Arc<AudioCallbackData>, event_tx: Sender<AudioEvent>) -> Self {
         Self {
             callback_data,
@@ -1419,7 +1519,7 @@ impl AndroidOutputCallbackState {
 }
 
 #[cfg(target_os = "android")]
-impl AudioOutputCallback for AndroidOutputCallbackState {
+impl AudioOutputCallback for AndroidOutputCallbackF32 {
     type FrameType = (f32, Stereo);
 
     fn on_error_before_close(
@@ -1480,12 +1580,99 @@ impl AudioOutputCallback for AndroidOutputCallbackState {
     }
 }
 
+/// Integer callback for DoP / native DSD transport over AAudio I32.
+/// Reads f32 samples from the decoder pipeline, extracts the raw bit
+/// patterns (which carry DoP markers / DSD bytes), and writes them as
+/// i32 to the AAudio HAL. No gain, format conversion, or DSP is applied.
+#[cfg(target_os = "android")]
+struct AndroidOutputCallbackI32 {
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    scratch: Vec<f32>,
+}
+
+#[cfg(target_os = "android")]
+impl AndroidOutputCallbackI32 {
+    fn new(callback_data: Arc<AudioCallbackData>, event_tx: Sender<AudioEvent>) -> Self {
+        Self {
+            callback_data,
+            event_tx,
+            scratch: vec![0.0; ANDROID_DIRECT_SCRATCH_SAMPLES],
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+impl AudioOutputCallback for AndroidOutputCallbackI32 {
+    type FrameType = (i32, Stereo);
+
+    fn on_error_before_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        eprintln!(
+            "Android managed i32 output error before close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        eprintln!(
+            "Android managed i32 output error after close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+    }
+
+    fn on_audio_ready(
+        &mut self,
+        _audio_stream: &mut dyn AudioOutputStreamSafe,
+        audio_data: &mut [(i32, i32)],
+    ) -> DataCallbackResult {
+        let required_samples = audio_data.len() * ANDROID_DIRECT_CHANNELS;
+
+        if required_samples > self.scratch.len() {
+            eprintln!(
+                "[oboe-i32] burst {} frames > scratch {} frames — growing scratch",
+                audio_data.len(),
+                self.scratch.len() / ANDROID_DIRECT_CHANNELS,
+            );
+            self.scratch.resize(required_samples, 0.0);
+        }
+
+        let scratch = &mut self.scratch[..required_samples];
+        audio_callback(scratch, &self.callback_data, &self.event_tx);
+
+        for (frame_index, frame) in audio_data.iter_mut().enumerate() {
+            let sample_index = frame_index * ANDROID_DIRECT_CHANNELS;
+            let l = scratch[sample_index].to_bits() as i32;
+            let r = scratch[sample_index + 1].to_bits() as i32;
+            *frame = (l, r);
+        }
+
+        DataCallbackResult::Continue
+    }
+}
+
 #[cfg(target_os = "android")]
 fn open_android_output_stream(
     callback_data: Arc<AudioCallbackData>,
     event_tx: Sender<AudioEvent>,
     target_sample_rate: u32,
     prefer_exclusive: bool,
+    use_integer_format: bool,
 ) -> Result<AndroidManagedStream, String> {
     let selected_device = select_android_output_device(target_sample_rate)?;
     let is_bluetooth = matches!(
@@ -1520,44 +1707,41 @@ fn open_android_output_stream(
     };
 
     let mut last_error = None;
-    let mut fallback_stream = None;
+    let mut fallback_kind = None;
+    let mut fallback_rate = 0u32;
 
     for &sharing_mode in sharing_modes {
         for &audio_api in attempts {
-            let mut builder = oboe::AudioStreamBuilder::default()
-                .set_stereo()
-                .set_f32()
-                .set_sample_rate(target_sample_rate as i32)
-                .set_frames_per_callback(frames_per_callback)
-                .set_sharing_mode(sharing_mode)
-                .set_performance_mode(performance_mode)
-                .set_usage(Usage::Media)
-                .set_content_type(ContentType::Music)
-                .set_channel_conversion_allowed(!bit_perfect_route)
-                .set_format_conversion_allowed(!bit_perfect_route)
-                .set_sample_rate_conversion_quality(
-                    if bit_perfect_route {
-                        SampleRateConversionQuality::None
-                    } else {
-                        SampleRateConversionQuality::Medium
-                    }
-                )
-                .set_audio_api(audio_api);
+            let result: Result<AndroidManagedStreamKind, String> = if use_integer_format {
+                let builder = oboe::AudioStreamBuilder::default()
+                    .set_stereo()
+                    .set_format::<i32>()
+                    .set_sample_rate(target_sample_rate as i32)
+                    .set_frames_per_callback(frames_per_callback)
+                    .set_sharing_mode(sharing_mode)
+                    .set_performance_mode(performance_mode)
+                    .set_usage(Usage::Media)
+                    .set_content_type(ContentType::Music)
+                    .set_channel_conversion_allowed(false)
+                    .set_format_conversion_allowed(false)
+                    .set_sample_rate_conversion_quality(SampleRateConversionQuality::None)
+                    .set_audio_api(audio_api);
 
-            if bit_perfect_route {
-                builder = builder.set_device_id(selected_device.id);
-            }
+                let builder = if bit_perfect_route {
+                    builder.set_device_id(selected_device.id)
+                } else {
+                    builder
+                };
 
-            let stream = match builder
-                .set_callback(AndroidOutputCallbackState::new(
-                    Arc::clone(&callback_data),
-                    event_tx.clone(),
-                ))
-                .open_stream()
-            {
-                Ok(stream) => stream,
-                Err(error) => {
-                    last_error = Some(format!(
+                match builder
+                    .set_callback(AndroidOutputCallbackI32::new(
+                        Arc::clone(&callback_data),
+                        event_tx.clone(),
+                    ))
+                    .open_stream()
+                {
+                    Ok(stream) => Ok(AndroidManagedStreamKind::I32(stream)),
+                    Err(error) => Err(format!(
                         "{} {} open failed on '{}' (id {}, type {:?}): {}",
                         audio_api_label(audio_api),
                         sharing_label(sharing_mode),
@@ -1565,57 +1749,120 @@ fn open_android_output_stream(
                         selected_device.id,
                         selected_device.device_type,
                         error
-                    ));
-                    continue;
+                    )),
+                }
+            } else {
+                let mut builder = oboe::AudioStreamBuilder::default()
+                    .set_stereo()
+                    .set_f32()
+                    .set_sample_rate(target_sample_rate as i32)
+                    .set_frames_per_callback(frames_per_callback)
+                    .set_sharing_mode(sharing_mode)
+                    .set_performance_mode(performance_mode)
+                    .set_usage(Usage::Media)
+                    .set_content_type(ContentType::Music)
+                    .set_channel_conversion_allowed(!bit_perfect_route)
+                    .set_format_conversion_allowed(!bit_perfect_route)
+                    .set_sample_rate_conversion_quality(
+                        if bit_perfect_route {
+                            SampleRateConversionQuality::None
+                        } else {
+                            SampleRateConversionQuality::Medium
+                        }
+                    )
+                    .set_audio_api(audio_api);
+
+                if bit_perfect_route {
+                    builder = builder.set_device_id(selected_device.id);
+                }
+
+                match builder
+                    .set_callback(AndroidOutputCallbackF32::new(
+                        Arc::clone(&callback_data),
+                        event_tx.clone(),
+                    ))
+                    .open_stream()
+                {
+                    Ok(stream) => Ok(AndroidManagedStreamKind::F32(stream)),
+                    Err(error) => Err(format!(
+                        "{} {} open failed on '{}' (id {}, type {:?}): {}",
+                        audio_api_label(audio_api),
+                        sharing_label(sharing_mode),
+                        selected_device.product_name,
+                        selected_device.id,
+                        selected_device.device_type,
+                        error
+                    )),
                 }
             };
 
-            let actual_rate = stream.get_sample_rate();
-            let actual_api = stream.get_audio_api();
-            let actual_sharing = stream.get_sharing_mode();
-            let actual_format = stream.get_format();
-            let actual_channels = stream.get_channel_count();
+            match result {
+                Ok(kind) => {
+                    let (actual_rate, actual_api, actual_sharing, actual_format, actual_channels) =
+                        match &kind {
+                            AndroidManagedStreamKind::F32(s) => (
+                                s.get_sample_rate(),
+                                s.get_audio_api(),
+                                s.get_sharing_mode(),
+                                s.get_format(),
+                                s.get_channel_count(),
+                            ),
+                            AndroidManagedStreamKind::I32(s) => (
+                                s.get_sample_rate(),
+                                s.get_audio_api(),
+                                s.get_sharing_mode(),
+                                s.get_format(),
+                                s.get_channel_count(),
+                            ),
+                        };
 
-            eprintln!(
-                "Android managed output opened '{}' (id {}, type {:?}) requested {} Hz -> actual {} Hz, api {:?}, sharing {:?}, format {:?}, channels {:?}",
-                selected_device.product_name,
-                selected_device.id,
-                selected_device.device_type,
-                target_sample_rate,
-                actual_rate,
-                actual_api,
-                actual_sharing,
-                actual_format,
-                actual_channels,
-            );
+                    eprintln!(
+                        "Android managed output opened '{}' (id {}, type {:?}) requested {} Hz -> actual {} Hz, api {:?}, sharing {:?}, format {:?}, channels {:?}",
+                        selected_device.product_name,
+                        selected_device.id,
+                        selected_device.device_type,
+                        target_sample_rate,
+                        actual_rate,
+                        actual_api,
+                        actual_sharing,
+                        actual_format,
+                        actual_channels,
+                    );
 
-            if bit_perfect_route && actual_rate != target_sample_rate as i32 {
-                last_error = Some(format!(
-                    "{} {} opened '{}' at {} Hz instead of requested {} Hz",
-                    audio_api_label(audio_api),
-                    sharing_label(sharing_mode),
-                    selected_device.product_name,
-                    actual_rate,
-                    target_sample_rate,
-                ));
-                if fallback_stream.is_none() {
-                    fallback_stream = Some(AndroidManagedStream {
-                        stream,
+                    if bit_perfect_route && actual_rate != target_sample_rate as i32 {
+                        last_error = Some(format!(
+                            "{} {} opened '{}' at {} Hz instead of requested {} Hz",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            actual_rate,
+                            target_sample_rate,
+                        ));
+                        if fallback_kind.is_none() {
+                            fallback_kind = Some(kind);
+                            fallback_rate = actual_rate.max(1) as u32;
+                        }
+                        continue;
+                    }
+
+                    return Ok(AndroidManagedStream {
+                        kind,
                         actual_sample_rate: actual_rate.max(1) as u32,
                     });
                 }
-                continue;
+                Err(error) => {
+                    last_error = Some(error);
+                    continue;
+                }
             }
-
-            return Ok(AndroidManagedStream {
-                stream,
-                actual_sample_rate: actual_rate.max(1) as u32,
-            });
         }
     }
 
-    if let Some(stream) = fallback_stream {
-        return Ok(stream);
+    if let Some(kind) = fallback_kind {
+        return Ok(AndroidManagedStream {
+            kind,
+            actual_sample_rate: fallback_rate.max(1),
+        });
     }
 
     Err(last_error.unwrap_or_else(|| {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -200,6 +200,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDirectU
             channels: channels as u16,
             is_dop: is_dop != 0,
             dsd_transport,
+            dsd_bit_rate: 0,
         })
     };
 

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -110,6 +110,23 @@ struct DacQuirk {
     prefer_padded_24bit_transport: bool,
 }
 
+/// DSD-specific quirk for UAC2 DACs where the descriptors may be
+/// ambiguous or missing. Mirrors Linux `sound/usb/quirks.c` approach.
+#[derive(Debug, Clone, Copy)]
+struct DsdQuirk {
+    vendor_id: u16,
+    product_id: u16,
+    product_name_contains: &'static str,
+    /// Expected subslot_size for native DSD (1=U8, 2=U16, 4=U32).
+    preferred_subslot: u8,
+    /// Byte order on the wire for DSD_U32: true = BE (most common, XMOS-style),
+    /// false = LE.
+    big_endian: bool,
+    /// Per-byte bit reversal (some DACs reverse bit order within each byte),
+    /// independent of the DSF-LSB→MSB normalization in the decoder pipeline.
+    bit_reverse: bool,
+}
+
 const KNOWN_DAC_QUIRKS: &[DacQuirk] = &[DacQuirk {
     vendor_id: 12230,
     product_id: 61546,
@@ -118,6 +135,34 @@ const KNOWN_DAC_QUIRKS: &[DacQuirk] = &[DacQuirk {
     settle_delay_ms: 50,
     prefer_padded_24bit_transport: true,
 }];
+
+const KNOWN_DSD_QUIRKS: &[DsdQuirk] = &[
+    // MOONDROP Dawn Pro: dual CS43131, likely DSD_U32_BE (XMOS-style bridge).
+    DsdQuirk {
+        vendor_id: 12230,
+        product_id: 61546,
+        product_name_contains: "MOONDROP Dawn Pro",
+        preferred_subslot: 4,
+        big_endian: true,
+        bit_reverse: false,
+    },
+];
+
+fn lookup_dsd_quirk(
+    vendor_id: u16,
+    product_id: u16,
+    product_name: &str,
+) -> Option<&'static DsdQuirk> {
+    for quirk in KNOWN_DSD_QUIRKS {
+        if quirk.vendor_id == vendor_id
+            && quirk.product_id == product_id
+            && product_name.contains(quirk.product_name_contains)
+        {
+            return Some(quirk);
+        }
+    }
+    None
+}
 
 fn lookup_dac_quirk(
     vendor_id: u16,
@@ -233,6 +278,10 @@ pub struct AndroidDirectUsbPlaybackFormat {
     pub channels: u16,
     pub is_dop: bool,
     pub dsd_transport: DsdTransportMode,
+    /// DSD 1-bit sample rate (e.g. 2_822_400 for DSD64). Set only when
+    /// dsd_transport == Native. The wire rate is computed as
+    /// `dsd_bit_rate / (8 * subslot_size)` after the alt-setting is chosen.
+    pub dsd_bit_rate: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -432,22 +481,22 @@ struct AndroidDirectUsbCapabilityModel {
 }
 
 #[derive(Debug, Clone, Serialize)]
-struct AndroidDirectUsbAltCapability {
-    interface_number: u8,
-    alt_setting: u8,
-    endpoint_address: u8,
-    endpoint_interval: u8,
-    service_interval_us: u32,
-    max_packet_bytes: usize,
-    format_tag: String,
-    channels: u16,
-    subslot_size: u8,
-    bit_resolution: u8,
-    sample_rates: Vec<u32>,
-    sync_type: String,
-    usage_type: String,
-    refresh: u8,
-    synch_address: u8,
+pub struct AndroidDirectUsbAltCapability {
+    pub interface_number: u8,
+    pub alt_setting: u8,
+    pub endpoint_address: u8,
+    pub endpoint_interval: u8,
+    pub service_interval_us: u32,
+    pub max_packet_bytes: usize,
+    pub format_tag: String,
+    pub channels: u16,
+    pub subslot_size: u8,
+    pub bit_resolution: u8,
+    pub sample_rates: Vec<u32>,
+    pub sync_type: String,
+    pub usage_type: String,
+    pub refresh: u8,
+    pub synch_address: u8,
 }
 
 #[derive(Debug)]
@@ -1058,6 +1107,7 @@ pub fn set_android_usb_dop_mode(
         channels: 2,
         is_dop: false,
         dsd_transport: DsdTransportMode::None,
+        dsd_bit_rate: 0,
     });
 
     let transport = if is_dop {
@@ -1071,6 +1121,7 @@ pub fn set_android_usb_dop_mode(
         channels: current.channels,
         is_dop,
         dsd_transport: transport,
+        dsd_bit_rate: 0,
     };
     let sanitized = sanitize_android_usb_playback_format(dop_format);
 
@@ -1084,28 +1135,30 @@ pub fn set_android_usb_dop_mode(
 }
 
 pub fn set_android_usb_dsd_native_mode(
-    byte_rate: u32,
-    bit_depth: u8,
+    dsd_bit_rate: u32,
 ) -> Result<(), String> {
     let mut guard = DIRECT_USB_STATE.lock();
     let Some(state) = guard.as_mut() else {
         return Err("No Android direct USB DAC is registered".to_string());
     };
 
+    let wire_rate = dsd_bit_rate / (8 * 4); // DSD_U32 default wire rate
     let current = state.playback_format.unwrap_or(AndroidDirectUsbPlaybackFormat {
-        sample_rate: byte_rate,
-        bit_depth,
+        sample_rate: wire_rate,
+        bit_depth: 1,
         channels: 2,
         is_dop: false,
         dsd_transport: DsdTransportMode::None,
+        dsd_bit_rate: 0,
     });
 
     let native_format = AndroidDirectUsbPlaybackFormat {
-        sample_rate: byte_rate,
-        bit_depth: if bit_depth > 0 { bit_depth } else { current.bit_depth },
+        sample_rate: wire_rate,
+        bit_depth: 1,
         channels: current.channels,
         is_dop: false,
         dsd_transport: DsdTransportMode::Native,
+        dsd_bit_rate,
     };
     let sanitized = sanitize_android_usb_playback_format(native_format);
 
@@ -1808,6 +1861,7 @@ fn sanitize_android_usb_playback_format(
         channels: playback_format.channels.max(1),
         is_dop: playback_format.is_dop,
         dsd_transport: playback_format.dsd_transport,
+        dsd_bit_rate: playback_format.dsd_bit_rate,
     }
 }
 
@@ -4026,6 +4080,7 @@ fn prepare_iso_transfer_payload(
     channels: usize,
     bytes_per_frame: usize,
     dsd_transport: DsdTransportMode,
+    dsd_big_endian: bool,
 ) -> Result<Option<IsoTransferPayload>, String> {
     let packet_sizes = scheduler.next_transfer_packet_bytes();
     let total_bytes: usize = packet_sizes.iter().sum();
@@ -4053,7 +4108,11 @@ fn prepare_iso_transfer_payload(
         ));
     }
 
-    let total_samples = total_bytes / slot_bytes;
+    let total_samples = if dsd_transport == DsdTransportMode::Native {
+        total_bytes
+    } else {
+        total_bytes / slot_bytes
+    };
     let mut packet_samples = vec![0i32; total_samples];
     let underrun = {
         let mut guard = pcm_buffer.lock();
@@ -4071,6 +4130,8 @@ fn prepare_iso_transfer_payload(
         candidate.subslot_size,
         candidate.bit_resolution,
         dsd_transport,
+        candidate.channels,
+        dsd_big_endian,
     )?;
 
     Ok(Some(IsoTransferPayload {
@@ -4265,6 +4326,13 @@ fn run_usb_output_loop(
         claimed_interfaces,
     } = claimed_handle;
     let playback_format = state.playback_format.unwrap();
+    let dsd_big_endian = lookup_dsd_quirk(
+        state.device.vendor_id,
+        state.device.product_id,
+        &state.device.product_name,
+    )
+    .map(|q| q.big_endian)
+    .unwrap_or(false);
     let slot_bytes = candidate.subslot_size as usize;
     if slot_bytes == 0 {
         let message = "Android USB direct selected an invalid zero-byte subslot".to_string();
@@ -4381,6 +4449,7 @@ fn run_usb_output_loop(
                 channels,
                 bytes_per_frame,
                 playback_format.dsd_transport,
+                dsd_big_endian,
             ) {
                 Ok(Some(payload)) => payload,
                 Ok(None) => continue,
@@ -4501,6 +4570,7 @@ fn run_usb_output_loop(
                     channels,
                     bytes_per_frame,
                     playback_format.dsd_transport,
+                    dsd_big_endian,
                 ) {
                     Ok(Some(payload)) => {
                         record_prepared_iso_transfer(
@@ -4771,12 +4841,29 @@ fn select_stream_candidate(
                 .clone();
             let sample_rates = representative_sample_rates_from_ranges(&sample_rate_ranges);
 
+            let effective_sample_rate = if playback_format.dsd_transport == DsdTransportMode::Native
+                && stream_format.format_tag == FORMAT_TAG_DSD
+                && playback_format.dsd_bit_rate > 0
+                && stream_format.subslot_size > 0
+            {
+                playback_format.dsd_bit_rate / (8 * u32::from(stream_format.subslot_size))
+            } else {
+                playback_format.sample_rate
+            };
+
             if !sample_rate_ranges.is_empty()
                 && stream_format.format_tag != FORMAT_TAG_DSD
                 && !sampling_frequency_ranges_support_rate(
                     &sample_rate_ranges,
-                    playback_format.sample_rate,
+                    effective_sample_rate,
                 )
+            {
+                continue;
+            }
+
+            if stream_format.format_tag == FORMAT_TAG_DSD
+                && !sample_rate_ranges.is_empty()
+                && !sampling_frequency_ranges_support_rate(&sample_rate_ranges, effective_sample_rate)
             {
                 continue;
             }
@@ -4815,7 +4902,7 @@ fn select_stream_candidate(
                 let bytes_per_frame =
                     stream_format.subslot_size as usize * stream_format.channels as usize;
                 let required_max_packet_bytes = required_max_packet_bytes(
-                    playback_format.sample_rate,
+                    effective_sample_rate,
                     service_interval_us,
                     bytes_per_frame,
                 );
@@ -4877,9 +4964,16 @@ fn select_stream_candidate(
         }
     }
 
+    let dsd_bit_rate = playback_format.dsd_bit_rate;
+    let is_native_dsd = playback_format.dsd_transport == DsdTransportMode::Native;
     candidates.sort_by_key(|candidate| {
+        let candidate_rate = if is_native_dsd && dsd_bit_rate > 0 {
+            dsd_bit_rate / (8 * u32::from(candidate.subslot_size.max(1)))
+        } else {
+            playback_format.sample_rate
+        };
         let required_bytes = required_max_packet_bytes(
-            playback_format.sample_rate,
+            candidate_rate,
             candidate.service_interval_us,
             candidate.subslot_size as usize * candidate.channels as usize,
         );
@@ -4896,10 +4990,19 @@ fn select_stream_candidate(
         )
     });
 
+    let label_rate = if is_native_dsd && dsd_bit_rate > 0 {
+        format!(
+            "DSD{}@{}Hz",
+            dsd_bit_rate,
+            dsd_bit_rate / 32
+        )
+    } else {
+        format!("{} Hz", playback_format.sample_rate)
+    };
     candidates.into_iter().next().ok_or_else(|| {
         format!(
-            "No isochronous OUT endpoint can carry {} Hz / {}-bit / {} ch",
-            playback_format.sample_rate, playback_format.bit_depth, playback_format.channels
+            "No isochronous OUT endpoint can carry {} / {}-bit / {} ch",
+            label_rate, playback_format.bit_depth, playback_format.channels
         )
     })
 }
@@ -5738,26 +5841,28 @@ fn transport_compatibility_penalty(
     if stream_format.channels != playback_format.channels {
         return u32::MAX;
     }
-    let Some(min_subslot_size) = bytes_per_sample(playback_format.bit_depth) else {
-        return u32::MAX;
-    };
     if !is_native_dsd {
+        let Some(min_subslot_size) = bytes_per_sample(playback_format.bit_depth) else {
+            return u32::MAX;
+        };
         if stream_format.bit_resolution != playback_format.bit_depth {
             return u32::MAX;
         }
         if stream_format.subslot_size < min_subslot_size as u8 {
             return u32::MAX;
         }
-    }
 
-    let container_bits = u32::from(stream_format.subslot_size) * 8;
-    if u32::from(stream_format.bit_resolution) > container_bits {
-        return u32::MAX;
-    }
+        let container_bits = u32::from(stream_format.subslot_size) * 8;
+        if u32::from(stream_format.bit_resolution) > container_bits {
+            return u32::MAX;
+        }
 
-    if !is_native_dsd {
         u32::from(stream_format.subslot_size) - min_subslot_size as u32
     } else {
+        let container_bits = u32::from(stream_format.subslot_size) * 8;
+        if u32::from(stream_format.bit_resolution) > container_bits {
+            return u32::MAX;
+        }
         0
     }
 }
@@ -5914,18 +6019,62 @@ fn encode_i32_le(sample: i32) -> [u8; 4] {
     sample.to_le_bytes()
 }
 
-/// Pack PCM for the active UAC subslot (`subslot_size` bytes × `bit_resolution` significant bits).
+/// Pack PCM / DoP / native DSD for the active UAC subslot.
+///
+/// PCM and DoP: each i32 encodes `subslot_size` wire bytes.
+/// Native DSD: each i32 carries one DSD byte; `subslot_size` consecutive
+/// same-channel bytes are packed into each wire word (1:1 byte count).
 fn encode_usb_pcm_slots(
     input: &[i32],
     output: &mut [u8],
     subslot_size: u8,
     bit_resolution: u8,
     dsd_transport: DsdTransportMode,
+    channels: u16,
+    big_endian: bool,
 ) -> Result<(), String> {
     let ss = subslot_size as usize;
     if ss == 0 {
         return Err("subslot_size is zero".to_string());
     }
+
+    if dsd_transport == DsdTransportMode::Native {
+        let ch = channels as usize;
+        if ch == 0 {
+            return Err("channels is zero".to_string());
+        }
+        if output.len() != input.len() {
+            return Err(format!(
+                "USB native DSD buffer length mismatch: output {} bytes, expected {} (1:1 with {} samples)",
+                output.len(),
+                input.len(),
+                input.len()
+            ));
+        }
+        if ss == 1 {
+            for (i, &sample) in input.iter().enumerate() {
+                output[i] = (sample & 0xFF) as u8;
+            }
+        } else {
+            let chunk_samples = ss * ch;
+            let num_chunks = input.len() / chunk_samples;
+            for chunk in 0..num_chunks {
+                let in_base = chunk * chunk_samples;
+                let out_base = chunk * chunk_samples;
+                for chan in 0..ch {
+                    for b in 0..ss {
+                        let in_idx = in_base + chan + b * ch;
+                        let dsd_byte = (input[in_idx] & 0xFF) as u8;
+                        let out_b = if big_endian { b } else { ss - 1 - b };
+                        let out_idx = out_base + chan * ss + out_b;
+                        output[out_idx] = dsd_byte;
+                    }
+                }
+            }
+        }
+        return Ok(());
+    }
+
     let expected = input.len().checked_mul(ss).ok_or_else(|| {
         format!(
             "USB PCM sample count overflow: {} samples × {} subslot",
@@ -5948,26 +6097,7 @@ fn encode_usb_pcm_slots(
             encode_dop_slots(input, output, subslot_size, bit_resolution);
             return Ok(());
         }
-        DsdTransportMode::Native => {
-            let ss = subslot_size as usize;
-            if ss == 1 {
-                for (i, &sample) in input.iter().enumerate() {
-                    output[i] = (sample & 0xFF) as u8;
-                }
-            } else {
-                log::warn!(
-                    "[USB-DSD] Native DSD subslot_size={} > 1: packing {} DSD bytes per slot (low bytes of i32)",
-                    ss, ss
-                );
-                for (i, &sample) in input.iter().enumerate() {
-                    let offset = i * ss;
-                    for b in 0..ss {
-                        output[offset + b] = ((sample >> (b * 8)) & 0xFF) as u8;
-                    }
-                }
-            }
-            return Ok(());
-        }
+        DsdTransportMode::Native => unreachable!("handled above"),
         DsdTransportMode::None => {}
     }
 
@@ -6012,42 +6142,18 @@ fn encode_usb_pcm_slots(
     }
 }
 
-fn encode_dop_slots(
-    input: &[i32],
-    output: &mut [u8],
-    subslot_size: u8,
-    bit_resolution: u8,
-) {
-    match (subslot_size, bit_resolution) {
-        (3, 24) => {
-            for (index, &sample) in input.iter().enumerate() {
-                let offset = index * 3;
-                output[offset] = sample as u8;
-                output[offset + 1] = (sample >> 8) as u8;
-                output[offset + 2] = (sample >> 16) as u8;
-            }
-        }
-        (4, 24) => {
-            for (index, &sample) in input.iter().enumerate() {
-                let left_justified = (sample as u32) << 8;
-                let offset = index * 4;
-                output[offset..offset + 4].copy_from_slice(&left_justified.to_le_bytes());
-            }
-        }
-        (4, 32) => {
-            for (index, &sample) in input.iter().enumerate() {
-                let offset = index * 4;
-                output[offset..offset + 4].copy_from_slice(&(sample as u32).to_le_bytes());
-            }
-        }
-        _ => {
-            for (index, &sample) in input.iter().enumerate() {
-                let val = sample as u32;
-                let offset = index * subslot_size as usize;
-                for byte_idx in 0..subslot_size.min(4) {
-                    output[offset + byte_idx as usize] = (val >> (byte_idx * 8)) as u8;
-                }
-            }
+/// DoP frames arrive 32-bit left-justified (marker in bits 31:24, 16 data bits
+/// in 23:8, low byte zero) — the same canonical word the DAP I32 path uses.
+/// Emit the top `subslot_size` bytes little-endian so the marker stays the
+/// most-significant wire byte, where the DAC scans for 0x05/0xFA.
+fn encode_dop_slots(input: &[i32], output: &mut [u8], subslot_size: u8, _bit_resolution: u8) {
+    let ss = subslot_size as usize;
+    for (index, &sample) in input.iter().enumerate() {
+        let w = sample as u32;
+        let offset = index * ss;
+        for b in 0..ss {
+            let shift = 8 * (4usize.saturating_sub(ss) + b);
+            output[offset + b] = if shift < 32 { (w >> shift) as u8 } else { 0 };
         }
     }
 }

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -5949,8 +5949,22 @@ fn encode_usb_pcm_slots(
             return Ok(());
         }
         DsdTransportMode::Native => {
-            for (i, &sample) in input.iter().enumerate() {
-                output[i] = (sample & 0xFF) as u8;
+            let ss = subslot_size as usize;
+            if ss == 1 {
+                for (i, &sample) in input.iter().enumerate() {
+                    output[i] = (sample & 0xFF) as u8;
+                }
+            } else {
+                log::warn!(
+                    "[USB-DSD] Native DSD subslot_size={} > 1: packing {} DSD bytes per slot (low bytes of i32)",
+                    ss, ss
+                );
+                for (i, &sample) in input.iter().enumerate() {
+                    let offset = i * ss;
+                    for b in 0..ss {
+                        output[offset + b] = ((sample >> (b * 8)) & 0xFF) as u8;
+                    }
+                }
             }
             return Ok(());
         }


### PR DESCRIPTION
# Summary

- Add DSD native support with LSB/MSB bit order, configurable override, quirk-based byte ordering for Android USB direct, multi-byte DSD slot support, and pipeline mode based on output strategy
- Add `ArtistEntity` with Isar annotations, `ArtistRepository` for cached metadata, and database schema integration
- Convert artist detail screen to Riverpod with dynamic color theming from album art
- Convert album art to vinyl record with animated morphing in full player screen
- Extract dynamic playlist color from album art for SmartMix detail screen
- Add `getMostPlayedSongAmong` method to `RecentlyPlayedRepository`

# Changes

## DSD Native Audio

- Add `DsdBitOrder` enum (`LSB`/`MSB`) with configurable override through audio API
- Implement bit_order for DSF, DFF, and Wavpack DSD decoders
- Pass `DsdBitOrder` through DSD decoder thread
- Add DSD-native support to Android USB direct with quirk-based byte ordering
- Refactor Android DSD output with integer stream support and USB strategy improvements
- Extract DoP word building into reusable method with I32 packing
- Enable UAC2 feature by default and support multi-byte DSD slots
- Set pipeline mode based on output strategy for bit-perfect playback
- Include DAP flag in native DSD detection
- Fix DSD native output sample rate and bit depth calculation
- Refactor DSD native output to use byte rate consistently
- Add default DSD bit rate initialization

## Artist Repository

- Add `ArtistEntity` model with Isar annotations
- Add Isar-generated `ArtistEntity` collection (795 lines)
- Add `ArtistRepository` for cached artist metadata
- Add `ArtistEntity` to database schema

## Dynamic Color Theming

- Convert `ArtistDetailScreen` to use Riverpod with dynamic color theming
- Extract dynamic playlist color from album art in `PlaylistDetailScreen`
- Use album color in visualizer preview
- Add `getMostPlayedSongAmong` method to `RecentlyPlayedRepository`

## UI Enhancements

- Convert album art to vinyl record with animated morphing in full player screen (318 lines rewritten)
- Move back button into flexible space in `SmartMixDetailScreen`
- Move back button from `SliverAppBar` leading to overlay position in artist/playlist detail screens

## Files Changed

- `lib/data/entities/artist_entity.dart`
- `lib/data/entities/artist_entity.g.dart`
- `lib/data/repositories/artist_repository.dart`
- `lib/data/repositories/recently_played_repository.dart`
- `lib/data/database.dart`
- `lib/features/artists/screens/artist_detail_screen.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/playlists/screens/playlist_detail_screen.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/services/player_service.dart`
- `rust/src/lib.rs`
- `rust/src/api/audio_api.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/audio/engine.rs`
- `rust/src/audio/device.rs`
- `rust/src/audio/dsd_engine/dsd/dop.rs`
- `rust/src/audio/dsd_engine/dsd_thread.rs`
- `rust/src/audio/dsd_engine/output/mod.rs`
- `rust/src/audio/dsd_engine/format/mod.rs`
- `rust/src/audio/dsd_engine/format/dsf_decoder.rs`
- `rust/src/audio/dsd_engine/format/dff_decoder.rs`
- `rust/src/audio/dsd_engine/format/wavpack_decoder.rs`