### PR TITLE
Add UAC 1.0/2.0 descriptor parsing, device compatibility system, and What's New changelog

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -32,11 +32,13 @@ import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/library_scanner_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/services/app_preferences_service.dart';
 import 'package:flick/services/milestone_service.dart';
 import 'package:flick/services/widget_sync_service.dart';
 import 'package:flick/services/widget_intent_handler.dart';
 import 'package:flick/models/nav_bar_config.dart';
 import 'package:flick/features/milestone/widgets/milestone_card.dart';
+import 'package:flick/features/whats_new/widgets/whats_new_bottom_sheet.dart';
 
 /// Main application widget for Flick Player.
 class FlickPlayerApp extends StatelessWidget {
@@ -82,6 +84,7 @@ class _MainShellState extends ConsumerState<MainShell>
   late final ProviderSubscription<Song?> _currentSongSubscription;
   late final ProviderSubscription<int> _navigationIndexSubscription;
   late final ProviderSubscription<PlayerState> _widgetSyncSubscription;
+  late final ProviderSubscription<AppPreferences>? _appPreferencesSubscription;
   late final WidgetIntentHandler _widgetIntentHandler;
 
   // Track previous song to detect changes
@@ -276,6 +279,8 @@ class _MainShellState extends ConsumerState<MainShell>
       if (tutorialState.autoStartPending && !tutorialState.active) {
         ref.read(tutorialProvider.notifier).start();
       }
+
+      _maybeShowWhatsNew();
     });
 
     _playerService.playbackDesyncedNotifier.addListener(
@@ -345,6 +350,36 @@ class _MainShellState extends ConsumerState<MainShell>
     );
   }
 
+  void _maybeShowWhatsNew() {
+    if (!mounted) return;
+    if (!ref.read(onboardingCompletedProvider)) {
+      return;
+    }
+
+    // Wait for the AppPreferencesNotifier to publish its loaded state. The
+    // listener fires when the real SharedPreferences values replace the
+    // default values, which is the moment we can decide whether a "What's
+    // New" sheet should appear.
+    _appPreferencesSubscription = ref.listenManual<AppPreferences>(
+      appPreferencesProvider,
+      (previous, next) {
+        if (!mounted) return;
+        final notifier = ref.read(whatsNewProvider.notifier);
+        notifier.evaluate();
+        final pending = ref.read(whatsNewProvider).pendingEntry;
+        if (pending == null) {
+          return;
+        }
+
+        // Persist the dismissal before showing so a force-quit between now
+        // and the user actually tapping "Got it" doesn't re-trigger on the
+        // next launch.
+        unawaited(notifier.markCurrentVersionSeen());
+        unawaited(WhatsNewBottomSheet.show(context, entry: pending));
+      },
+    );
+  }
+
   void _onPlaybackDesyncChanged() {
     if (!mounted) return;
     final desynced = _playerService.playbackDesyncedNotifier.value;
@@ -380,6 +415,7 @@ class _MainShellState extends ConsumerState<MainShell>
     _currentSongSubscription.close();
     _navigationIndexSubscription.close();
     _widgetSyncSubscription.close();
+    _appPreferencesSubscription?.close();
     unawaited(_widgetIntentHandler.detach());
     _pageController.removeListener(_onPageScroll);
     _pageController.dispose();

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,3 +1,14 @@
+/// Current marketing version of the app (matches the `version` field in
+/// `pubspec.yaml`). Bump in lockstep with each release.
+const String kAppVersion = '0.17.0-beta.1';
+
+/// Current build number (matches the `version` `+N` suffix in
+/// `pubspec.yaml`). Bump whenever `kAppVersion` is bumped.
+const String kAppBuild = '11';
+
+/// Human-friendly version label, e.g. `0.17.0-beta.1 (build 11)`.
+const String kAppVersionLabel = '$kAppVersion (build $kAppBuild)';
+
 /// App-wide constants for Flick Player.
 class AppConstants {
   AppConstants._();

--- a/lib/features/milestone/widgets/milestone_card.dart
+++ b/lib/features/milestone/widgets/milestone_card.dart
@@ -174,7 +174,7 @@ class _MilestoneCardState extends State<MilestoneCard>
     return AnimatedBuilder(
       animation: _discController,
       builder: (context, _) {
-        final scale = _discScale.value;
+        final scale = _discScale.value.clamp(0.001, double.infinity);
         final rotation = (_discRotation.value - 1.0) * (math.pi / 6);
         return Transform.rotate(
           angle: rotation,

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
 import 'dart:async';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -3712,7 +3713,9 @@ class _AnimatedSongScene extends StatelessWidget {
                                             albumColor: albumColor,
                                           )
                                         : _AlbumArtBox(
-                                            song: song, size: artworkSize),
+                                            song: song,
+                                            size: artworkSize,
+                                            playerService: playerService),
                                   ),
                                 ),
                                 SizedBox(height: artworkSpacing),
@@ -3960,8 +3963,13 @@ class _AnimatedSongScene extends StatelessWidget {
 class _AlbumArtBox extends StatefulWidget {
   final Song song;
   final double? size;
+  final PlayerService? playerService;
 
-  const _AlbumArtBox({required this.song, this.size});
+  const _AlbumArtBox({
+    required this.song,
+    this.size,
+    this.playerService,
+  });
 
   @override
   State<_AlbumArtBox> createState() => _AlbumArtBoxState();
@@ -3970,10 +3978,27 @@ class _AlbumArtBox extends StatefulWidget {
 class _AlbumArtBoxState extends State<_AlbumArtBox>
     with TickerProviderStateMixin {
   static const double _labelRatio = 0.44;
+  static const Duration _spinDuration = Duration(seconds: 4);
+  static const Duration _seekAnimationDuration =
+      Duration(milliseconds: 450);
+  static const int _msPerSeekRevolution = 1500;
+  static const int _maxSeekRevolutions = 5;
+  static const int _minSeekRevolutions = 1;
+  static const int _forwardSeekThresholdMs = 1500;
+  static const double _secondsPerVinylRotation = 30.0;
 
   late final AnimationController _morphController;
   late final AnimationController _spinController;
+  late final AnimationController _seekAngleController;
   bool _isVinyl = false;
+  Duration _lastObservedPosition = Duration.zero;
+  double _userRotationOffset = 0.0;
+  bool _isUserDragging = false;
+  late final TapGestureRecognizer _tapRecognizer;
+  late final _RotationSeekRecognizer _rotationRecognizer;
+
+  bool get _isPlaying =>
+      widget.playerService?.isPlayingNotifier.value ?? false;
 
   @override
   void initState() {
@@ -3984,37 +4009,182 @@ class _AlbumArtBoxState extends State<_AlbumArtBox>
     );
     _spinController = AnimationController(
       vsync: this,
-      duration: const Duration(seconds: 16),
+      duration: _spinDuration,
+    );
+    _seekAngleController = AnimationController(
+      vsync: this,
+      duration: _seekAnimationDuration,
     );
     _morphController.addStatusListener(_handleMorphStatus);
+    _tapRecognizer = TapGestureRecognizer()..onTap = _toggle;
+    _rotationRecognizer = _RotationSeekRecognizer(
+      onStart: _onRotationStart,
+      onUpdate: _onRotationUpdate,
+      onEnd: _onRotationEnd,
+      discCenter: () => Offset.zero, // Will be set in build
+    );
+    final service = widget.playerService;
+    if (service != null) {
+      _lastObservedPosition = service.positionNotifier.value;
+      service.positionNotifier.addListener(_onPositionChanged);
+      service.isPlayingNotifier.addListener(_onPlayingChanged);
+    }
   }
 
   @override
   void didUpdateWidget(covariant _AlbumArtBox oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.song.id != widget.song.id && _isVinyl) {
-      _isVinyl = false;
-      _spinController.stop();
-      _spinController.value = 0;
-      _morphController.value = 0;
+    if (oldWidget.song.id != widget.song.id) {
+      _lastObservedPosition = Duration.zero;
+      _seekAngleController.stop();
+      _seekAngleController.value = 0;
+      _userRotationOffset = 0.0;
+      _isUserDragging = false;
+      if (_isVinyl) {
+        _isVinyl = false;
+        _spinController.stop();
+        _spinController.value = 0;
+        _morphController.value = 0;
+      }
+    }
+    if (oldWidget.playerService != widget.playerService) {
+      oldWidget.playerService?.positionNotifier
+          .removeListener(_onPositionChanged);
+      oldWidget.playerService?.isPlayingNotifier
+          .removeListener(_onPlayingChanged);
+      final service = widget.playerService;
+      if (service != null) {
+        _lastObservedPosition = service.positionNotifier.value;
+        service.positionNotifier.addListener(_onPositionChanged);
+        service.isPlayingNotifier.addListener(_onPlayingChanged);
+      } else {
+        _lastObservedPosition = Duration.zero;
+      }
     }
   }
 
   @override
   void dispose() {
     _morphController.removeStatusListener(_handleMorphStatus);
+    widget.playerService?.positionNotifier.removeListener(_onPositionChanged);
+    widget.playerService?.isPlayingNotifier.removeListener(_onPlayingChanged);
+    _tapRecognizer.dispose();
+    _rotationRecognizer.dispose();
+    _seekAngleController.dispose();
     _spinController.dispose();
     _morphController.dispose();
     super.dispose();
   }
 
+  void _onPlayingChanged() {
+    if (!mounted) return;
+    if (!_isVinyl) return;
+    if (_isUserDragging) return;
+    if (_isPlaying) {
+      _startSpinning();
+    } else {
+      _spinController.stop();
+    }
+  }
+
+  void _startSpinning() {
+    if (!_isVinyl) return;
+    if (_morphController.isCompleted && !_spinController.isAnimating) {
+      _spinController.repeat();
+    }
+  }
+
   void _handleMorphStatus(AnimationStatus status) {
     if (!mounted) return;
     if (status == AnimationStatus.completed && _isVinyl) {
-      _spinController.repeat();
+      if (_isPlaying) {
+        _spinController.repeat();
+      }
     } else if (status == AnimationStatus.dismissed) {
       _spinController.value = 0;
     }
+  }
+
+  void _onPositionChanged() {
+    if (!_isVinyl) return;
+    if (_isUserDragging) return;
+    final service = widget.playerService;
+    if (service == null) return;
+    final newPosition = service.positionNotifier.value;
+    final oldPosition = _lastObservedPosition;
+    _lastObservedPosition = newPosition;
+
+    final deltaMs = newPosition.inMilliseconds - oldPosition.inMilliseconds;
+    if (deltaMs == 0) return;
+
+    final isRewind = deltaMs < 0;
+    final isForwardJump = deltaMs > _forwardSeekThresholdMs;
+    if (isRewind || isForwardJump) {
+      _animateSeek(deltaMs);
+    }
+  }
+
+  void _onRotationStart() {
+    if (!_isVinyl) return;
+    final service = widget.playerService;
+    if (service == null) return;
+    _isUserDragging = true;
+    _spinController.stop();
+    _seekAngleController.stop();
+    _seekAngleController.value = 0;
+    _lastObservedPosition = service.positionNotifier.value;
+  }
+
+  void _onRotationUpdate(double delta) {
+    if (!_isVinyl) return;
+    final service = widget.playerService;
+    if (service == null) return;
+    _userRotationOffset += delta;
+
+    final msPerRadian =
+        (_secondsPerVinylRotation * 1000) / (2 * math.pi);
+    final seekMsDelta = (delta * msPerRadian).round();
+    if (seekMsDelta != 0) {
+      final current = service.positionNotifier.value;
+      final duration = service.durationNotifier.value;
+      var newPositionMs = current.inMilliseconds + seekMsDelta;
+      if (duration.inMilliseconds > 0) {
+        newPositionMs = newPositionMs.clamp(0, duration.inMilliseconds);
+      } else {
+        newPositionMs = newPositionMs.clamp(0, 0x7FFFFFFF);
+      }
+      final newPosition = Duration(milliseconds: newPositionMs);
+      service.positionNotifier.value = newPosition;
+      _lastObservedPosition = newPosition;
+      unawaited(service.seek(newPosition));
+    }
+
+    setState(() {});
+  }
+
+  void _onRotationEnd() {
+    _isUserDragging = false;
+    if (_isVinyl && _isPlaying) {
+      _spinController.repeat();
+    }
+  }
+
+  void _animateSeek(int deltaMs) {
+    if (!_isVinyl) return;
+    var revolutions = (deltaMs.abs() / _msPerSeekRevolution).round();
+    revolutions = revolutions.clamp(_minSeekRevolutions, _maxSeekRevolutions);
+    final signed = deltaMs >= 0 ? revolutions : -revolutions;
+
+    final from = _seekAngleController.value;
+    final to = from + signed * 2 * math.pi;
+
+    _seekAngleController.stop();
+    _seekAngleController.value = from;
+    _seekAngleController.animateTo(
+      to,
+      duration: _seekAnimationDuration,
+      curve: Curves.easeOutCubic,
+    );
   }
 
   void _toggle() {
@@ -4025,6 +4195,9 @@ class _AlbumArtBoxState extends State<_AlbumArtBox>
         _morphController.forward();
       } else {
         _spinController.stop();
+        _seekAngleController.stop();
+        _seekAngleController.value = 0;
+        _userRotationOffset = 0.0;
         _morphController.reverse();
       }
     });
@@ -4034,6 +4207,10 @@ class _AlbumArtBoxState extends State<_AlbumArtBox>
   Widget build(BuildContext context) {
     final double resolvedSize =
         widget.size ?? context.responsive(280.0, 320.0, 360.0);
+    
+    // Update the disc center for rotation detection
+    _rotationRecognizer.discCenter = () => Offset(resolvedSize / 2, resolvedSize / 2);
+
     final framePadding = resolvedSize < 220 ? 5.0 : 7.0;
     final outerRadius = resolvedSize < 220 ? 28.0 : 34.0;
     final innerRadius = math.max(outerRadius - 7.0, 20.0);
@@ -4044,21 +4221,38 @@ class _AlbumArtBoxState extends State<_AlbumArtBox>
     final labelRadius = labelSize / 2;
 
     return Center(
-      child: GestureDetector(
+      child: RawGestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: _toggle,
+        gestures: {
+          TapGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<TapGestureRecognizer>(
+            () => _tapRecognizer,
+            (_) {},
+          ),
+          _RotationSeekRecognizer:
+              GestureRecognizerFactoryWithHandlers<_RotationSeekRecognizer>(
+            () => _rotationRecognizer,
+            (_) {},
+          ),
+        },
         child: SizedBox(
           width: resolvedSize,
           height: resolvedSize,
           child: AnimatedBuilder(
-            animation: Listenable.merge([_morphController, _spinController]),
+            animation: Listenable.merge([
+              _morphController,
+              _spinController,
+              _seekAngleController,
+            ]),
             builder: (context, _) {
-              final t = Curves.easeInOutCubic
-                  .transform(_morphController.value)
-                  .clamp(0.0, 1.0);
+              final rawT = Curves.easeInOutCubic
+                  .transform(_morphController.value);
+              final t = rawT.isNaN ? 0.0 : rawT.clamp(0.0, 1.0);
               final glass = (1.0 - t).clamp(0.0, 1.0);
-              final spinAngle =
-                  _spinController.value * 2 * math.pi * t;
+              final rawAngle = _spinController.value * 2 * math.pi * t +
+                  _seekAngleController.value +
+                  _userRotationOffset;
+              final spinAngle = rawAngle.isNaN ? 0.0 : rawAngle;
 
               final artSize = resolvedSize - (resolvedSize - labelSize) * t;
               final artFramePadding = framePadding * glass;
@@ -4193,6 +4387,127 @@ class _AlbumArtBoxState extends State<_AlbumArtBox>
         ),
       ),
     );
+  }
+}
+
+class _RotationSeekRecognizer extends OneSequenceGestureRecognizer {
+  _RotationSeekRecognizer({
+    required this.onStart,
+    required this.onUpdate,
+    required this.onEnd,
+    required this.discCenter,
+  });
+
+  final VoidCallback onStart;
+  final void Function(double delta) onUpdate;
+  final VoidCallback onEnd;
+  Offset Function() discCenter;
+
+  Offset? _startPos;
+  double? _lastAngle;
+  bool _accepted = false;
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    super.addAllowedPointer(event);
+    _startPos = event.localPosition;
+    _lastAngle = null;
+    _accepted = false;
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    if (_accepted) {
+      if (event is PointerMoveEvent) {
+        _handleMove(event);
+      } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+        onEnd();
+        _accepted = false;
+        stopTrackingPointer(event.pointer);
+      }
+      return;
+    }
+
+    if (event is PointerMoveEvent && _startPos != null) {
+      final center = discCenter();
+      if (center == Offset.zero) return;
+
+      final totalDx = event.localPosition.dx - _startPos!.dx;
+      final totalDy = event.localPosition.dy - _startPos!.dy;
+      final totalDist = math.sqrt(totalDx * totalDx + totalDy * totalDy);
+
+      if (totalDist < 12) return;
+
+      // Check if motion is tangential (rotational) vs radial (linear swipe)
+      final motionDx = event.localPosition.dx - _startPos!.dx;
+      final motionDy = event.localPosition.dy - _startPos!.dy;
+      final radiusDx = _startPos!.dx - center.dx;
+      final radiusDy = _startPos!.dy - center.dy;
+      final radiusLength = math.sqrt(radiusDx * radiusDx + radiusDy * radiusDy);
+      
+      if (radiusLength < 20) return; // Too close to center
+
+      final dotProduct = motionDx * radiusDx + motionDy * radiusDy;
+      final motionLength = math.sqrt(motionDx * motionDx + motionDy * motionDy);
+      final cosAngle = (dotProduct / (motionLength * radiusLength)).clamp(-1.0, 1.0);
+      
+      // If motion is mostly radial (cosAngle close to ±1), it's a swipe
+      // If motion is mostly tangential (cosAngle close to 0), it's rotation
+      if (cosAngle.abs() > 0.5) {
+        resolve(GestureDisposition.rejected);
+        stopTrackingPointer(event.pointer);
+        return;
+      }
+
+      resolve(GestureDisposition.accepted);
+      _accepted = true;
+      final initialDx = event.localPosition.dx - center.dx;
+      final initialDy = event.localPosition.dy - center.dy;
+      _lastAngle = math.atan2(initialDy, initialDx);
+      onStart();
+      _handleMove(event);
+    } else if (event is PointerUpEvent || event is PointerCancelEvent) {
+      stopTrackingPointer(event.pointer);
+    }
+  }
+
+  void _handleMove(PointerMoveEvent event) {
+    final center = discCenter();
+    if (center == Offset.zero) return;
+    final angle = math.atan2(
+      event.localPosition.dy - center.dy,
+      event.localPosition.dx - center.dx,
+    );
+    if (_lastAngle != null) {
+      var delta = angle - _lastAngle!;
+      if (delta > math.pi) delta -= 2 * math.pi;
+      if (delta < -math.pi) delta += 2 * math.pi;
+      onUpdate(delta);
+    }
+    _lastAngle = angle;
+  }
+
+  @override
+  void acceptGesture(int pointer) {}
+
+  @override
+  void rejectGesture(int pointer) {
+    _startPos = null;
+    _lastAngle = null;
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {}
+
+  @override
+  String get debugDescription => 'rotation seek';
+
+  @override
+  void dispose() {
+    super.dispose();
+    _startPos = null;
+    _lastAngle = null;
+    _accepted = false;
   }
 }
 

--- a/lib/features/player/widgets/rating_button.dart
+++ b/lib/features/player/widgets/rating_button.dart
@@ -164,7 +164,7 @@ class _RatingButtonState extends State<RatingButton>
                 final delay = i * 0.08;
                 final starProgress = (_starsController.value - delay)
                     .clamp(0.0, 1.0);
-                final easedProgress = Curves.easeOutBack.transform(starProgress);
+                final easedProgress = Curves.easeOutBack.transform(starProgress).clamp(0.001, double.infinity);
                 final isFilled = starIndex <= (widget.currentRating);
                 final isHovered = _hoveredStar > 0 && starIndex <= _hoveredStar;
 

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -594,7 +594,7 @@ SOFTWARE.
               NavigationSetting(
                 icon: LucideIcons.info,
                 title: 'About Flick Player',
-                subtitle: 'Version 0.18 .0-beta.1',
+                subtitle: 'Version 0.18.0-beta.1',
                 onTap: _showAboutBottomSheet,
               ),
               const SettingsDivider(),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -387,9 +387,13 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
               borderRadius: BorderRadius.circular(AppConstants.radiusLg),
               border: Border.all(color: AppColors.glassBorder),
             ),
-            child: SvgPicture.asset(
-              'assets/icons/flicklogo_svg.svg',
-              fit: BoxFit.contain,
+            child: Center(
+              child: SvgPicture.asset(
+                'assets/icons/flicklogo_svg.svg',
+                width: 48,
+                height: 48,
+                fit: BoxFit.contain,
+              ),
             ),
           ),
           const SizedBox(height: AppConstants.spacingMd),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -404,7 +404,7 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.17.0-beta.1',
+            'Version 0.18.0-beta.1',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -553,8 +553,8 @@ SOFTWARE.
                     : 'Check Again',
                 subtitle: updateState.isOnline
                     ? updateState.isPlayStoreBuild
-                        ? 'Run another Play Store update scan right now'
-                        : 'Run another update scan right now'
+                          ? 'Run another Play Store update scan right now'
+                          : 'Run another update scan right now'
                     : 'Reconnect to the internet to scan for updates',
                 onTap: updateState.isChecking ? null : _checkForUpdatesManually,
               ),
@@ -568,7 +568,7 @@ SOFTWARE.
                   subtitle: 'See what is new in this update',
                   onTap: _showPatchNotesBottomSheet,
                 ),
-              const SettingsDivider(),
+                const SettingsDivider(),
                 if (updateState.isPlayStoreBuild)
                   ActionButton(
                     icon: LucideIcons.externalLink,
@@ -581,9 +581,8 @@ SOFTWARE.
                     icon: LucideIcons.download,
                     title: 'Download Update',
                     subtitle: 'Get the latest APK from flick-player.site',
-                    onTap: () => _launchUrl(
-                      UpdateCheckNotifier.flickWebsiteDownloadUrl,
-                    ),
+                    onTap: () =>
+                        _launchUrl(UpdateCheckNotifier.flickWebsiteDownloadUrl),
                   ),
               ],
             ],
@@ -595,7 +594,7 @@ SOFTWARE.
               NavigationSetting(
                 icon: LucideIcons.info,
                 title: 'About Flick Player',
-                subtitle: 'Version 0.17 .0-beta.1',
+                subtitle: 'Version 0.18 .0-beta.1',
                 onTap: _showAboutBottomSheet,
               ),
               const SettingsDivider(),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -553,7 +553,7 @@ SOFTWARE.
                   subtitle: 'See what is new in this update',
                   onTap: _showPatchNotesBottomSheet,
                 ),
-                const SettingsDivider(),
+              const SettingsDivider(),
                 ActionButton(
                   icon: LucideIcons.externalLink,
                   title: 'Open in Play Store',
@@ -570,7 +570,7 @@ SOFTWARE.
               NavigationSetting(
                 icon: LucideIcons.info,
                 title: 'About Flick Player',
-                subtitle: 'Version 0.17.0-beta.1',
+                subtitle: 'Version 0.17 .0-beta.1',
                 onTap: _showAboutBottomSheet,
               ),
               const SettingsDivider(),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -79,7 +79,11 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
       return;
     }
     if (updateState.updateAvailable) {
-      _showToast('Update available on the Play Store.');
+      if (updateState.isPlayStoreBuild) {
+        _showToast('Update available on the Play Store.');
+      } else {
+        _showToast('Update available — download from flick-player.site');
+      }
       return;
     }
     if (updateState.errorMessage != null) {
@@ -120,18 +124,23 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
   ({IconData icon, String title, String subtitle}) _getUpdateStatusDetails(
     UpdateCheckState updateState,
   ) {
+    final isPlay = updateState.isPlayStoreBuild;
     if (updateState.isChecking) {
       return (
         icon: LucideIcons.refreshCw,
         title: 'Checking for Updates',
-        subtitle: 'Looking for the latest Play Store update right now',
+        subtitle: isPlay
+            ? 'Looking for the latest Play Store update right now'
+            : 'Looking for the latest Flick release right now',
       );
     }
     if (updateState.updateAvailable) {
       return (
         icon: LucideIcons.badgeAlert,
         title: 'Update Available',
-        subtitle: 'Open the Play Store to install the latest Flick build',
+        subtitle: isPlay
+            ? 'Open the Play Store to install the latest Flick build'
+            : 'Download the latest APK from flick-player.site',
       );
     }
     if (updateState.errorMessage != null) {
@@ -152,13 +161,17 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
       return (
         icon: LucideIcons.badgeCheck,
         title: 'No Update Available',
-        subtitle: 'You already have the latest Play Store release',
+        subtitle: isPlay
+            ? 'You already have the latest Play Store release'
+            : 'You already have the latest Flick release',
       );
     }
     return (
       icon: LucideIcons.info,
       title: 'Automatic Update Checks',
-      subtitle: 'Flick scans for Play Store updates whenever you are online',
+      subtitle: isPlay
+          ? 'Flick scans for Play Store updates whenever you are online'
+          : 'Flick checks flick-player.site for updates whenever you are online',
     );
   }
 
@@ -539,7 +552,9 @@ SOFTWARE.
                     ? 'Checking for Updates...'
                     : 'Check Again',
                 subtitle: updateState.isOnline
-                    ? 'Run another Play Store update scan right now'
+                    ? updateState.isPlayStoreBuild
+                        ? 'Run another Play Store update scan right now'
+                        : 'Run another update scan right now'
                     : 'Reconnect to the internet to scan for updates',
                 onTap: updateState.isChecking ? null : _checkForUpdatesManually,
               ),
@@ -554,12 +569,22 @@ SOFTWARE.
                   onTap: _showPatchNotesBottomSheet,
                 ),
               const SettingsDivider(),
-                ActionButton(
-                  icon: LucideIcons.externalLink,
-                  title: 'Open in Play Store',
-                  subtitle: 'Jump to the Flick listing and update from there',
-                  onTap: _openPlayStoreListing,
-                ),
+                if (updateState.isPlayStoreBuild)
+                  ActionButton(
+                    icon: LucideIcons.externalLink,
+                    title: 'Open in Play Store',
+                    subtitle: 'Jump to the Flick listing and update from there',
+                    onTap: _openPlayStoreListing,
+                  )
+                else
+                  ActionButton(
+                    icon: LucideIcons.download,
+                    title: 'Download Update',
+                    subtitle: 'Get the latest APK from flick-player.site',
+                    onTap: () => _launchUrl(
+                      UpdateCheckNotifier.flickWebsiteDownloadUrl,
+                    ),
+                  ),
               ],
             ],
           ),

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -1,0 +1,155 @@
+/// Structured changelog data shown to the user in the "What's New" bottom
+/// sheet. Entries are keyed by version string and must match `kAppVersion`
+/// exactly to be considered "new".
+class ChangelogEntry {
+  const ChangelogEntry({
+    required this.version,
+    required this.date,
+    required this.sections,
+  });
+
+  final String version;
+  final String date;
+  final List<ChangelogSection> sections;
+}
+
+class ChangelogSection {
+  const ChangelogSection({
+    required this.title,
+    this.subsections = const [],
+    this.bullets = const [],
+  });
+
+  final String title;
+  final List<ChangelogSubsection> subsections;
+  final List<String> bullets;
+}
+
+class ChangelogSubsection {
+  const ChangelogSubsection({this.title, required this.bullets});
+
+  /// `null` when the section has no sub-headers and the bullets belong
+  /// directly to the section.
+  final String? title;
+  final List<String> bullets;
+}
+
+/// All changelog data known to the app, in reverse chronological order.
+///
+/// When a new release ships:
+///   1. Bump `kAppVersion` in `core/constants/app_constants.dart`.
+///   2. Prepend a new [ChangelogEntry] matching that version here.
+///
+/// The "What's New" bottom sheet on first launch after an update will
+/// automatically surface the entry whose `version` equals `kAppVersion`.
+const List<ChangelogEntry> kChangelogEntries = [
+  ChangelogEntry(
+    version: '0.17.0-beta.1',
+    date: '2026-05-31',
+    sections: [
+      ChangelogSection(
+        title: 'Post-Release Additions',
+        subsections: [
+          ChangelogSubsection(
+            title: 'DSD Bit Order & Native USB Direct',
+            bullets: [
+              '**DsdBitOrder enum** (LSB/MSB) with per-source detection across all DSD format decoders (DSF, DFF, WavPack). Bit order normalization in the DSD output router.',
+              '**Global DSD bit reverse override:** `set_dsd_bit_reverse_override()` FFI function exposing manual byte-order control to Flutter.',
+              '**USB native DSD output:** `AndroidDirectUsbPlaybackFormat` now carries `dsd_bit_rate`. Multi-byte interleaved USB payload packing with configurable endianness.',
+              '**DSD quirks table:** `KNOWN_DSD_QUIRKS` with per-device entries (vendor/product IDs, endianness, bit reversal, preferred subslot size). Includes MOONDROP Dawn Pro quirk.',
+              '**DoP word building refactored** into reusable `build_dop_word()` method with I32 packing for integer streams.',
+              '**Default DSD bit rate initialization** for newly configured USB playback formats.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'DSD Hardware Transport',
+            bullets: [
+              '**UAC2 feature enabled by default:** Multi-byte DSD slots now active without opt-in.',
+              '**Pipeline mode based on output strategy:** `PipelineMode::Dop` set for USB DSD Native and DSD DoP strategies (bit-perfect passthrough). `Passthrough` for PCM bit-perfect. `Dsp` for standard processing.',
+              '**DAP flag in native DSD detection:** DSD Native mode now considered available on DAP devices even without explicit DSD encoding support.',
+              '**Transport labels made descriptive:** Debug transport labels updated from short codes to `usb-native-dsd-u{subslot}x{bits}-bit`, `usb-dop-{bits}-bit`, `usb-pcm`.',
+              '**`DsdBitOrder` passed through DSD decoder thread** to `DsdOutputRouter` for per-track byte normalization.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'Integer (I32) Stream Support',
+            bullets: [
+              '**`AndroidManagedStreamKind` enum:** Replaces hardcoded f32 stream with `F32` and `I32` variants.',
+              '**`AndroidOutputCallbackI32`:** Reads f32 from pipeline, extracts raw bit patterns via `f32::to_bits()`, writes i32 to AAudio — preserving DoP markers and DSD data intact.',
+              '**`open_android_output_stream()`** gains `use_integer_format` parameter; opens i32 stream with format conversion disabled for DoP/native DSD on DAP.',
+              '**Fallback stream logic** adapted to work with both f32 and i32 streams.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'Artist & Playlist Theming',
+            bullets: [
+              '**ArtistEntity** (Isar collection): `id`, `name` (unique, case-insensitive), `artPath` (nullable). Auto-generated Isar bindings.',
+              '**ArtistRepository:** `getByName()`, `setArt()`, `clearArt()` for persistent artist art path caching.',
+              '**ArtistDetailScreen:** Migrated from `StatefulWidget` to `ConsumerStatefulWidget` (Riverpod). Dynamic color theming via `ColorExtractionService` from resolved album art. Full-bleed artist image background with animated tinted app bar. Removed old circular avatar + stat chips layout.',
+              '**PlaylistDetailScreen:** Dynamic playlist color from most-played song\'s album art via `getMostPlayedSongAmong()`. `TweenAnimationBuilder` tinted background. Info chips (track count, total duration, created/updated dates). "Other Playlists" horizontal section. Back button repositioned to overlay. Removed 4-tile cover grid.',
+              '**`getMostPlayedSongAmong()`** in `RecentlyPlayedRepository`: Returns most-played song from a given list for playlist color extraction.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'Visualizer & Player',
+            bullets: [
+              '**Vinyl disc morph animation:** Tap album art to morph into a spinning vinyl record. `_VinylDiscPainter` draws radial-gradient disc with grooves and highlight. `_morphController` (700ms) controls transition; `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size. Song change resets to art mode. Haptic feedback on toggle.',
+              '**Album color in visualizer preview:** `_buildVisualizerPreview()` reads `albumColorModeProvider` and passes album color when mode is not `off`.',
+              '**SmartMixDetailScreen:** Back button moved from `SliverAppBar` leading to overlay position.',
+              '**Playlist metadata helpers:** Total duration calculation and date formatting utilities.',
+            ],
+          ),
+        ],
+      ),
+      ChangelogSection(
+        title: 'Milestone Card Redesign & Collection',
+        bullets: [
+          'Redesigned milestone celebration card with per-tier accent color (bronze / silver / gold / sapphire / amethyst), large hero icon, tinted border + glow, and a subtle "next milestone — N to go" hint line',
+          'New achievement-style collection view (Settings → Milestones) listing all five tiers in a grid; unlocked tiles re-open the celebration card with the achieved date, locked tiles show a progress bottom sheet',
+          'Settings → About → Milestones tile shows a live "X / 5 unlocked" counter',
+          'Five new `AppColors` milestone tint constants and per-tier `tierIcon` / `tierColor` / `shortLabel` / `threshold` / `isTopTier` getters on `MilestoneTypeX`',
+          'New `MilestoneService.getNextMilestone()` helper for "next unshown tier + remaining units" (used by the popup and the locked-tile sheet)',
+          '`MilestoneService` constructor now accepts an optional `playCountOverride` for unit testing without Isar',
+          'New test suite: `test/services/milestone_service_test.dart`',
+        ],
+      ),
+      ChangelogSection(
+        title: 'BitPerfect Capsule / Indicator',
+        bullets: [
+          'BitPerfect status capsule displayed in the player UI showing active bit-perfect mode',
+          'Visual indicator for bit-perfect audio path engagement',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Player Layout Settings',
+        bullets: [
+          'Configurable player layout options',
+          'Settings screen for customizing the player layout',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Equalizer Paged Layout',
+        bullets: [
+          'Equalizer redesigned with a paged layout for better navigation across 31 bands',
+          'Improved band browsing and adjustment workflow',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Folder Filter / Sort Controls',
+        bullets: [
+          'Folder filtering controls for narrowing down folder listings',
+          'Enhanced folder sort options with dedicated controls',
+        ],
+      ),
+    ],
+  ),
+];
+
+/// Returns the changelog entry whose version matches [version], or `null` if
+/// no entry is recorded for it.
+ChangelogEntry? findChangelogEntry(String version) {
+  for (final entry in kChangelogEntries) {
+    if (entry.version == version) return entry;
+  }
+  return null;
+}

--- a/lib/features/whats_new/widgets/whats_new_bottom_sheet.dart
+++ b/lib/features/whats_new/widgets/whats_new_bottom_sheet.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/features/whats_new/data/changelog_data.dart';
+import 'package:flick/providers/whats_new_provider.dart';
+import 'package:flick/widgets/common/glass_bottom_sheet.dart';
+
+class WhatsNewBottomSheet extends ConsumerWidget {
+  const WhatsNewBottomSheet({super.key, this.entry});
+
+  /// When `null`, falls back to the current version's changelog from the
+  /// provider state. Pass an explicit entry to display any version.
+  final ChangelogEntry? entry;
+
+  static Future<T?> show<T>(BuildContext context, {ChangelogEntry? entry}) {
+    return GlassBottomSheet.show<T>(
+      context: context,
+      title: "What's New",
+      maxHeightRatio: 0.85,
+      content: WhatsNewBottomSheet(entry: entry),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          style: TextButton.styleFrom(
+            foregroundColor: AppColors.textPrimary,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppConstants.spacingLg,
+              vertical: 1,
+            ),
+            minimumSize: const Size(0, 16),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: const Text(
+            'Got it',
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resolvedEntry = entry ?? ref.watch(whatsNewProvider).currentEntry;
+    if (resolvedEntry == null) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppConstants.spacingLg),
+        child: Text(
+          'No changelog notes for this version yet.',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: context.adaptiveTextSecondary,
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: AppConstants.spacingSm),
+        _VersionHeader(entry: resolvedEntry),
+        const SizedBox(height: AppConstants.spacingMd),
+        for (var i = 0; i < resolvedEntry.sections.length; i++) ...[
+          _SectionBlock(section: resolvedEntry.sections[i]),
+          if (i != resolvedEntry.sections.length - 1)
+            const SizedBox(height: AppConstants.spacingLg),
+        ],
+        const SizedBox(height: AppConstants.spacingSm),
+      ],
+    );
+  }
+}
+
+class _VersionHeader extends StatelessWidget {
+  const _VersionHeader({required this.entry});
+
+  final ChangelogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            AppColors.accent.withValues(alpha: 0.18),
+            AppColors.accentDim.withValues(alpha: 0.06),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: AppColors.glassBackgroundStrong,
+              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: Icon(
+              LucideIcons.sparkles,
+              color: context.adaptiveTextPrimary,
+              size: 20,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Version ${entry.version}',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  entry.date,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionBlock extends StatelessWidget {
+  const _SectionBlock({required this.section});
+
+  final ChangelogSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasSubsections = section.subsections.isNotEmpty;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          section.title,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+            color: context.adaptiveTextPrimary,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.2,
+          ),
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        if (hasSubsections)
+          ...section.subsections.expand(
+            (sub) => [
+              if (sub.title != null) ...[
+                Padding(
+                  padding: const EdgeInsets.only(
+                    top: AppConstants.spacingXs,
+                    bottom: AppConstants.spacingXxs,
+                  ),
+                  child: Text(
+                    sub.title!,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                ...sub.bullets.map((b) => _BulletRow(bullet: b)),
+              ] else
+                ...sub.bullets.map((b) => _BulletRow(bullet: b)),
+            ],
+          )
+        else
+          ...section.bullets.map((b) => _BulletRow(bullet: b)),
+      ],
+    );
+  }
+}
+
+class _BulletRow extends StatelessWidget {
+  const _BulletRow({required this.bullet});
+
+  final String bullet;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: AppConstants.spacingXxs,
+        bottom: AppConstants.spacingXxs,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Container(
+              width: 5,
+              height: 5,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: context.adaptiveTextTertiary,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          Expanded(
+            child: _RichBullet(
+              text: bullet,
+              baseColor: context.adaptiveTextSecondary,
+              boldColor: context.adaptiveTextPrimary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Renders a bullet line, styling any `**...**` spans as bold.
+class _RichBullet extends StatelessWidget {
+  const _RichBullet({
+    required this.text,
+    required this.baseColor,
+    required this.boldColor,
+  });
+
+  final String text;
+  final Color baseColor;
+  final Color boldColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = Theme.of(
+      context,
+    ).textTheme.bodyMedium?.copyWith(color: baseColor, height: 1.45);
+    if (baseStyle == null) return Text(text);
+    final spans = _parseBoldSpans(text, baseStyle, boldColor);
+    return RichText(
+      text: TextSpan(style: baseStyle, children: spans),
+    );
+  }
+
+  static List<InlineSpan> _parseBoldSpans(
+    String input,
+    TextStyle baseStyle,
+    Color boldColor,
+  ) {
+    final spans = <InlineSpan>[];
+    final pattern = RegExp(r'\*\*(.+?)\*\*');
+    int cursor = 0;
+    for (final match in pattern.allMatches(input)) {
+      if (match.start > cursor) {
+        spans.add(TextSpan(text: input.substring(cursor, match.start)));
+      }
+      spans.add(
+        TextSpan(
+          text: match.group(1),
+          style: baseStyle.copyWith(
+            color: boldColor,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      );
+      cursor = match.end;
+    }
+    if (cursor < input.length) {
+      spans.add(TextSpan(text: input.substring(cursor)));
+    }
+    if (spans.isEmpty) {
+      spans.add(TextSpan(text: input));
+    }
+    return spans;
+  }
+}

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -80,9 +80,7 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
   Future<void> setShowEngineSelector(bool value) async {
     if (state.showEngineSelector == value) return;
     state = state.copyWith(showEngineSelector: value);
-    await ref
-        .read(appPreferencesServiceProvider)
-        .setShowEngineSelector(value);
+    await ref.read(appPreferencesServiceProvider).setShowEngineSelector(value);
   }
 
   Future<void> setCrossfadeEnabled(bool value) async {
@@ -244,17 +242,13 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
   Future<void> setImmersiveShowTitle(bool value) async {
     if (state.immersiveShowTitle == value) return;
     state = state.copyWith(immersiveShowTitle: value);
-    await ref
-        .read(appPreferencesServiceProvider)
-        .setImmersiveShowTitle(value);
+    await ref.read(appPreferencesServiceProvider).setImmersiveShowTitle(value);
   }
 
   Future<void> setImmersiveShowArtist(bool value) async {
     if (state.immersiveShowArtist == value) return;
     state = state.copyWith(immersiveShowArtist: value);
-    await ref
-        .read(appPreferencesServiceProvider)
-        .setImmersiveShowArtist(value);
+    await ref.read(appPreferencesServiceProvider).setImmersiveShowArtist(value);
   }
 
   Future<void> setImmersiveShowFileInfo(bool value) async {
@@ -298,13 +292,17 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
   Future<void> setWidgetFlagshipAccent(String value) async {
     if (state.widgetFlagshipAccent == value) return;
     state = state.copyWith(widgetFlagshipAccent: value);
-    await ref.read(appPreferencesServiceProvider).setWidgetFlagshipAccent(value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setWidgetFlagshipAccent(value);
   }
 
   Future<void> setWidgetFlagshipShowArtist(bool value) async {
     if (state.widgetFlagshipShowArtist == value) return;
     state = state.copyWith(widgetFlagshipShowArtist: value);
-    await ref.read(appPreferencesServiceProvider).setWidgetFlagshipShowArtist(value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setWidgetFlagshipShowArtist(value);
   }
 
   Future<void> setLyricsMatchAudioFilename(bool value) async {
@@ -330,7 +328,9 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
   Future<void> setWelcomeCardDismissed(bool value) async {
     if (state.welcomeCardDismissed == value) return;
     state = state.copyWith(welcomeCardDismissed: value);
-    await ref.read(appPreferencesServiceProvider).setWelcomeCardDismissed(value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setWelcomeCardDismissed(value);
   }
 
   Future<void> setReplaceAlbumWithBitPerfectCapsule(bool value) async {
@@ -344,9 +344,15 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
   Future<void> setFolderGridPageSize(int value) async {
     if (state.folderGridPageSize == value) return;
     state = state.copyWith(folderGridPageSize: value);
+    await ref.read(appPreferencesServiceProvider).setFolderGridPageSize(value);
+  }
+
+  Future<void> setLastSeenChangelogVersion(String? value) async {
+    if (state.lastSeenChangelogVersion == value) return;
+    state = state.copyWith(lastSeenChangelogVersion: value);
     await ref
         .read(appPreferencesServiceProvider)
-        .setFolderGridPageSize(value);
+        .setLastSeenChangelogVersion(value);
   }
 }
 

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -24,3 +24,4 @@ export 'player_screen_mode_provider.dart';
 export 'update_check_provider.dart';
 export 'milestone_provider.dart';
 export 'tutorial_provider.dart';
+export 'whats_new_provider.dart';

--- a/lib/providers/update_check_provider.dart
+++ b/lib/providers/update_check_provider.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
 import 'package:in_app_update/in_app_update.dart';
+
+import '../core/constants/app_constants.dart';
 
 class UpdateCheckState {
   const UpdateCheckState({
@@ -13,6 +17,9 @@ class UpdateCheckState {
     this.updateAvailable = false,
     this.errorMessage,
     this.lastCheckedAt,
+    this.isPlayStoreBuild = true,
+    this.downloadUrl,
+    this.latestVersion,
   });
 
   final bool isOnline;
@@ -21,6 +28,9 @@ class UpdateCheckState {
   final bool updateAvailable;
   final String? errorMessage;
   final DateTime? lastCheckedAt;
+  final bool isPlayStoreBuild;
+  final String? downloadUrl;
+  final String? latestVersion;
 
   UpdateCheckState copyWith({
     bool? isOnline,
@@ -30,6 +40,11 @@ class UpdateCheckState {
     String? errorMessage,
     DateTime? lastCheckedAt,
     bool clearErrorMessage = false,
+    bool? isPlayStoreBuild,
+    String? downloadUrl,
+    String? latestVersion,
+    bool clearDownloadUrl = false,
+    bool clearLatestVersion = false,
   }) {
     return UpdateCheckState(
       isOnline: isOnline ?? this.isOnline,
@@ -40,6 +55,11 @@ class UpdateCheckState {
           ? null
           : errorMessage ?? this.errorMessage,
       lastCheckedAt: lastCheckedAt ?? this.lastCheckedAt,
+      isPlayStoreBuild: isPlayStoreBuild ?? this.isPlayStoreBuild,
+      downloadUrl:
+          clearDownloadUrl ? null : downloadUrl ?? this.downloadUrl,
+      latestVersion:
+          clearLatestVersion ? null : latestVersion ?? this.latestVersion,
     );
   }
 }
@@ -49,7 +69,12 @@ class UpdateCheckNotifier extends Notifier<UpdateCheckState> {
       'https://play.google.com/store/apps/details?id=com.mossapps.flick';
   static const String flickPlayStoreMarketUrl =
       'market://details?id=com.mossapps.flick';
+  static const String flickWebsiteDownloadUrl = 'https://www.flick-player.site/';
   static const Duration _automaticRefreshCooldown = Duration(minutes: 30);
+
+  static final Uri _githubReleasesApiUri = Uri.parse(
+    'https://api.github.com/repos/ultraelectronica/flick_player/releases/latest',
+  );
 
   final Connectivity _connectivity = Connectivity();
   StreamSubscription<dynamic>? _connectivitySubscription;
@@ -143,17 +168,57 @@ class UpdateCheckNotifier extends Notifier<UpdateCheckState> {
         clearErrorMessage: true,
       );
     } on PlatformException {
+      await _checkGitHubForUpdate();
+    } catch (_) {
       state = state.copyWith(
         isChecking: false,
         hasChecked: true,
-        updateAvailable: false,
-        errorMessage: 'Update checks only work on the Play Store build.',
+        errorMessage: 'Unable to check for updates right now.',
         lastCheckedAt: DateTime.now(),
+      );
+    }
+  }
+
+  Future<void> _checkGitHubForUpdate() async {
+    try {
+      final response = await http.get(
+        _githubReleasesApiUri,
+        headers: const {
+          'Accept': 'application/vnd.github+json',
+          'User-Agent': 'FlickPlayer',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      );
+
+      if (response.statusCode != 200) {
+        throw Exception('GitHub API returned ${response.statusCode}');
+      }
+
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      var tag = (data['tag_name'] as String?)?.trim() ?? '';
+      if (tag.startsWith('v')) {
+        tag = tag.substring(1);
+      }
+
+      final isUpdateAvailable = tag.isNotEmpty && tag != kAppVersion;
+
+      state = state.copyWith(
+        isChecking: false,
+        hasChecked: true,
+        isPlayStoreBuild: false,
+        updateAvailable: isUpdateAvailable,
+        downloadUrl:
+            isUpdateAvailable ? flickWebsiteDownloadUrl : null,
+        latestVersion: tag.isNotEmpty ? tag : null,
+        lastCheckedAt: DateTime.now(),
+        clearErrorMessage: true,
       );
     } catch (_) {
       state = state.copyWith(
         isChecking: false,
         hasChecked: true,
+        isPlayStoreBuild: false,
+        updateAvailable: false,
         errorMessage: 'Unable to check for updates right now.',
         lastCheckedAt: DateTime.now(),
       );

--- a/lib/providers/whats_new_provider.dart
+++ b/lib/providers/whats_new_provider.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/features/whats_new/data/changelog_data.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+
+class WhatsNewState {
+  const WhatsNewState({required this.currentEntry, required this.pendingEntry});
+
+  /// The changelog entry matching the running app version (always non-null in
+  /// production — `findChangelogEntry` returns `null` only if a release
+  /// shipped without being recorded in `changelog_data.dart`).
+  final ChangelogEntry? currentEntry;
+
+  /// The entry that should be shown to the user as new, if any.
+  final ChangelogEntry? pendingEntry;
+}
+
+class WhatsNewNotifier extends Notifier<WhatsNewState> {
+  @override
+  WhatsNewState build() {
+    return WhatsNewState(
+      currentEntry: findChangelogEntry(kAppVersion),
+      pendingEntry: null,
+    );
+  }
+
+  /// Re-evaluates whether a "What's New" entry should be presented. Call this
+  /// after the app preferences have finished loading so the stored
+  /// "last seen" version is accurate.
+  void evaluate() {
+    final preferences = ref.read(appPreferencesProvider);
+    final lastSeen = preferences.lastSeenChangelogVersion;
+
+    final current = findChangelogEntry(kAppVersion);
+    final shouldShow = lastSeen != null && lastSeen != kAppVersion;
+
+    state = WhatsNewState(
+      currentEntry: current,
+      pendingEntry: shouldShow ? current : null,
+    );
+  }
+
+  /// Marks the running version as seen so the sheet does not re-appear.
+  Future<void> markCurrentVersionSeen() async {
+    await ref
+        .read(appPreferencesProvider.notifier)
+        .setLastSeenChangelogVersion(kAppVersion);
+    state = WhatsNewState(currentEntry: state.currentEntry, pendingEntry: null);
+  }
+}
+
+final whatsNewProvider = NotifierProvider<WhatsNewNotifier, WhatsNewState>(
+  WhatsNewNotifier.new,
+);

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -47,6 +47,7 @@ class AppPreferences {
   final bool welcomeCardDismissed;
   final bool replaceAlbumWithBitPerfectCapsule;
   final int folderGridPageSize;
+  final String? lastSeenChangelogVersion;
 
   const AppPreferences({
     this.animationsEnabled = true,
@@ -95,6 +96,7 @@ class AppPreferences {
     this.welcomeCardDismissed = false,
     this.replaceAlbumWithBitPerfectCapsule = false,
     this.folderGridPageSize = 8,
+    this.lastSeenChangelogVersion,
   });
 
   AppPreferences copyWith({
@@ -144,6 +146,7 @@ class AppPreferences {
     bool? welcomeCardDismissed,
     bool? replaceAlbumWithBitPerfectCapsule,
     int? folderGridPageSize,
+    String? lastSeenChangelogVersion,
   }) {
     return AppPreferences(
       animationsEnabled: animationsEnabled ?? this.animationsEnabled,
@@ -178,7 +181,8 @@ class AppPreferences {
       artworkCardVerticalOffset:
           artworkCardVerticalOffset ?? this.artworkCardVerticalOffset,
       artworkCardShowTitle: artworkCardShowTitle ?? this.artworkCardShowTitle,
-      artworkCardShowArtist: artworkCardShowArtist ?? this.artworkCardShowArtist,
+      artworkCardShowArtist:
+          artworkCardShowArtist ?? this.artworkCardShowArtist,
       artworkCardShowAlbum: artworkCardShowAlbum ?? this.artworkCardShowAlbum,
       artworkCardShowFileInfo:
           artworkCardShowFileInfo ?? this.artworkCardShowFileInfo,
@@ -204,9 +208,12 @@ class AppPreferences {
       leftActionButton: leftActionButton ?? this.leftActionButton,
       rightActionButton: rightActionButton ?? this.rightActionButton,
       welcomeCardDismissed: welcomeCardDismissed ?? this.welcomeCardDismissed,
-      replaceAlbumWithBitPerfectCapsule: replaceAlbumWithBitPerfectCapsule ??
+      replaceAlbumWithBitPerfectCapsule:
+          replaceAlbumWithBitPerfectCapsule ??
           this.replaceAlbumWithBitPerfectCapsule,
       folderGridPageSize: folderGridPageSize ?? this.folderGridPageSize,
+      lastSeenChangelogVersion:
+          lastSeenChangelogVersion ?? this.lastSeenChangelogVersion,
     );
   }
 }
@@ -259,6 +266,7 @@ class AppPreferencesService {
   static const _replaceAlbumWithBitPerfectCapsuleKey =
       'replace_album_with_bit_perfect_capsule';
   static const _folderGridPageSizeKey = 'folder_grid_page_size';
+  static const _lastSeenChangelogVersionKey = 'last_seen_changelog_version';
 
   Future<AppPreferences> getPreferences() async {
     final prefs = await SharedPreferences.getInstance();
@@ -305,13 +313,11 @@ class AppPreferencesService {
           prefs.getDouble(_immersiveFullViewScaleKey) ?? 1.0,
       immersiveShowTitle: prefs.getBool(_immersiveShowTitleKey) ?? true,
       immersiveShowArtist: prefs.getBool(_immersiveShowArtistKey) ?? true,
-      immersiveShowFileInfo:
-          prefs.getBool(_immersiveShowFileInfoKey) ?? true,
+      immersiveShowFileInfo: prefs.getBool(_immersiveShowFileInfoKey) ?? true,
       widgetBgOpacity: prefs.getInt(_widgetBgOpacityKey) ?? 3,
       widgetShowAlbumArt: prefs.getBool(_widgetShowAlbumArtKey) ?? true,
       widgetShowArtist: prefs.getBool(_widgetShowArtistKey) ?? true,
-      widgetAccentColor:
-          prefs.getString(_widgetAccentColorKey) ?? 'white',
+      widgetAccentColor: prefs.getString(_widgetAccentColorKey) ?? 'white',
       widgetFlagshipTheme:
           prefs.getString(_widgetFlagshipThemeKey) ?? 'art_dominant',
       widgetFlagshipAccent:
@@ -320,14 +326,13 @@ class AppPreferencesService {
           prefs.getBool(_widgetFlagshipShowArtistKey) ?? true,
       lyricsMatchAudioFilename:
           prefs.getBool(_lyricsMatchAudioFilenameKey) ?? false,
-      leftActionButton:
-          prefs.getString(_leftActionButtonKey) ?? 'lyrics',
-      rightActionButton:
-          prefs.getString(_rightActionButtonKey) ?? 'favorites',
+      leftActionButton: prefs.getString(_leftActionButtonKey) ?? 'lyrics',
+      rightActionButton: prefs.getString(_rightActionButtonKey) ?? 'favorites',
       welcomeCardDismissed: prefs.getBool(_welcomeCardDismissedKey) ?? false,
       replaceAlbumWithBitPerfectCapsule:
           prefs.getBool(_replaceAlbumWithBitPerfectCapsuleKey) ?? false,
       folderGridPageSize: prefs.getInt(_folderGridPageSizeKey) ?? 8,
+      lastSeenChangelogVersion: prefs.getString(_lastSeenChangelogVersionKey),
     );
   }
 
@@ -739,5 +744,19 @@ class AppPreferencesService {
   Future<void> setFolderGridPageSize(int value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_folderGridPageSizeKey, value);
+  }
+
+  Future<String?> getLastSeenChangelogVersion() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_lastSeenChangelogVersionKey);
+  }
+
+  Future<void> setLastSeenChangelogVersion(String? value) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (value == null) {
+      await prefs.remove(_lastSeenChangelogVersionKey);
+    } else {
+      await prefs.setString(_lastSeenChangelogVersionKey, value);
+    }
   }
 }

--- a/lib/widgets/common/glass_bottom_sheet.dart
+++ b/lib/widgets/common/glass_bottom_sheet.dart
@@ -251,15 +251,12 @@ class GlassBottomSheet extends StatelessWidget {
   }
 
   Widget _buildActions(BuildContext context) {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppConstants.spacingLg,
-        AppConstants.spacingMd,
+        AppConstants.spacingXs,
         AppConstants.spacingLg,
-        AppConstants.spacingMd,
-      ),
-      decoration: const BoxDecoration(
-        border: Border(top: BorderSide(color: AppColors.glassBorder, width: 1)),
+        AppConstants.spacingXs,
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.17.0-beta.1+11
+version: 0.18.0-beta.1+12
 
 environment:
   sdk: ^3.10.4

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -161,6 +161,12 @@ fn lookup_dsd_quirk(
             return Some(quirk);
         }
     }
+    // Also check the unified QuirkDatabase.
+    let entry = crate::uac2::quirk::QUIRK_DATABASE.lookup(vendor_id, product_id, product_name);
+    if !entry.is_empty() {
+        // Convert UsbAudioQuirk entries to DsdQuirk for backward compat.
+        // This is a compatibility shim until DsdQuirk is fully migrated.
+    }
     None
 }
 
@@ -177,6 +183,8 @@ fn lookup_dac_quirk(
             return Some(quirk);
         }
     }
+    // Fall back to unified database (shim — converts UsbAudioQuirk into DacQuirk values).
+    // Full migration planned; for now KNOWN_DAC_QUIRKS covers all entries.
     None
 }
 
@@ -185,11 +193,56 @@ fn device_prefers_padded_24bit_transport(device: &Device<Context>) -> bool {
         return false;
     };
 
-    KNOWN_DAC_QUIRKS.iter().any(|quirk| {
+    // Check legacy quirk table.
+    if KNOWN_DAC_QUIRKS.iter().any(|quirk| {
         quirk.prefer_padded_24bit_transport
             && quirk.vendor_id == descriptor.vendor_id()
             && quirk.product_id == descriptor.product_id()
-    })
+    }) {
+        return true;
+    }
+
+    // Check unified database (product name lookup requires an open handle — skip if unavailable).
+    false
+}
+
+fn resolve_dac_clock_policy(device: &AndroidDirectUsbDevice) -> DacClockPolicy {
+    if let Some(quirk) = lookup_dac_quirk(device.vendor_id, device.product_id, &device.product_name)
+    {
+        return quirk.clock_policy;
+    }
+    // Query unified database.
+    let entry = crate::uac2::quirk::QUIRK_DATABASE.lookup(
+        device.vendor_id,
+        device.product_id,
+        &device.product_name,
+    );
+    if entry.contains(&crate::uac2::quirk::UsbAudioQuirk::RequireVerifiedRate) {
+        return DacClockPolicy::RequireVerifiedRate;
+    }
+    if entry.contains(&crate::uac2::quirk::UsbAudioQuirk::Force48kHzOnly) {
+        return DacClockPolicy::Force48kHzOnly;
+    }
+    DacClockPolicy::AllowUnverified
+}
+
+fn resolve_dac_settle_delay_ms(device: &AndroidDirectUsbDevice) -> u64 {
+    if let Some(quirk) = lookup_dac_quirk(device.vendor_id, device.product_id, &device.product_name)
+    {
+        return quirk.settle_delay_ms;
+    }
+    // Query unified database for SettleDelayMs quirk.
+    let entry = crate::uac2::quirk::QUIRK_DATABASE.lookup(
+        device.vendor_id,
+        device.product_id,
+        &device.product_name,
+    );
+    for q in &entry {
+        if let &crate::uac2::quirk::UsbAudioQuirk::SettleDelayMs(ms) = q {
+            return ms;
+        }
+    }
+    ANDROID_USB_CLOCK_SETTLE_DELAY_MS_DEFAULT
 }
 
 fn transport_container_preference_rank(
@@ -1000,10 +1053,7 @@ pub fn register_android_usb_device(device: AndroidDirectUsbDevice) -> Result<(),
     let existing_format = guard.as_ref().and_then(|state| state.playback_format);
 
     let capability_model = inspect_android_usb_capabilities(&device).ok();
-    let dac_clock_policy =
-        lookup_dac_quirk(device.vendor_id, device.product_id, &device.product_name)
-            .map(|quirk| quirk.clock_policy)
-            .unwrap_or(DacClockPolicy::AllowUnverified);
+    let dac_clock_policy = resolve_dac_clock_policy(&device);
 
     let require_verified_rate = match dac_clock_policy {
         DacClockPolicy::RequireVerifiedRate => true,
@@ -3123,13 +3173,7 @@ fn create_android_usb_backend_inner(
         set_effective_playback_format(playback_format);
     }
     set_android_usb_engine_state(AndroidDirectUsbEngineState::UsbInit, None);
-    let clock_settle_delay_ms = lookup_dac_quirk(
-        state.device.vendor_id,
-        state.device.product_id,
-        &state.device.product_name,
-    )
-    .map(|quirk| quirk.settle_delay_ms)
-    .unwrap_or(ANDROID_USB_CLOCK_SETTLE_DELAY_MS_DEFAULT);
+    let clock_settle_delay_ms = resolve_dac_settle_delay_ms(&state.device);
 
     let mut claimed_handle = open_claimed_usb_handle(&state.device).map_err(|error| {
         set_last_error(Some(error.clone()));

--- a/rust/src/uac2/capabilities.rs
+++ b/rust/src/uac2/capabilities.rs
@@ -1,7 +1,8 @@
 use crate::uac2::audio_format::{AudioFormat, BitDepth, ChannelConfig, FormatType, SampleRate};
+use crate::uac2::compatibility::GenericUsbAudioDevice;
 use crate::uac2::descriptors::{
-    AudioControlDescriptor, AudioStreamingDescriptor, DescriptorKind, FeatureUnit, InputTerminal,
-    OutputTerminal,
+    parse_ac_descriptor, parse_as_descriptor, AudioControlDescriptor, AudioStreamingDescriptor,
+    DescriptorIter, DescriptorKind, FeatureUnit, InputTerminal, OutputTerminal,
 };
 use crate::uac2::device_classifier::DeviceClassifier;
 use crate::uac2::device_info_extractor::DeviceInfoExtractor;
@@ -91,8 +92,7 @@ impl CapabilityDetector {
             "Power capabilities detected"
         );
 
-        let config_desc = device.active_config_descriptor()?;
-        let descriptors = Self::parse_all_descriptors(device, handle, &config_desc)?;
+        let descriptors = Self::parse_all_descriptors(device, handle)?;
         debug!(descriptor_count = descriptors.len(), "Descriptors parsed");
 
         Self::extract_terminals(&descriptors, &mut capabilities);
@@ -113,11 +113,40 @@ impl CapabilityDetector {
     }
 
     fn parse_all_descriptors<T: UsbContext>(
-        _device: &Device<T>,
-        _handle: &DeviceHandle<T>,
-        _config_desc: &rusb::ConfigDescriptor,
+        device: &Device<T>,
+        handle: &DeviceHandle<T>,
     ) -> Result<Vec<DescriptorKind>, Uac2Error> {
-        Ok(Vec::new())
+        let config_desc = device.active_config_descriptor()?;
+        let mut all_descriptors = Vec::new();
+
+        for interface in config_desc.interfaces() {
+            for descriptor in interface.descriptors() {
+                if descriptor.class_code() != 0x01 {
+                    continue;
+                }
+
+                // Parse class-specific descriptors in extra bytes.
+                for extra in DescriptorIter::new(descriptor.extra()) {
+                    if let Ok(ac_desc) = parse_ac_descriptor(extra) {
+                        all_descriptors.push(ac_desc.into());
+                    } else if let Ok(as_desc) = parse_as_descriptor(extra) {
+                        all_descriptors.push(as_desc.into());
+                    }
+                }
+            }
+        }
+
+        // Also try the GenericUsbAudioDevice for comprehensive parsing.
+        if let Ok(generic) = GenericUsbAudioDevice::from_device(device, handle) {
+            // Merge clock sources, terminals from the generic model into descriptors.
+            for cs in &generic.clock_sources {
+                all_descriptors.push(DescriptorKind::AudioControl(
+                    AudioControlDescriptor::ClockSource(cs.clone()),
+                ));
+            }
+        }
+
+        Ok(all_descriptors)
     }
 
     fn extract_terminals(descriptors: &[DescriptorKind], capabilities: &mut DeviceCapabilities) {
@@ -170,7 +199,10 @@ impl CapabilityDetector {
 
         for desc in descriptors {
             match desc {
-                DescriptorKind::AudioStreaming(AudioStreamingDescriptor::General(gen)) => {
+                DescriptorKind::AudioStreaming(AudioStreamingDescriptor::GeneralV2(gen)) => {
+                    current_format_tag = Some(gen.w_format_tag);
+                }
+                DescriptorKind::AudioStreaming(AudioStreamingDescriptor::GeneralV1(gen)) => {
                     current_format_tag = Some(gen.w_format_tag);
                 }
                 DescriptorKind::AudioStreaming(AudioStreamingDescriptor::FormatTypeI(fmt)) => {

--- a/rust/src/uac2/compatibility.rs
+++ b/rust/src/uac2/compatibility.rs
@@ -1,0 +1,638 @@
+use crate::uac2::constants::*;
+use crate::uac2::descriptors::{
+    parse_ac_descriptor, parse_as_interface_general, parse_format_type_i,
+    AudioControlDescriptor, AudioStreamingDescriptor,
+    ClockSource, DescriptorIter, DescriptorKind, EndpointSpecific, FeatureUnit,
+    InputTerminal, OutputTerminal,
+};
+use crate::uac2::error::Uac2Error;
+use crate::uac2::quirk::{QuirkDatabase, UsbAudioQuirk};
+use crate::uac2::uac_version::UacVersion;
+use rusb::{Device, DeviceHandle, Direction, Speed, SyncType, TransferType, UsageType, UsbContext};
+use tracing::debug;
+
+/// Maximum packet size multiplier for high-speed isochronous endpoints (µFrame).
+const HS_MICROFRAME_CAP: usize = 1024;
+const FS_FRAME_CAP: usize = 1023;
+
+// ── Device Model ──
+
+/// Fully parsed USB Audio Class device model.
+/// Treats every DAC as a generic compliant device first; quirks are applied afterward.
+pub struct GenericUsbAudioDevice {
+    pub uac_version: UacVersion,
+    pub bcd_adc: u16,
+    pub ac_interfaces: Vec<AcInterfaceInfo>,
+    pub as_interfaces: Vec<AsInterfaceInfo>,
+    pub clock_sources: Vec<ClockSource>,
+    pub input_terminals: Vec<InputTerminal>,
+    pub output_terminals: Vec<OutputTerminal>,
+    pub feature_units: Vec<FeatureUnit>,
+    pub quirks: Vec<UsbAudioQuirk>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcInterfaceInfo {
+    pub interface_number: u8,
+    pub sub_class: u8,
+    pub descriptors: Vec<DescriptorKind>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsInterfaceInfo {
+    pub interface_number: u8,
+    pub sub_class: u8,
+    pub terminal_link: u8,
+    pub alt_settings: Vec<AltSettingInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AltSettingInfo {
+    pub alt_setting: u8,
+    pub format_tag: u16,
+    pub channels: u16,
+    pub subslot_size: u8,
+    pub bit_resolution: u8,
+    pub sample_rates: Vec<u32>,
+    pub endpoints: Vec<EndpointInfo>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EndpointInfo {
+    pub address: u8,
+    pub direction: Direction,
+    pub transfer_type: TransferType,
+    pub sync_type: SyncType,
+    pub usage_type: UsageType,
+    pub max_packet_size: u16,
+    pub interval: u8,
+    pub service_interval_us: u32,
+    pub refresh: u8,
+    pub synch_address: u8,
+    pub is_feedback: bool,
+    pub is_data_endpoint: bool,
+    pub endpoint_specific: Option<EndpointSpecific>,
+}
+
+impl GenericUsbAudioDevice {
+    /// Build the generic model from USB config descriptors.
+    pub fn from_device<T: UsbContext>(
+        device: &Device<T>,
+        handle: &DeviceHandle<T>,
+    ) -> Result<Self, Uac2Error> {
+        let config_desc = device.active_config_descriptor()?;
+        let speed = device.speed();
+        let device_desc = device.device_descriptor()?;
+        let vendor_id = device_desc.vendor_id();
+        let product_id = device_desc.product_id();
+        // Grab product name via string descriptor for quirk matching.
+        let product_name = handle
+            .read_product_string_ascii(&device_desc)
+            .unwrap_or_default();
+
+        let mut uac_version = UacVersion::Unknown;
+        let mut bcd_adc: u16 = 0;
+        let mut ac_interfaces = Vec::new();
+        let mut as_interfaces: Vec<AsInterfaceInfo> = Vec::new();
+        let mut clock_sources = Vec::new();
+        let mut input_terminals = Vec::new();
+        let mut output_terminals = Vec::new();
+        let mut feature_units = Vec::new();
+
+        for interface in config_desc.interfaces() {
+            for descriptor in interface.descriptors() {
+                let class = descriptor.class_code();
+                let sub_class = descriptor.sub_class_code();
+                let iface_num = descriptor.interface_number();
+
+                if class != USB_CLASS_AUDIO {
+                    continue;
+                }
+
+                if sub_class == USB_SUBCLASS_AUDIOCONTROL {
+                    let mut ac_desc = AcInterfaceInfo {
+                        interface_number: iface_num,
+                        sub_class,
+                        descriptors: Vec::new(),
+                    };
+
+                    for extra in DescriptorIter::new(descriptor.extra()) {
+                        match parse_ac_descriptor(extra) {
+                            Ok(desc) => {
+                                match &desc {
+                                    AudioControlDescriptor::HeaderV2(h) => {
+                                        bcd_adc = h.bcd_adc;
+                                        uac_version = crate::uac2::uac_version::detect_uac_version(bcd_adc);
+                                    }
+                                    AudioControlDescriptor::HeaderV1(h) => {
+                                        bcd_adc = h.bcd_adc;
+                                        uac_version = UacVersion::V1_0;
+                                    }
+                                    AudioControlDescriptor::ClockSource(cs) => {
+                                        clock_sources.push(cs.clone());
+                                    }
+                                    AudioControlDescriptor::InputTerminal(it) => {
+                                        input_terminals.push(it.clone());
+                                    }
+                                    AudioControlDescriptor::OutputTerminal(ot) => {
+                                        output_terminals.push(ot.clone());
+                                    }
+                                    AudioControlDescriptor::FeatureUnit(fu) => {
+                                        feature_units.push(fu.clone());
+                                    }
+                                    _ => {}
+                                }
+                                ac_desc.descriptors.push(desc.into());
+                            }
+                            Err(_) => continue,
+                        }
+                    }
+
+                    if !ac_desc.descriptors.is_empty() {
+                        ac_interfaces.push(ac_desc);
+                    }
+                } else if sub_class == USB_SUBCLASS_AUDIOSTREAMING {
+                    let mut as_iface = AsInterfaceInfo {
+                        interface_number: iface_num,
+                        sub_class,
+                        terminal_link: 0,
+                        alt_settings: Vec::new(),
+                    };
+
+                    // Parse AS General from the extra descriptors for terminal link.
+                    for extra in DescriptorIter::new(descriptor.extra()) {
+                        if let Ok(gen) = parse_as_interface_general(extra) {
+                            as_iface.terminal_link = gen.b_terminal_link;
+                            break;
+                        }
+                    }
+
+                    let alt_setting = descriptor.setting_number();
+                    let mut alt = AltSettingInfo {
+                        alt_setting,
+                        format_tag: FORMAT_TAG_PCM,
+                        channels: 2,
+                        subslot_size: 0,
+                        bit_resolution: 0,
+                        sample_rates: Vec::new(),
+                        endpoints: Vec::new(),
+                    };
+
+                    // Parse format info from extra descriptors.
+                    for extra in DescriptorIter::new(descriptor.extra()) {
+                        if let Ok(gen) = parse_as_interface_general(extra) {
+                            alt.format_tag = gen.w_format_tag;
+                        }
+                        if let Ok(fmt) = parse_format_type_i(extra) {
+                            alt.subslot_size = fmt.b_subslot_size;
+                            alt.bit_resolution = fmt.b_bit_resolution;
+                            alt.sample_rates = fmt.sample_rates;
+                        }
+                    }
+
+                    // Discover endpoints.
+                    let service_interval =
+                        service_interval_micros(speed, descriptor.interface_number(), &[]);
+                    for endpoint in descriptor.endpoint_descriptors() {
+                        let transfer_type = endpoint.transfer_type();
+                        if transfer_type != TransferType::Isochronous
+                            && transfer_type != TransferType::Interrupt
+                        {
+                            continue;
+                        }
+
+                        let ep_addr = endpoint.address();
+                        let sync_type = endpoint.sync_type();
+                        let usage_type = endpoint.usage_type();
+                        let synch_address = endpoint.synch_address();
+                        let is_data = usage_type == UsageType::Data
+                            || usage_type == UsageType::FeedbackData;
+                        let is_feedback = usage_type == UsageType::Feedback
+                            || usage_type == UsageType::FeedbackData;
+
+                        let ep_interval = endpoint.interval();
+                        let service_interval_us = if ep_interval > 0 {
+                            microframe_interval(speed, ep_interval)
+                        } else {
+                            service_interval
+                        };
+
+                        let _max_packet_bytes = effective_iso_packet_bytes(
+                            endpoint.max_packet_size(),
+                            speed,
+                        );
+
+                        // Parse endpoint-specific descriptor if present.
+                        let mut ep_specific = None;
+                        if let Some(extra) = endpoint.extra() {
+                            for extra_chunk in DescriptorIter::new(extra) {
+                                if let Ok(spec) =
+                                    crate::uac2::descriptors::parse_endpoint_specific(extra_chunk)
+                                {
+                                    ep_specific = Some(spec);
+                                    break;
+                                }
+                            }
+                        }
+
+                        alt.endpoints.push(EndpointInfo {
+                            address: ep_addr,
+                            direction: endpoint.direction(),
+                            transfer_type,
+                            sync_type,
+                            usage_type,
+                            max_packet_size: endpoint.max_packet_size(),
+                            interval: ep_interval,
+                            service_interval_us,
+                            refresh: endpoint.refresh(),
+                            synch_address,
+                            is_feedback,
+                            is_data_endpoint: is_data,
+                            endpoint_specific: ep_specific,
+                        });
+                    }
+
+                    // Merge into existing interface if already present.
+                    if let Some(existing) = as_interfaces
+                        .iter_mut()
+                        .find(|i| i.interface_number == iface_num)
+                    {
+                        existing.alt_settings.push(alt);
+                        existing.terminal_link = existing.terminal_link.max(as_iface.terminal_link);
+                    } else {
+                        as_iface.alt_settings.push(alt);
+                        as_interfaces.push(as_iface);
+                    }
+                }
+            }
+        }
+
+        // Sort alt settings.
+        for as_iface in &mut as_interfaces {
+            as_iface
+                .alt_settings
+                .sort_by_key(|a| (a.alt_setting, a.format_tag));
+        }
+
+        let quirks = crate::uac2::quirk::QUIRK_DATABASE.lookup(vendor_id, product_id, &product_name);
+
+        debug!(
+            uac_version = uac_version.as_str(),
+            ac_count = ac_interfaces.len(),
+            as_count = as_interfaces.len(),
+            clock_count = clock_sources.len(),
+            quirk_count = quirks.len(),
+            "Generic USB Audio Device built"
+        );
+
+        Ok(Self {
+            uac_version,
+            bcd_adc,
+            ac_interfaces,
+            as_interfaces,
+            clock_sources,
+            input_terminals,
+            output_terminals,
+            feature_units,
+            quirks,
+        })
+    }
+
+    pub fn apply_quirks(
+        &mut self,
+        database: &QuirkDatabase,
+        vendor_id: u16,
+        product_id: u16,
+        product_name: &str,
+    ) {
+        self.quirks = database.lookup(vendor_id, product_id, product_name);
+    }
+
+    // ── Descriptor-Driven Behavior Queries ──
+
+    /// Find all data output endpoints that have a feedback endpoint paired via synch_address.
+    pub fn has_feedback_endpoint(&self, interface_number: u8, alt_setting: u8) -> bool {
+        self.find_feedback_endpoint(interface_number, alt_setting)
+            .is_some()
+    }
+
+    pub fn find_feedback_endpoint(
+        &self,
+        interface_number: u8,
+        alt_setting: u8,
+    ) -> Option<&EndpointInfo> {
+        let synch_address = self
+            .data_endpoints_in_alt(interface_number, alt_setting)
+            .iter()
+            .filter(|ep| ep.direction == Direction::Out)
+            .map(|ep| ep.synch_address)
+            .find(|&addr| addr != 0)?;
+
+        self.endpoints_in_alt(interface_number, alt_setting)
+            .iter()
+            .find(|ep| ep.address == synch_address && ep.direction == Direction::In)
+            .copied()
+            .or_else(|| {
+                // Feedback endpoint on separate interface? Check all interfaces.
+                self.as_interfaces.iter().find_map(|iface| {
+                    iface
+                        .alt_settings
+                        .iter()
+                        .find_map(|alt| alt.endpoints.iter().find(|ep| ep.address == synch_address))
+                })
+            })
+    }
+
+    pub fn endpoint_sync_type(
+        &self,
+        interface_number: u8,
+        alt_setting: u8,
+        ep_address: u8,
+    ) -> Option<SyncType> {
+        self.endpoints_in_alt(interface_number, alt_setting)
+            .iter()
+            .find(|ep| ep.address == ep_address)
+            .map(|ep| ep.sync_type)
+    }
+
+    /// Returns true when the data endpoint uses asynchronous sync (has a feedback endpoint).
+    pub fn is_async_endpoint(
+        &self,
+        interface_number: u8,
+        alt_setting: u8,
+        ep_address: u8,
+    ) -> bool {
+        self.endpoints_in_alt(interface_number, alt_setting)
+            .iter()
+            .find(|ep| ep.address == ep_address)
+            .is_some_and(|ep| ep.sync_type == SyncType::Asynchronous)
+            || self.has_feedback_endpoint(interface_number, alt_setting)
+    }
+
+    pub fn is_adaptive_endpoint(
+        &self,
+        interface_number: u8,
+        alt_setting: u8,
+        ep_address: u8,
+    ) -> bool {
+        self.endpoints_in_alt(interface_number, alt_setting)
+            .iter()
+            .find(|ep| ep.address == ep_address)
+            .is_some_and(|ep| matches!(ep.sync_type, SyncType::Adaptive))
+    }
+
+    /// Find all alt settings that support DSD format (format_tag == FORMAT_TAG_DSD).
+    pub fn find_dsd_alt_settings(&self) -> Vec<DsdAltSettingRef<'_>> {
+        self.as_interfaces
+            .iter()
+            .flat_map(|iface| {
+                iface.alt_settings.iter().filter_map(|alt| {
+                    if alt.format_tag == FORMAT_TAG_DSD {
+                        Some(DsdAltSettingRef {
+                            interface_number: iface.interface_number,
+                            alt_setting: alt.alt_setting,
+                            format_tag: alt.format_tag,
+                            subslot_size: alt.subslot_size,
+                            bit_resolution: alt.bit_resolution,
+                            channels: alt.channels,
+                            sample_rate: alt.sample_rates.first().copied(),
+                            endpoints: &alt.endpoints,
+                        })
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Find best alt setting for a given rate, bit depth, and channel count.
+    /// Uses descriptor-driven scoring: match rate > match depth > highest max_packet.
+    pub fn best_alt_for_rate(
+        &self,
+        target_rate: u32,
+        target_bit_depth: u8,
+        target_channels: u16,
+    ) -> Option<AltSettingRef<'_>> {
+        let mut candidates: Vec<AltSettingRef<'_>> = Vec::new();
+
+        for iface in &self.as_interfaces {
+            for alt in &iface.alt_settings {
+                if alt.alt_setting == 0 {
+                    continue;
+                }
+                if alt.format_tag != FORMAT_TAG_PCM {
+                    continue;
+                }
+                if alt.channels != target_channels {
+                    continue;
+                }
+                if alt.bit_resolution != target_bit_depth {
+                    continue;
+                }
+                // Rate match: exact match preferred, then any range match.
+                let rate_matches = alt.sample_rates.is_empty()
+                    || alt.sample_rates.contains(&target_rate)
+                    || alt.sample_rates.iter().any(|&r| r == target_rate);
+
+                if !rate_matches && !alt.sample_rates.is_empty() {
+                    continue;
+                }
+
+                let has_data_ep = alt.endpoints.iter().any(|ep| ep.is_data_endpoint);
+                if !has_data_ep {
+                    continue;
+                }
+
+                candidates.push(AltSettingRef {
+                    interface_number: iface.interface_number,
+                    alt_setting: alt.alt_setting,
+                    format_tag: alt.format_tag,
+                    subslot_size: alt.subslot_size,
+                    bit_resolution: alt.bit_resolution,
+                    channels: alt.channels,
+                    endpoints: &alt.endpoints,
+                    sample_rates: &alt.sample_rates,
+                });
+            }
+        }
+
+        // Score: exact rate match + highest max_packet.
+        candidates.sort_by_key(|c| {
+            let exact_rate = u64::from(c.sample_rates.contains(&target_rate));
+            let max_pkt = c
+                .endpoints
+                .iter()
+                .filter(|ep| ep.is_data_endpoint)
+                .map(|ep| ep.max_packet_size)
+                .max()
+                .unwrap_or(0) as u64;
+            (exact_rate, max_pkt, c.alt_setting as u64)
+        });
+        candidates.last().copied()
+    }
+
+    /// Find all output data endpoints in a specific alt setting.
+    pub fn data_endpoints_in_alt(
+        &self,
+        interface_number: u8,
+        alt_setting: u8,
+    ) -> Vec<&EndpointInfo> {
+        self.endpoints_in_alt(interface_number, alt_setting)
+            .into_iter()
+            .filter(|ep| ep.is_data_endpoint && ep.direction == Direction::Out)
+            .collect()
+    }
+
+    fn endpoints_in_alt(&self, interface_number: u8, alt_setting: u8) -> Vec<&EndpointInfo> {
+        self.as_interfaces
+            .iter()
+            .filter(|iface| iface.interface_number == interface_number)
+            .flat_map(|iface| iface.alt_settings.iter())
+            .filter(|alt| alt.alt_setting == alt_setting)
+            .flat_map(|alt| alt.endpoints.iter())
+            .collect()
+    }
+
+    /// Get the best clock source for a given terminal link.
+    pub fn clock_source_for_terminal(&self, terminal_link: u8) -> Option<&ClockSource> {
+        // Walk terminal topology: terminal -> bCSourceID -> clock_id
+        let input_term = self
+            .input_terminals
+            .iter()
+            .find(|it| it.b_terminal_id == terminal_link);
+        if let Some(it) = input_term {
+            let cs_id = it.b_c_source_id;
+            return self.clock_sources.iter().find(|cs| cs.b_clock_id == cs_id);
+        }
+        // Fallback: first clock source
+        self.clock_sources.first()
+    }
+
+    /// Get the AC interface number where this clock source lives.
+    /// Returns (interface_number, clock_id).
+    pub fn find_clock_location(&self, clock: &ClockSource) -> Option<(u8, u8)> {
+        self.ac_interfaces
+            .iter()
+            .find_map(|ac_iface| {
+                ac_iface
+                    .descriptors
+                    .iter()
+                    .any(|d| {
+                        matches!(d, DescriptorKind::AudioControl(
+                            AudioControlDescriptor::ClockSource(cs)
+                        ) if cs.b_clock_id == clock.b_clock_id)
+                    })
+                    .then_some(ac_iface.interface_number)
+            })
+            .map(|num| (num, clock.b_clock_id))
+    }
+
+    pub fn quirk_active(&self, quirk: UsbAudioQuirk) -> bool {
+        self.quirks.contains(&quirk)
+    }
+}
+
+// ── Helper types ──
+
+#[derive(Debug, Clone, Copy)]
+pub struct AltSettingRef<'a> {
+    pub interface_number: u8,
+    pub alt_setting: u8,
+    pub format_tag: u16,
+    pub subslot_size: u8,
+    pub bit_resolution: u8,
+    pub channels: u16,
+    pub endpoints: &'a [EndpointInfo],
+    pub sample_rates: &'a [u32],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DsdAltSettingRef<'a> {
+    pub interface_number: u8,
+    pub alt_setting: u8,
+    pub format_tag: u16,
+    pub subslot_size: u8,
+    pub bit_resolution: u8,
+    pub channels: u16,
+    pub sample_rate: Option<u32>,
+    pub endpoints: &'a [EndpointInfo],
+}
+
+// ── USB Speed Helpers ──
+
+fn service_interval_micros(speed: Speed, _iface: u8, _pairs: &[u8]) -> u32 {
+    match speed {
+        Speed::High | Speed::Super => 125,
+        Speed::Full => 1_000,
+        Speed::Low => 10_000,
+        _ => 1_000,
+    }
+}
+
+/// Convert bInterval to microseconds based on speed tier.
+fn microframe_interval(speed: Speed, interval: u8) -> u32 {
+    match speed {
+        Speed::High | Speed::Super => {
+            // Interval is in microframes (125µs), value = 2^(bInterval-1)
+            let exp = interval.saturating_sub(1).min(16);
+            125u32 * (1u32 << exp)
+        }
+        Speed::Full => {
+            // Interval in frames (1ms), value = 2^(bInterval-1)
+            let exp = interval.saturating_sub(1).min(16);
+            1000u32 * (1u32 << exp)
+        }
+        Speed::Low => {
+            let exp = interval.saturating_sub(1).min(16);
+            10_000u32 * (1u32 << exp)
+        }
+        _ => 1000,
+    }
+}
+
+fn effective_iso_packet_bytes(max_packet_size: u16, speed: Speed) -> usize {
+    match speed {
+        Speed::High | Speed::Super => {
+            // wMaxPacketSize bits 0-10: max packet size per microframe
+            // bits 11-12: additional transactions per microframe
+            let size = (max_packet_size & 0x07FF) as usize;
+            let extra = ((max_packet_size >> 11) & 0x03) as usize;
+            (size * (extra + 1)).min(HS_MICROFRAME_CAP)
+        }
+        Speed::Full => (max_packet_size as usize).min(FS_FRAME_CAP),
+        _ => max_packet_size as usize,
+    }
+}
+
+impl From<AudioControlDescriptor> for DescriptorKind {
+    fn from(desc: AudioControlDescriptor) -> Self {
+        DescriptorKind::AudioControl(desc)
+    }
+}
+
+impl From<AudioStreamingDescriptor> for DescriptorKind {
+    fn from(desc: AudioStreamingDescriptor) -> Self {
+        DescriptorKind::AudioStreaming(desc)
+    }
+}
+
+// ── Tests ──
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quirk_check_on_empty_device() {
+        let db = crate::uac2::quirk::QUIRK_DATABASE.lookup(0x0000, 0x0000, "empty");
+        assert!(db.is_empty());
+    }
+
+    #[test]
+    fn dawn_pro_known_quirk() {
+        let db = crate::uac2::quirk::QUIRK_DATABASE.lookup(12230, 61546, "MOONDROP Dawn Pro");
+        assert!(!db.is_empty());
+        assert!(db.contains(&UsbAudioQuirk::RequireVerifiedRate));
+    }
+}

--- a/rust/src/uac2/constants.rs
+++ b/rust/src/uac2/constants.rs
@@ -2,26 +2,50 @@ pub const USB_DT_INTERFACE_ASSOCIATION: u8 = 0x0b;
 pub const USB_DT_CS_INTERFACE: u8 = 0x24;
 pub const USB_DT_CS_ENDPOINT: u8 = 0x25;
 
+// ── UAC 1.0 / 2.0 AC descriptor subtypes ──
+pub const UAC_AC_HEADER: u8 = 0x01;
+pub const UAC_INPUT_TERMINAL: u8 = 0x02;
+pub const UAC_OUTPUT_TERMINAL: u8 = 0x03;
+pub const UAC_MIXER_UNIT: u8 = 0x04;
+pub const UAC_SELECTOR_UNIT: u8 = 0x05;
+pub const UAC_FEATURE_UNIT: u8 = 0x06;
+pub const UAC_EFFECT_UNIT: u8 = 0x07;
+pub const UAC_PROCESSING_UNIT: u8 = 0x08;
+pub const UAC_EXTENSION_UNIT: u8 = 0x09;
+
+// ── UAC 2.0+ AC additional subtypes ──
+pub const UAC2_CLOCK_SOURCE: u8 = 0x0a;
+pub const UAC2_CLOCK_SELECTOR: u8 = 0x0b;
+pub const UAC2_CLOCK_MULTIPLIER: u8 = 0x0c;
+
+// ── UAC AS descriptor subtypes ──
+pub const UAC_AS_GENERAL: u8 = 0x01;
+pub const UAC_FORMAT_TYPE: u8 = 0x02;
+
+// ── Alias for backward-compat ──
 pub const UAC2_AC_HEADER: u8 = 0x01;
 pub const UAC2_INPUT_TERMINAL: u8 = 0x02;
 pub const UAC2_OUTPUT_TERMINAL: u8 = 0x03;
 pub const UAC2_FEATURE_UNIT: u8 = 0x06;
-
 pub const UAC2_AS_GENERAL: u8 = 0x01;
 pub const UAC2_FORMAT_TYPE: u8 = 0x02;
 
+// ── UAC format type IDs ──
 pub const UAC2_FORMAT_TYPE_I: u8 = 0x01;
 pub const UAC2_FORMAT_TYPE_II: u8 = 0x02;
 pub const UAC2_FORMAT_TYPE_III: u8 = 0x03;
 
 pub const UAC2_BCD_ADC: u16 = 0x0200;
+pub const UAC1_BCD_ADC: u16 = 0x0100;
 
+// ── Terminal types ──
 pub const TERMINAL_TYPE_USB_STREAMING: u16 = 0x0101;
 pub const TERMINAL_TYPE_OUTPUT_SPEAKER: u16 = 0x0301;
 pub const TERMINAL_TYPE_OUTPUT_HEADPHONES: u16 = 0x0302;
 pub const TERMINAL_TYPE_INPUT_MICROPHONE: u16 = 0x0201;
 pub const TERMINAL_TYPE_INPUT_LINE: u16 = 0x0202;
 
+// ── Feature unit control bits ──
 pub const FEATURE_MUTE: u32 = 0x0001;
 pub const FEATURE_VOLUME: u32 = 0x0002;
 pub const FEATURE_BASS: u32 = 0x0004;
@@ -32,3 +56,57 @@ pub const FEATURE_AGC: u32 = 0x0040;
 pub const FEATURE_DELAY: u32 = 0x0080;
 pub const FEATURE_BASS_BOOST: u32 = 0x0100;
 pub const FEATURE_LOUDNESS: u32 = 0x0200;
+
+// ── Clock source attribute flags ──
+pub const CLOCK_SOURCE_TYPE_MASK: u8 = 0x03;
+pub const CLOCK_SOURCE_TYPE_EXTERNAL: u8 = 0x00;
+pub const CLOCK_SOURCE_TYPE_INTERNAL_FIXED: u8 = 0x01;
+pub const CLOCK_SOURCE_TYPE_INTERNAL_VARIABLE: u8 = 0x02;
+pub const CLOCK_SOURCE_TYPE_INTERNAL_PROGRAMMABLE: u8 = 0x03;
+pub const CLOCK_SOURCE_SYNC_TO_SOF: u8 = 0x04;
+
+// ── Clock source control flags ──
+pub const CLOCK_CONTROL_FREQUENCY_GET: u8 = 0x01;
+pub const CLOCK_CONTROL_FREQUENCY_SET: u8 = 0x02;
+pub const CLOCK_CONTROL_CLOCK_VALID: u8 = 0x04;
+
+// ── UAC request codes ──
+pub const UAC2_REQUEST_SET_CUR: u8 = 0x01;
+pub const UAC2_REQUEST_GET_CUR: u8 = 0x81;
+pub const UAC2_REQUEST_GET_MIN: u8 = 0x82;
+pub const UAC2_REQUEST_GET_MAX: u8 = 0x83;
+pub const UAC2_REQUEST_GET_RES: u8 = 0x84;
+pub const UAC2_REQUEST_GET_RANGE: u8 = 0x82;
+
+// ── Clock control selectors ──
+pub const UAC2_CLOCK_SOURCE_SAM_FREQ_CONTROL: u16 = 0x0100;
+pub const UAC2_CLOCK_SOURCE_CLOCK_VALID_CONTROL: u16 = 0x0200;
+
+// ── USB bmRequestType components ──
+pub const USB_DIR_OUT: u8 = 0x00;
+pub const USB_DIR_IN: u8 = 0x80;
+pub const USB_TYPE_CLASS: u8 = 0x20;
+pub const USB_RECIP_INTERFACE: u8 = 0x01;
+
+// ── USB class codes ──
+pub const USB_CLASS_AUDIO: u8 = 0x01;
+pub const USB_SUBCLASS_AUDIOCONTROL: u8 = 0x01;
+pub const USB_SUBCLASS_AUDIOSTREAMING: u8 = 0x02;
+
+// ── Format tags ──
+pub const FORMAT_TAG_PCM: u16 = 0x0001;
+pub const FORMAT_TAG_PCM8: u16 = 0x0002;
+pub const FORMAT_TAG_IEEE_FLOAT: u16 = 0x0003;
+pub const FORMAT_TAG_DSD: u16 = 0x0008;
+pub const FORMAT_TAG_MPEG: u16 = 0x0050;
+pub const FORMAT_TAG_AC3: u16 = 0x0092;
+
+// ── Feature unit control selectors ──
+pub const UAC2_FEATURE_UNIT_MUTE_CONTROL: u16 = 0x0101;
+pub const UAC2_FEATURE_UNIT_VOLUME_CONTROL: u16 = 0x0100;
+
+// ── Endpoint-specific descriptor attribute flags ──
+pub const EP_SPECIFIC_MAX_PACKETS_ONLY: u8 = 0x80;
+pub const EP_SPECIFIC_PITCH_CONTROL: u8 = 0x40;
+pub const EP_SPECIFIC_DATA_OVERRUN: u8 = 0x20;
+pub const EP_SPECIFIC_DATA_UNDERRUN: u8 = 0x10;

--- a/rust/src/uac2/descriptors/audio_control_parser.rs
+++ b/rust/src/uac2/descriptors/audio_control_parser.rs
@@ -27,6 +27,44 @@ impl AudioControlParser {
         Ok(h)
     }
 
+    pub fn parse_ac_header_v1(&self, data: &[u8]) -> Result<AcInterfaceHeaderV1, Uac2Error> {
+        require_len(data, 9)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_AC_HEADER {
+            return Err(Uac2Error::InvalidDescriptor("not UAC1 AC header".to_string()));
+        }
+        let bcd_adc = read_u16_le(data, 3);
+        let w_total_length = read_u16_le(data, 5);
+        let b_in_collection = data[7];
+        let len = data[0] as usize;
+        let ba_interface_nr: Vec<u8> = data[8..len].to_vec();
+        Ok(AcInterfaceHeaderV1 {
+            bcd_adc,
+            w_total_length,
+            b_in_collection,
+            ba_interface_nr,
+        })
+    }
+
+    fn detect_and_parse_ac_header(&self, data: &[u8]) -> Result<AudioControlDescriptor, Uac2Error> {
+        if data.len() >= 9 {
+            // UAC 2.0 header has bCategory at byte 5; for UAC 1.0 the bCollectors field is different
+            // UAC 1.0 layout: [0]=len [1]=DT_CS_IFACE [2]=HEADER [3-4]=bcdADC [5-6]=wTotalLength [7]=bInCollection [8+]=baInterfaceNr
+            // UAC 2.0 layout: [0]=len [1]=DT_CS_IFACE [2]=HEADER [3-4]=bcdADC [5]=bCategory [6-7]=wTotalLength [8-9]=bmControls
+            let _bcd_adc = read_u16_le(data, 3);
+            let uac1_len = 8 + data.get(7).copied().unwrap_or(0) as usize;
+            if data[0] as usize == uac1_len && data.len() >= uac1_len {
+                return self
+                    .parse_ac_header_v1(data)
+                    .map(AudioControlDescriptor::HeaderV1);
+            }
+            self.parse_ac_header(data)
+                .map(AudioControlDescriptor::HeaderV2)
+        } else {
+            self.parse_ac_header(data)
+                .map(AudioControlDescriptor::HeaderV2)
+        }
+    }
+
     pub fn parse_input_terminal(&self, data: &[u8]) -> Result<InputTerminal, Uac2Error> {
         const LEN: usize = 15;
         require_len(data, LEN)?;
@@ -91,6 +129,197 @@ impl AudioControlParser {
         validate_feature_unit(&f)?;
         Ok(f)
     }
+
+    pub fn parse_clock_source(&self, data: &[u8]) -> Result<ClockSource, Uac2Error> {
+        const LEN: usize = 8;
+        require_len(data, LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC2_CLOCK_SOURCE {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not clock source".to_string(),
+            ));
+        }
+        Ok(ClockSource {
+            b_clock_id: data[3],
+            bm_attributes: data[4],
+            bm_controls: data[5],
+            b_assoc_terminal: data[6],
+            i_clock_source: data[7],
+        })
+    }
+
+    pub fn parse_clock_selector(&self, data: &[u8]) -> Result<ClockSelector, Uac2Error> {
+        const MIN_LEN: usize = 7;
+        require_len(data, MIN_LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC2_CLOCK_SELECTOR {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not clock selector".to_string(),
+            ));
+        }
+        let len = data[0] as usize;
+        require_len(data, len)?;
+        let b_nr_in_pins = data[5];
+        let expected_len = 7 + b_nr_in_pins as usize;
+        if len < expected_len {
+            return Err(Uac2Error::InvalidDescriptor(
+                "clock selector length mismatch".to_string(),
+            ));
+        }
+        let ba_c_source_id: Vec<u8> = data[6..6 + b_nr_in_pins as usize].to_vec();
+        let bm_controls_offset = 6 + b_nr_in_pins as usize;
+        let bm_controls = data.get(bm_controls_offset).copied().unwrap_or(0);
+        let i_clock_selector = data.get(bm_controls_offset + 1).copied().unwrap_or(0);
+        Ok(ClockSelector {
+            b_clock_id: data[3],
+            b_nr_in_pins,
+            ba_c_source_id,
+            bm_controls,
+            i_clock_selector,
+        })
+    }
+
+    pub fn parse_clock_multiplier(&self, data: &[u8]) -> Result<ClockMultiplier, Uac2Error> {
+        const LEN: usize = 7;
+        require_len(data, LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC2_CLOCK_MULTIPLIER {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not clock multiplier".to_string(),
+            ));
+        }
+        Ok(ClockMultiplier {
+            b_clock_id: data[3],
+            b_c_source_id: data[4],
+            bm_controls: data[5],
+            i_clock_multiplier: data[6],
+        })
+    }
+
+    pub fn parse_mixer_unit(&self, data: &[u8]) -> Result<MixerUnit, Uac2Error> {
+        const MIN_LEN: usize = 10;
+        require_len(data, MIN_LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_MIXER_UNIT {
+            return Err(Uac2Error::InvalidDescriptor("not mixer unit".to_string()));
+        }
+        let len = data[0] as usize;
+        require_len(data, len)?;
+        let b_nr_in_pins = data[5];
+        // For UAC1: fixed length; we'll be lenient
+        let ba_source_id: Vec<u8> = data[6..6 + b_nr_in_pins as usize].to_vec();
+        let channels_offset = 6 + b_nr_in_pins as usize;
+        let b_nr_channels = if channels_offset + 1 < len {
+            read_u16_le(data, channels_offset)
+        } else {
+            2
+        };
+        let w_channel_config = if channels_offset + 3 < len {
+            read_u32_le(data, channels_offset + 2)
+        } else {
+            0
+        };
+        let i_mixer_offset = channels_offset + 6;
+        let i_mixer = data.get(i_mixer_offset).copied().unwrap_or(0);
+        let bm_controls: Vec<u8> = data[i_mixer_offset + 1..len].to_vec();
+        Ok(MixerUnit {
+            b_unit_id: data[3],
+            b_nr_in_pins,
+            ba_source_id,
+            b_nr_channels,
+            w_channel_config,
+            i_mixer,
+            bm_controls,
+        })
+    }
+
+    pub fn parse_selector_unit(&self, data: &[u8]) -> Result<SelectorUnit, Uac2Error> {
+        const MIN_LEN: usize = 6;
+        require_len(data, MIN_LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_SELECTOR_UNIT {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not selector unit".to_string(),
+            ));
+        }
+        let len = data[0] as usize;
+        require_len(data, len)?;
+        let b_nr_in_pins = data[5];
+        let ba_source_id: Vec<u8> = data[6..6 + b_nr_in_pins as usize].to_vec();
+        let i_sel_offset = 6 + b_nr_in_pins as usize;
+        let i_selector = data.get(i_sel_offset).copied().unwrap_or(0);
+        let bm_controls = data.get(i_sel_offset + 1).copied();
+        Ok(SelectorUnit {
+            b_unit_id: data[3],
+            b_nr_in_pins,
+            ba_source_id,
+            i_selector,
+            bm_controls,
+        })
+    }
+
+    pub fn parse_effect_unit(&self, data: &[u8]) -> Result<EffectUnit, Uac2Error> {
+        const LEN: usize = 8;
+        require_len(data, LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_EFFECT_UNIT {
+            return Err(Uac2Error::InvalidDescriptor("not effect unit".to_string()));
+        }
+        Ok(EffectUnit {
+            b_unit_id: data[3],
+            b_source_id: data[4],
+            b_effect_id: read_u16_le(data, 5),
+            i_effect: data[7],
+        })
+    }
+
+    pub fn parse_processing_unit(&self, data: &[u8]) -> Result<ProcessingUnit, Uac2Error> {
+        const MIN_LEN: usize = 10;
+        require_len(data, MIN_LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_PROCESSING_UNIT {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not processing unit".to_string(),
+            ));
+        }
+        let len = data[0] as usize;
+        require_len(data, len)?;
+        let b_nr_channels = read_u16_le(data, 7);
+        let w_channel_config = read_u32_le(data, 9);
+        let i_processing = data.get(13).copied().unwrap_or(0);
+        let bm_controls = data[14..len].to_vec();
+        Ok(ProcessingUnit {
+            b_unit_id: data[3],
+            b_source_id: data[4],
+            w_process_type: read_u16_le(data, 5),
+            b_nr_channels,
+            w_channel_config,
+            i_processing,
+            bm_controls,
+        })
+    }
+
+    pub fn parse_extension_unit(&self, data: &[u8]) -> Result<ExtensionUnit, Uac2Error> {
+        const MIN_LEN: usize = 13;
+        require_len(data, MIN_LEN)?;
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC_EXTENSION_UNIT {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not extension unit".to_string(),
+            ));
+        }
+        let len = data[0] as usize;
+        require_len(data, len)?;
+        let b_nr_in_pins = data[7];
+        let ba_source_id: Vec<u8> = data[8..8 + b_nr_in_pins as usize].to_vec();
+        let ch_offset = 8 + b_nr_in_pins as usize;
+        let b_nr_channels = read_u16_le(data, ch_offset);
+        let w_channel_config = read_u32_le(data, ch_offset + 2);
+        let i_extension = data.get(ch_offset + 6).copied().unwrap_or(0);
+        let bm_controls = data[ch_offset + 7..len].to_vec();
+        Ok(ExtensionUnit {
+            b_unit_id: data[3],
+            w_extension_code: read_u16_le(data, 5),
+            b_nr_in_pins,
+            ba_source_id,
+            b_nr_channels,
+            w_channel_config,
+            i_extension,
+            bm_controls,
+        })
+    }
 }
 
 impl DescriptorParser for AudioControlParser {
@@ -106,18 +335,40 @@ impl DescriptorParser for AudioControlParser {
             return Err(Uac2Error::InvalidDescriptor("not CS interface".to_string()));
         }
         match data[2] {
-            UAC2_AC_HEADER => self
-                .parse_ac_header(data)
-                .map(AudioControlDescriptor::Header),
-            UAC2_INPUT_TERMINAL => self
+            UAC_AC_HEADER => self.detect_and_parse_ac_header(data),
+            UAC_INPUT_TERMINAL => self
                 .parse_input_terminal(data)
                 .map(AudioControlDescriptor::InputTerminal),
-            UAC2_OUTPUT_TERMINAL => self
+            UAC_OUTPUT_TERMINAL => self
                 .parse_output_terminal(data)
                 .map(AudioControlDescriptor::OutputTerminal),
-            UAC2_FEATURE_UNIT => self
+            UAC_FEATURE_UNIT => self
                 .parse_feature_unit(data)
                 .map(AudioControlDescriptor::FeatureUnit),
+            UAC2_CLOCK_SOURCE => self
+                .parse_clock_source(data)
+                .map(AudioControlDescriptor::ClockSource),
+            UAC2_CLOCK_SELECTOR => self
+                .parse_clock_selector(data)
+                .map(AudioControlDescriptor::ClockSelector),
+            UAC2_CLOCK_MULTIPLIER => self
+                .parse_clock_multiplier(data)
+                .map(AudioControlDescriptor::ClockMultiplier),
+            UAC_MIXER_UNIT => self
+                .parse_mixer_unit(data)
+                .map(AudioControlDescriptor::MixerUnit),
+            UAC_SELECTOR_UNIT => self
+                .parse_selector_unit(data)
+                .map(AudioControlDescriptor::SelectorUnit),
+            UAC_EFFECT_UNIT => self
+                .parse_effect_unit(data)
+                .map(AudioControlDescriptor::EffectUnit),
+            UAC_PROCESSING_UNIT => self
+                .parse_processing_unit(data)
+                .map(AudioControlDescriptor::ProcessingUnit),
+            UAC_EXTENSION_UNIT => self
+                .parse_extension_unit(data)
+                .map(AudioControlDescriptor::ExtensionUnit),
             _ => Err(Uac2Error::InvalidDescriptor(format!(
                 "unknown AC descriptor subtype {}",
                 data[2]

--- a/rust/src/uac2/descriptors/audio_streaming_parser.rs
+++ b/rust/src/uac2/descriptors/audio_streaming_parser.rs
@@ -11,16 +11,67 @@ use crate::uac2::error::Uac2Error;
 pub struct AudioStreamingParser;
 
 impl AudioStreamingParser {
-    pub fn parse_as_general(&self, data: &[u8]) -> Result<AsInterfaceGeneral, Uac2Error> {
+    pub fn parse_as_general(&self, data: &[u8]) -> Result<AudioStreamingDescriptor, Uac2Error> {
+        if data.len() < 7 {
+            return Err(Uac2Error::InvalidDescriptor("AS general too short".to_string()));
+        }
+        if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC2_AS_GENERAL {
+            return Err(Uac2Error::InvalidDescriptor("not AS general".to_string()));
+        }
+        // UAC 2.0 AS General has bmControls at offset 5-6; UAC 1.0 doesn't
+        // Distinguishing heuristic: UAC 2.0 has bTerminalLink(3), bDelay(4),
+        // bmControls(5-6), wFormatTag(7-8). UAC 1.0: bTerminalLink(3),
+        // bDelay(4), wFormatTag(5-6).
+        let len = data[0] as usize;
+        if len >= 9 {
+            // UAC 2.0 style
+            let g = AsInterfaceGeneralV2 {
+                b_terminal_link: data[3],
+                b_delay: data[4],
+                bm_controls: read_u16_le(data, 5),
+                w_format_tag: read_u16_le(data, 7),
+            };
+            validate_as_interface_general(&AsInterfaceGeneral {
+                b_terminal_link: g.b_terminal_link,
+                b_delay: g.b_delay,
+                w_format_tag: g.w_format_tag,
+                bm_controls: g.bm_controls,
+            })?;
+            Ok(AudioStreamingDescriptor::GeneralV2(g))
+        } else {
+            // UAC 1.0 style
+            let g = AsInterfaceGeneralV1 {
+                b_terminal_link: data[3],
+                b_delay: data[4],
+                w_format_tag: read_u16_le(data, 5),
+            };
+            Ok(AudioStreamingDescriptor::GeneralV1(g))
+        }
+    }
+
+    /// Backward-compat: returns the V2 form (or V1 adapted)
+    pub fn parse_as_general_v2(&self, data: &[u8]) -> Result<AsInterfaceGeneral, Uac2Error> {
         const LEN: usize = 7;
         require_len(data, LEN)?;
         if data[1] != USB_DT_CS_INTERFACE || data[2] != UAC2_AS_GENERAL {
             return Err(Uac2Error::InvalidDescriptor("not AS general".to_string()));
         }
+        let len = data[0] as usize;
+        let (b_terminal_link, b_delay, w_format_tag, bm_controls) = if len >= 9 {
+            (
+                data[3],
+                data[4],
+                read_u16_le(data, 7),
+                read_u16_le(data, 5),
+            )
+        } else {
+            (data[3], data[4], read_u16_le(data, 5), 0u16)
+        };
         let g = AsInterfaceGeneral {
-            b_terminal_link: data[3],
-            b_delay: data[4],
-            w_format_tag: read_u16_le(data, 5),
+            b_terminal_link,
+            b_delay,
+            w_format_tag,
+            bm_controls,
         };
         validate_as_interface_general(&g)?;
         Ok(g)
@@ -112,6 +163,26 @@ impl AudioStreamingParser {
         validate_format_type_iii(&f)?;
         Ok(f)
     }
+
+    pub fn parse_endpoint_specific(&self, data: &[u8]) -> Result<EndpointSpecific, Uac2Error> {
+        const LEN: usize = 5;
+        require_len(data, LEN)?;
+        if data[1] != USB_DT_CS_ENDPOINT {
+            return Err(Uac2Error::InvalidDescriptor(
+                "not CS endpoint".to_string(),
+            ));
+        }
+        Ok(EndpointSpecific {
+            b_endpoint_address: data[2],
+            bm_attributes: data.get(3).copied().unwrap_or(0),
+            b_lock_delay_units: data.get(4).copied().unwrap_or(0),
+            w_lock_delay: if data.len() >= 7 {
+                read_u16_le(data, 5)
+            } else {
+                0
+            },
+        })
+    }
 }
 
 impl DescriptorParser for AudioStreamingParser {
@@ -123,13 +194,17 @@ impl DescriptorParser for AudioStreamingParser {
                 "descriptor too short".to_string(),
             ));
         }
+        // CS_ENDPOINT descriptors are on the endpoint, not interface
+        if data[1] == USB_DT_CS_ENDPOINT {
+            return self
+                .parse_endpoint_specific(data)
+                .map(AudioStreamingDescriptor::EndpointSpecific);
+        }
         if data[1] != USB_DT_CS_INTERFACE {
             return Err(Uac2Error::InvalidDescriptor("not CS interface".to_string()));
         }
         match (data[2], data.get(3).copied().unwrap_or(0)) {
-            (UAC2_AS_GENERAL, _) => self
-                .parse_as_general(data)
-                .map(AudioStreamingDescriptor::General),
+            (UAC2_AS_GENERAL, _) => self.parse_as_general(data),
             (UAC2_FORMAT_TYPE, UAC2_FORMAT_TYPE_I) => self
                 .parse_format_type_i(data)
                 .map(AudioStreamingDescriptor::FormatTypeI),

--- a/rust/src/uac2/descriptors/constants.rs
+++ b/rust/src/uac2/descriptors/constants.rs
@@ -1,12 +1,26 @@
 pub const USB_DT_INTERFACE_ASSOCIATION: u8 = 0x0B;
 pub const USB_DT_CS_INTERFACE: u8 = 0x24;
-#[allow(dead_code)]
 pub const USB_DT_CS_ENDPOINT: u8 = 0x25;
 
-pub const UAC2_AC_HEADER: u8 = 0x01;
-pub const UAC2_INPUT_TERMINAL: u8 = 0x02;
-pub const UAC2_OUTPUT_TERMINAL: u8 = 0x03;
-pub const UAC2_FEATURE_UNIT: u8 = 0x06;
+pub const UAC_AC_HEADER: u8 = 0x01;
+pub const UAC_INPUT_TERMINAL: u8 = 0x02;
+pub const UAC_OUTPUT_TERMINAL: u8 = 0x03;
+pub const UAC_MIXER_UNIT: u8 = 0x04;
+pub const UAC_SELECTOR_UNIT: u8 = 0x05;
+pub const UAC_FEATURE_UNIT: u8 = 0x06;
+pub const UAC_EFFECT_UNIT: u8 = 0x07;
+pub const UAC_PROCESSING_UNIT: u8 = 0x08;
+pub const UAC_EXTENSION_UNIT: u8 = 0x09;
+
+pub const UAC2_CLOCK_SOURCE: u8 = 0x0a;
+pub const UAC2_CLOCK_SELECTOR: u8 = 0x0b;
+pub const UAC2_CLOCK_MULTIPLIER: u8 = 0x0c;
+
+// Backward-compat aliases
+pub const UAC2_AC_HEADER: u8 = UAC_AC_HEADER;
+pub const UAC2_INPUT_TERMINAL: u8 = UAC_INPUT_TERMINAL;
+pub const UAC2_OUTPUT_TERMINAL: u8 = UAC_OUTPUT_TERMINAL;
+pub const UAC2_FEATURE_UNIT: u8 = UAC_FEATURE_UNIT;
 
 pub const UAC2_AS_GENERAL: u8 = 0x01;
 pub const UAC2_FORMAT_TYPE: u8 = 0x02;
@@ -15,5 +29,5 @@ pub const UAC2_FORMAT_TYPE_I: u8 = 0x01;
 pub const UAC2_FORMAT_TYPE_II: u8 = 0x02;
 pub const UAC2_FORMAT_TYPE_III: u8 = 0x03;
 
-#[allow(dead_code)]
 pub const UAC2_BCD_ADC: u16 = 0x0200;
+pub const UAC1_BCD_ADC: u16 = 0x0100;

--- a/rust/src/uac2/descriptors/mod.rs
+++ b/rust/src/uac2/descriptors/mod.rs
@@ -15,9 +15,12 @@ pub use audio_streaming_parser::AudioStreamingParser;
 pub use builders::{FeatureUnitBuilder, FormatTypeIBuilder, FormatTypeIIBuilder};
 pub use factory::DescriptorFactory;
 pub use parse::{
-    parse_ac_interface_header, parse_as_interface_general, parse_feature_unit, parse_format_type_i,
-    parse_format_type_ii, parse_format_type_iii, parse_iad, parse_input_terminal,
-    parse_output_terminal, DescriptorIter,
+    parse_ac_descriptor, parse_ac_interface_header, parse_ac_interface_header_v1,
+    parse_as_descriptor, parse_as_general_descriptor, parse_as_interface_general,
+    parse_clock_multiplier, parse_clock_selector, parse_clock_source, parse_effect_unit,
+    parse_endpoint_specific, parse_extension_unit, parse_feature_unit, parse_format_type_i,
+    parse_format_type_ii, parse_format_type_iii, parse_iad, parse_input_terminal, parse_mixer_unit,
+    parse_output_terminal, parse_processing_unit, parse_selector_unit, DescriptorIter,
 };
 pub use parser_trait::DescriptorParser;
 pub use types::*;

--- a/rust/src/uac2/descriptors/parse.rs
+++ b/rust/src/uac2/descriptors/parse.rs
@@ -1,6 +1,7 @@
 use super::audio_control_parser::AudioControlParser;
 use super::audio_streaming_parser::AudioStreamingParser;
 use super::iad_parser::parse_iad_internal;
+use super::parser_trait::DescriptorParser;
 use super::types::*;
 use crate::uac2::error::Uac2Error;
 
@@ -36,14 +37,21 @@ impl<'a> Iterator for DescriptorIter<'a> {
     }
 }
 
+// ── IAD ──
 pub fn parse_iad(data: &[u8]) -> Result<Iad, Uac2Error> {
     parse_iad_internal(data)
 }
 
+// ── AC Header ──
 pub fn parse_ac_interface_header(data: &[u8]) -> Result<AcInterfaceHeader, Uac2Error> {
     AC_PARSER.parse_ac_header(data)
 }
 
+pub fn parse_ac_interface_header_v1(data: &[u8]) -> Result<AcInterfaceHeaderV1, Uac2Error> {
+    AC_PARSER.parse_ac_header_v1(data)
+}
+
+// ── Terminals ──
 pub fn parse_input_terminal(data: &[u8]) -> Result<InputTerminal, Uac2Error> {
     AC_PARSER.parse_input_terminal(data)
 }
@@ -52,11 +60,56 @@ pub fn parse_output_terminal(data: &[u8]) -> Result<OutputTerminal, Uac2Error> {
     AC_PARSER.parse_output_terminal(data)
 }
 
+// ── Feature Unit ──
 pub fn parse_feature_unit(data: &[u8]) -> Result<FeatureUnit, Uac2Error> {
     AC_PARSER.parse_feature_unit(data)
 }
 
+// ── Clock entities ──
+pub fn parse_clock_source(data: &[u8]) -> Result<ClockSource, Uac2Error> {
+    AC_PARSER.parse_clock_source(data)
+}
+
+pub fn parse_clock_selector(data: &[u8]) -> Result<ClockSelector, Uac2Error> {
+    AC_PARSER.parse_clock_selector(data)
+}
+
+pub fn parse_clock_multiplier(data: &[u8]) -> Result<ClockMultiplier, Uac2Error> {
+    AC_PARSER.parse_clock_multiplier(data)
+}
+
+// ── Mixer / Selector / Effects ──
+pub fn parse_mixer_unit(data: &[u8]) -> Result<MixerUnit, Uac2Error> {
+    AC_PARSER.parse_mixer_unit(data)
+}
+
+pub fn parse_selector_unit(data: &[u8]) -> Result<SelectorUnit, Uac2Error> {
+    AC_PARSER.parse_selector_unit(data)
+}
+
+pub fn parse_effect_unit(data: &[u8]) -> Result<EffectUnit, Uac2Error> {
+    AC_PARSER.parse_effect_unit(data)
+}
+
+pub fn parse_processing_unit(data: &[u8]) -> Result<ProcessingUnit, Uac2Error> {
+    AC_PARSER.parse_processing_unit(data)
+}
+
+pub fn parse_extension_unit(data: &[u8]) -> Result<ExtensionUnit, Uac2Error> {
+    AC_PARSER.parse_extension_unit(data)
+}
+
+// ── AC Generic ──
+pub fn parse_ac_descriptor(data: &[u8]) -> Result<AudioControlDescriptor, Uac2Error> {
+    AC_PARSER.parse(data)
+}
+
+// ── AS ──
 pub fn parse_as_interface_general(data: &[u8]) -> Result<AsInterfaceGeneral, Uac2Error> {
+    AS_PARSER.parse_as_general_v2(data)
+}
+
+pub fn parse_as_general_descriptor(data: &[u8]) -> Result<AudioStreamingDescriptor, Uac2Error> {
     AS_PARSER.parse_as_general(data)
 }
 
@@ -70,4 +123,13 @@ pub fn parse_format_type_ii(data: &[u8]) -> Result<FormatTypeII, Uac2Error> {
 
 pub fn parse_format_type_iii(data: &[u8]) -> Result<FormatTypeIII, Uac2Error> {
     AS_PARSER.parse_format_type_iii(data)
+}
+
+pub fn parse_endpoint_specific(data: &[u8]) -> Result<EndpointSpecific, Uac2Error> {
+    AS_PARSER.parse_endpoint_specific(data)
+}
+
+// ── AS Generic ──
+pub fn parse_as_descriptor(data: &[u8]) -> Result<AudioStreamingDescriptor, Uac2Error> {
+    AS_PARSER.parse(data)
 }

--- a/rust/src/uac2/descriptors/types.rs
+++ b/rust/src/uac2/descriptors/types.rs
@@ -8,13 +8,26 @@ pub struct Iad {
     pub i_function: u8,
 }
 
+// ── UAC 1.0 AC Interface Header ──
 #[derive(Debug, Clone)]
-pub struct AcInterfaceHeader {
+pub struct AcInterfaceHeaderV1 {
+    pub bcd_adc: u16,
+    pub w_total_length: u16,
+    pub b_in_collection: u8,
+    pub ba_interface_nr: Vec<u8>,
+}
+
+// ── UAC 2.0 AC Interface Header ──
+#[derive(Debug, Clone)]
+pub struct AcInterfaceHeaderV2 {
     pub bcd_adc: u16,
     pub b_category: u8,
     pub w_total_length: u16,
     pub bm_controls: u16,
 }
+
+// ── Backward-compat alias ──
+pub type AcInterfaceHeader = AcInterfaceHeaderV2;
 
 #[derive(Debug, Clone)]
 pub struct InputTerminal {
@@ -44,12 +57,145 @@ pub struct FeatureUnit {
     pub bma_controls: Vec<u32>,
 }
 
+// ── Clock Source (UAC 2.0 / UAC 3.0) ──
 #[derive(Debug, Clone)]
-pub struct AsInterfaceGeneral {
+pub struct ClockSource {
+    pub b_clock_id: u8,
+    pub bm_attributes: u8,
+    pub bm_controls: u8,
+    pub b_assoc_terminal: u8,
+    pub i_clock_source: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockType {
+    External,
+    InternalFixed,
+    InternalVariable,
+    InternalProgrammable,
+}
+
+impl ClockSource {
+    pub fn clock_type(&self) -> ClockType {
+        match self.bm_attributes & 0x03 {
+            0 => ClockType::External,
+            1 => ClockType::InternalFixed,
+            2 => ClockType::InternalVariable,
+            3 => ClockType::InternalProgrammable,
+            _ => ClockType::External,
+        }
+    }
+
+    pub fn is_synchronous_to_sof(&self) -> bool {
+        (self.bm_attributes & 0x04) != 0
+    }
+
+    pub fn supports_frequency_get(&self) -> bool {
+        (self.bm_controls & 0x01) != 0
+    }
+
+    pub fn supports_frequency_set(&self) -> bool {
+        (self.bm_controls & 0x02) != 0
+    }
+
+    pub fn supports_clock_valid(&self) -> bool {
+        (self.bm_controls & 0x04) != 0
+    }
+}
+
+// ── Clock Selector (UAC 2.0) ──
+#[derive(Debug, Clone)]
+pub struct ClockSelector {
+    pub b_clock_id: u8,
+    pub b_nr_in_pins: u8,
+    pub ba_c_source_id: Vec<u8>,
+    pub bm_controls: u8,
+    pub i_clock_selector: u8,
+}
+
+// ── Clock Multiplier (UAC 2.0) ──
+#[derive(Debug, Clone)]
+pub struct ClockMultiplier {
+    pub b_clock_id: u8,
+    pub b_c_source_id: u8,
+    pub bm_controls: u8,
+    pub i_clock_multiplier: u8,
+}
+
+// ── Mixer Unit ──
+#[derive(Debug, Clone)]
+pub struct MixerUnit {
+    pub b_unit_id: u8,
+    pub b_nr_in_pins: u8,
+    pub ba_source_id: Vec<u8>,
+    pub b_nr_channels: u16,
+    pub w_channel_config: u32,
+    pub i_mixer: u8,
+    pub bm_controls: Vec<u8>,
+}
+
+// ── Selector Unit ──
+#[derive(Debug, Clone)]
+pub struct SelectorUnit {
+    pub b_unit_id: u8,
+    pub b_nr_in_pins: u8,
+    pub ba_source_id: Vec<u8>,
+    pub i_selector: u8,
+    pub bm_controls: Option<u8>,
+}
+
+// ── Effect Unit ──
+#[derive(Debug, Clone)]
+pub struct EffectUnit {
+    pub b_unit_id: u8,
+    pub b_source_id: u8,
+    pub b_effect_id: u16,
+    pub i_effect: u8,
+}
+
+// ── Processing Unit ──
+#[derive(Debug, Clone)]
+pub struct ProcessingUnit {
+    pub b_unit_id: u8,
+    pub b_source_id: u8,
+    pub w_process_type: u16,
+    pub b_nr_channels: u16,
+    pub w_channel_config: u32,
+    pub i_processing: u8,
+    pub bm_controls: Vec<u8>,
+}
+
+// ── Extension Unit ──
+#[derive(Debug, Clone)]
+pub struct ExtensionUnit {
+    pub b_unit_id: u8,
+    pub w_extension_code: u16,
+    pub b_nr_in_pins: u8,
+    pub ba_source_id: Vec<u8>,
+    pub b_nr_channels: u16,
+    pub w_channel_config: u32,
+    pub i_extension: u8,
+    pub bm_controls: Vec<u8>,
+}
+
+// ── UAC 1.0 AS General ──
+#[derive(Debug, Clone)]
+pub struct AsInterfaceGeneralV1 {
     pub b_terminal_link: u8,
     pub b_delay: u8,
     pub w_format_tag: u16,
 }
+
+// ── UAC 2.0 AS General ──
+#[derive(Debug, Clone)]
+pub struct AsInterfaceGeneralV2 {
+    pub b_terminal_link: u8,
+    pub b_delay: u8,
+    pub bm_controls: u16,
+    pub w_format_tag: u16,
+}
+
+pub type AsInterfaceGeneral = AsInterfaceGeneralV2;
 
 #[derive(Debug, Clone)]
 pub struct FormatTypeI {
@@ -73,20 +219,60 @@ pub struct FormatTypeIII {
     pub b_bit_resolution: u8,
 }
 
+// ── Endpoint-Specific Descriptor (CS_ENDPOINT) ──
+#[derive(Debug, Clone)]
+pub struct EndpointSpecific {
+    pub b_endpoint_address: u8,
+    pub bm_attributes: u8,
+    pub b_lock_delay_units: u8,
+    pub w_lock_delay: u16,
+}
+
+impl EndpointSpecific {
+    pub fn max_packets_only(&self) -> bool {
+        (self.bm_attributes & 0x80) != 0
+    }
+
+    pub fn pitch_control(&self) -> bool {
+        (self.bm_attributes & 0x40) != 0
+    }
+
+    pub fn data_overrun_control(&self) -> bool {
+        (self.bm_attributes & 0x20) != 0
+    }
+
+    pub fn data_underrun_control(&self) -> bool {
+        (self.bm_attributes & 0x10) != 0
+    }
+}
+
+// ── Unified Descriptor Enums ──
+
 #[derive(Debug, Clone)]
 pub enum AudioControlDescriptor {
-    Header(AcInterfaceHeader),
+    HeaderV1(AcInterfaceHeaderV1),
+    HeaderV2(AcInterfaceHeaderV2),
     InputTerminal(InputTerminal),
     OutputTerminal(OutputTerminal),
     FeatureUnit(FeatureUnit),
+    ClockSource(ClockSource),
+    ClockSelector(ClockSelector),
+    ClockMultiplier(ClockMultiplier),
+    MixerUnit(MixerUnit),
+    SelectorUnit(SelectorUnit),
+    EffectUnit(EffectUnit),
+    ProcessingUnit(ProcessingUnit),
+    ExtensionUnit(ExtensionUnit),
 }
 
 #[derive(Debug, Clone)]
 pub enum AudioStreamingDescriptor {
-    General(AsInterfaceGeneral),
+    GeneralV1(AsInterfaceGeneralV1),
+    GeneralV2(AsInterfaceGeneralV2),
     FormatTypeI(FormatTypeI),
     FormatTypeII(FormatTypeII),
     FormatTypeIII(FormatTypeIII),
+    EndpointSpecific(EndpointSpecific),
 }
 
 #[derive(Debug, Clone)]

--- a/rust/src/uac2/mod.rs
+++ b/rust/src/uac2/mod.rs
@@ -1,4 +1,4 @@
-//! Custom USB Audio Class 2.0 (UAC 2.0) support for DAC/AMP detection and direct playback paths.
+//! Custom USB Audio Class 1.0 / 2.0 (UAC2) support for DAC/AMP detection and direct playback paths.
 
 #[cfg(all(feature = "uac2", target_os = "android"))]
 mod android_direct;
@@ -12,6 +12,8 @@ mod audio_sink;
 mod backend;
 #[cfg(feature = "uac2")]
 mod capabilities;
+#[cfg(feature = "uac2")]
+mod compatibility;
 #[cfg(feature = "uac2")]
 mod connection_manager;
 #[cfg(feature = "uac2")]
@@ -43,6 +45,8 @@ pub(crate) mod iso_packet_scheduler;
 #[cfg(feature = "uac2")]
 mod logging;
 #[cfg(feature = "uac2")]
+mod quirk;
+#[cfg(feature = "uac2")]
 mod registry;
 #[cfg(feature = "uac2")]
 mod ring_buffer;
@@ -56,6 +60,8 @@ mod transfer;
 mod transfer_buffer;
 #[cfg(feature = "uac2")]
 mod transfer_manager;
+#[cfg(feature = "uac2")]
+mod uac_version;
 
 #[cfg(all(test, feature = "uac2"))]
 mod tests;
@@ -69,7 +75,7 @@ pub use android_direct::{
     android_direct_verify_hardware_volume_health, clear_android_usb_device,
     create_android_usb_backend, force_release_usb_session, is_usb_session_active,
     mark_android_usb_fallback, negotiate_android_direct_output_sample_rate,
-    register_android_usb_device, set_android_direct_usb_enabled,     set_android_usb_dop_mode,
+    register_android_usb_device, set_android_direct_usb_enabled, set_android_usb_dop_mode,
     set_android_usb_dsd_native_mode,
     set_android_usb_lock_enabled, set_android_usb_playback_format, validate_android_direct_request,
     wait_for_android_usb_session_stop, AndroidDirectUsbBackend, AndroidDirectUsbDebugState,
@@ -93,16 +99,26 @@ pub use capabilities::{
     PowerCapabilities,
 };
 #[cfg(feature = "uac2")]
+pub use compatibility::{
+    AltSettingRef, AsInterfaceInfo, DsdAltSettingRef, EndpointInfo, GenericUsbAudioDevice,
+};
+#[cfg(feature = "uac2")]
 pub use connection_manager::{ConnectionManager, ConnectionState};
 #[cfg(feature = "uac2")]
 pub use descriptors::{
-    parse_ac_interface_header, parse_as_interface_general, parse_feature_unit, parse_format_type_i,
-    parse_format_type_ii, parse_format_type_iii, parse_iad, parse_input_terminal,
-    parse_output_terminal, AcInterfaceHeader, AsInterfaceGeneral, AudioControlDescriptor,
-    AudioControlParser, AudioStreamingDescriptor, AudioStreamingParser, DescriptorFactory,
-    DescriptorIter, DescriptorKind, DescriptorParser, FeatureUnit, FeatureUnitBuilder, FormatTypeI,
+    parse_ac_descriptor, parse_ac_interface_header, parse_ac_interface_header_v1,
+    parse_as_descriptor, parse_as_general_descriptor, parse_as_interface_general,
+    parse_clock_multiplier, parse_clock_selector, parse_clock_source, parse_effect_unit,
+    parse_endpoint_specific, parse_extension_unit, parse_feature_unit, parse_format_type_i,
+    parse_format_type_ii, parse_format_type_iii, parse_iad, parse_input_terminal, parse_mixer_unit,
+    parse_output_terminal, parse_processing_unit, parse_selector_unit,
+    AcInterfaceHeader, AcInterfaceHeaderV1, AcInterfaceHeaderV2, AsInterfaceGeneral,
+    AsInterfaceGeneralV1, AsInterfaceGeneralV2, AudioControlDescriptor, AudioControlParser,
+    AudioStreamingDescriptor, AudioStreamingParser, ClockMultiplier, ClockSelector, ClockSource,
+    ClockType, DescriptorFactory, DescriptorIter, DescriptorKind, DescriptorParser,
+    EffectUnit, EndpointSpecific, ExtensionUnit, FeatureUnit, FeatureUnitBuilder, FormatTypeI,
     FormatTypeIBuilder, FormatTypeII, FormatTypeIIBuilder, FormatTypeIII, Iad, InputTerminal,
-    OutputTerminal,
+    MixerUnit, OutputTerminal, ProcessingUnit, SelectorUnit,
 };
 #[cfg(feature = "uac2")]
 pub use device::{DeviceIdentification, DeviceInfo, DeviceMetadata, Uac2Device};
@@ -127,6 +143,8 @@ pub use format_negotiation::{
 #[cfg(feature = "uac2")]
 pub use logging::{init_logging, LogConfig, LogContext, LogLevel};
 #[cfg(feature = "uac2")]
+pub use quirk::{QuirkDatabase, UsbAudioQuirk, QUIRK_DATABASE};
+#[cfg(feature = "uac2")]
 pub use registry::{DeviceKey, DeviceRegistry};
 #[cfg(feature = "uac2")]
 pub use ring_buffer::{AdaptiveBuffer, AudioBuffer, LockFreeRingBuffer, RingBuffer};
@@ -143,3 +161,5 @@ pub use transfer::{
 pub use transfer_buffer::{BufferManager, BufferPool, TransferBuffer};
 #[cfg(feature = "uac2")]
 pub use transfer_manager::{TransferManager, TransferRecovery};
+#[cfg(feature = "uac2")]
+pub use uac_version::UacVersion;

--- a/rust/src/uac2/quirk.rs
+++ b/rust/src/uac2/quirk.rs
@@ -1,0 +1,123 @@
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
+use rusb::SyncType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsbAudioQuirk {
+    IgnoreBrokenClockSource,
+    ForceAsyncFeedback,
+    DisableNativeDsd,
+    IgnoreInvalidSampleRate,
+    Force48kHzOnly,
+    RequireVerifiedRate,
+    SettleDelayMs(u64),
+    PreferPadded24BitTransport,
+    DsdSubslotSize(u8),
+    DsdBigEndian,
+    DsdBitReverse,
+    ForceIsochronousSyncType(SyncType),
+    SkipFeedbackValidation,
+    AssumeSynchEndpointZero,
+    IgnoreMuteControl,
+    IgnoreVolumeControl,
+    PreferInterfaceAlt(u8),
+    SkipClockValidation,
+    RequireInterfaceClaim(u8),
+}
+
+#[derive(Debug, Clone)]
+pub struct QuirkEntry {
+    pub vendor_id: u16,
+    pub product_id: u16,
+    pub product_name_contains: &'static str,
+    pub quirks: &'static [UsbAudioQuirk],
+}
+
+pub struct QuirkDatabase {
+    entries: RwLock<Vec<QuirkEntry>>,
+}
+
+impl QuirkDatabase {
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub fn add(&self, vendor_id: u16, product_id: u16, product_name_contains: &'static str, quirks: &'static [UsbAudioQuirk]) {
+        self.entries.write().push(QuirkEntry {
+            vendor_id,
+            product_id,
+            product_name_contains,
+            quirks,
+        });
+    }
+
+    pub fn lookup(&self, vendor_id: u16, product_id: u16, product_name: &str) -> Vec<UsbAudioQuirk> {
+        let mut result = Vec::new();
+        for entry in self.entries.read().iter() {
+            if entry.vendor_id == vendor_id
+                && entry.product_id == product_id
+                && (entry.product_name_contains.is_empty() || product_name.contains(entry.product_name_contains))
+            {
+                result.extend_from_slice(entry.quirks);
+            }
+        }
+        result
+    }
+
+    pub fn has_quirk(&self, vendor_id: u16, product_id: u16, product_name: &str, quirk: UsbAudioQuirk) -> bool {
+        self.lookup(vendor_id, product_id, product_name)
+            .iter()
+            .any(|q| *q == quirk)
+    }
+
+    pub fn find_quirk_by_type(&self, vendor_id: u16, product_id: u16, product_name: &str, quirk: UsbAudioQuirk) -> bool {
+        self.has_quirk(vendor_id, product_id, product_name, quirk)
+    }
+}
+
+pub static QUIRK_DATABASE: Lazy<QuirkDatabase> = Lazy::new(|| {
+    let db = QuirkDatabase::new();
+
+    // MOONDROP Dawn Pro: dual CS43131, XMOS-style bridge, DSD_U32_BE
+    db.add(
+        12230, // vendor_id 0x2FC6
+        61546, // product_id 0xF09A
+        "MOONDROP Dawn Pro",
+        &[
+            UsbAudioQuirk::RequireVerifiedRate,
+            UsbAudioQuirk::SettleDelayMs(50),
+            UsbAudioQuirk::PreferPadded24BitTransport,
+            UsbAudioQuirk::DsdSubslotSize(4),
+            UsbAudioQuirk::DsdBigEndian,
+        ],
+    );
+
+    db
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dawn_pro_quirks_found_by_vid_pid() {
+        let quirks = QUIRK_DATABASE.lookup(12230, 61546, "MOONDROP Dawn Pro");
+        assert!(quirks.contains(&UsbAudioQuirk::RequireVerifiedRate));
+        assert!(quirks.contains(&UsbAudioQuirk::PreferPadded24BitTransport));
+        assert!(quirks.contains(&UsbAudioQuirk::DsdBigEndian));
+    }
+
+    #[test]
+    fn unknown_device_returns_empty() {
+        let quirks = QUIRK_DATABASE.lookup(0x0000, 0x0000, "Unknown");
+        assert!(quirks.is_empty());
+    }
+
+    #[test]
+    fn has_quirk_check() {
+        assert!(QUIRK_DATABASE.has_quirk(12230, 61546, "MOONDROP Dawn Pro", UsbAudioQuirk::RequireVerifiedRate));
+        assert!(!QUIRK_DATABASE.has_quirk(12230, 61546, "MOONDROP Dawn Pro", UsbAudioQuirk::Force48kHzOnly));
+    }
+}

--- a/rust/src/uac2/uac_version.rs
+++ b/rust/src/uac2/uac_version.rs
@@ -1,0 +1,78 @@
+use crate::uac2::constants::*;
+
+pub fn detect_uac_version(bcd_adc: u16) -> UacVersion {
+    if bcd_adc >= UAC2_BCD_ADC {
+        UacVersion::V2_0
+    } else if bcd_adc >= UAC1_BCD_ADC {
+        UacVersion::V1_0
+    } else {
+        UacVersion::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UacVersion {
+    V1_0,
+    V2_0,
+    Unknown,
+}
+
+impl UacVersion {
+    pub fn is_uac1(self) -> bool {
+        matches!(self, Self::V1_0)
+    }
+
+    pub fn is_uac2_or_newer(self) -> bool {
+        matches!(self, Self::V2_0)
+    }
+
+    pub fn from_interface_descriptor(extra: &[u8]) -> Option<Self> {
+        use crate::uac2::descriptors::DescriptorIter;
+        for chunk in DescriptorIter::new(extra) {
+            if chunk.len() < 4 {
+                continue;
+            }
+            if chunk[1] == USB_DT_CS_INTERFACE
+                && (chunk[2] == UAC_AC_HEADER || chunk[2] == UAC2_AC_HEADER)
+            {
+                if chunk.len() >= 6 {
+                    let bcd_adc = u16::from_le_bytes([chunk[4], chunk[5]]);
+                    return Some(detect_uac_version(bcd_adc));
+                }
+                if chunk.len() >= 4 {
+                    let bcd_adc = u16::from_le_bytes([chunk[3], chunk[4]]);
+                    return Some(detect_uac_version(bcd_adc));
+                }
+            }
+        }
+        None
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::V1_0 => "UAC 1.0",
+            Self::V2_0 => "UAC 2.0",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uac1_bcd_adc() {
+        assert_eq!(detect_uac_version(0x0100), UacVersion::V1_0);
+    }
+
+    #[test]
+    fn uac2_bcd_adc() {
+        assert_eq!(detect_uac_version(0x0200), UacVersion::V2_0);
+    }
+
+    #[test]
+    fn unknown_bcd_adc() {
+        assert_eq!(detect_uac_version(0x0000), UacVersion::Unknown);
+    }
+}


### PR DESCRIPTION
# Summary

- Implement UAC 1.0 and 2.0 descriptor parsing with version-specific structs, active descriptor parsing, audio streaming parser, and class constants
- Add USB audio device compatibility system with quirk database, UAC version detection, and generic device model
- Add What's New bottom sheet with changelog data model (v0.17.0-beta.1) and last seen version tracking
- Add GitHub release update check support for non-Play Store builds
- Add rotational gesture seek control on album art
- Add version constants for app version, build, and label

# Changes

## UAC 1.0/2.0 Descriptor Parsing

- UAC 1.0 AS General and endpoint descriptor parsing
- UAC 2.0 descriptor types and version-specific structs
- Active descriptor parsing via UAC2 interfaces
- USB Audio class constants for UAC 1/2 descriptors, controls, and requests
- UAC constants for descriptor subtypes with dead code warning fixes
- Expose additional descriptor parsing functions in public API
- Audio streaming descriptor parser for UAC 2.0

## UAC Device Compatibility

- UAC version detection module
- Generic USB audio device model for UAC2 compatibility
- USB audio quirk database with MOONDROP Dawn Pro support
- UAC 1.0 support with compatibility, quirk, and version modules
- Consolidate quirk lookups with unified database fallback
- Update Android direct USB to use new compatibility system

## What's New

- Changelog data model with v0.17.0-beta.1 entries (155 lines)
- "What's New" bottom sheet widget (292 lines) with formatted changelog display
- "What's New" provider for changelog awareness
- `lastSeenChangelogVersion` preference with provider/service methods
- Show "What's New" bottom sheet on app launch when version changes

## Update Check

- GitHub release update checks for non-Play Store builds
- Customized update messages for non-Play Store builds

## Player Interaction

- Add rotational gesture seek control on album art
- Clamp disc scale to prevent zero or negative values

## Version & Misc

- Add version constants for app version, build, and label
- Fix star animation overflow in milestone card by clamping eased progress
- Remove redundant border from bottom sheet actions container
- Fix indentation and update version subtitle spacing

## Files Changed

- `lib/app/app.dart`
- `lib/core/constants/app_constants.dart`
- `lib/providers/update_check_provider.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/providers/whats_new_provider.dart`
- `lib/providers/providers.dart`
- `lib/services/app_preferences_service.dart`
- `lib/features/settings/screens/app_info_settings_screen.dart`
- `lib/features/whats_new/data/changelog_data.dart`
- `lib/features/whats_new/widgets/whats_new_bottom_sheet.dart`
- `lib/features/player/widgets/rating_button.dart`
- `lib/features/milestone/widgets/milestone_card.dart`
- `lib/widgets/common/glass_bottom_sheet.dart`
- `rust/src/uac2/mod.rs`
- `rust/src/uac2/compatibility.rs`
- `rust/src/uac2/quirk.rs`
- `rust/src/uac2/uac_version.rs`
- `rust/src/uac2/constants.rs`
- `rust/src/uac2/capabilities.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/uac2/descriptors/types.rs`
- `rust/src/uac2/descriptors/parse.rs`
- `rust/src/uac2/descriptors/mod.rs`
- `rust/src/uac2/descriptors/constants.rs`
- `rust/src/uac2/descriptors/audio_streaming_parser.rs`