### PR TITLE
Update Isar to 3.3.2, add Markdown release notes, and handle database incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,9 @@
 - File type filter and sort options in folder browser.
 
 ### Build & Compatibility
-- **minSdk lowered to 24** (Android 7.0+), down from 26.
-- **Impeller rendering configurable** via bool resource, disabled by default.
+- **minSdk stays at 26** (Android 8.0+). Core library desugaring enabled for Java 17 target.
+- **Impeller rendering configurable** via bool resource, disabled on API 24/25, enabled on API 26+.
+- **Isar bumped to 3.3.2** with MDBX_INCOMPATIBLE recovery: corrupt database files are deleted and the library database is recreated automatically.
 - **V1 and V2 APK signing** enabled in release config.
 - Notification channel creation guarded behind API 26 check.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,97 @@
 # Changelog
 
+## 0.18.0-beta.1 (2026-06-07)
+
+### UAC 1.0 & 2.0 Descriptor Parsing
+- USB Audio Class 1.0 and 2.0 descriptor parsing with version detection (header, unit, endpoint). Split version-specific structs and types.
+- UAC 1.0/2.0 class constants for descriptors, controls, and requests.
+- Active descriptor parsing via UAC2 interfaces with unified quirk database fallback.
+- Generic USB audio device model for UAC2 compatibility.
+- USB diagnostics refactored with UrbTransportInfo model for transport data isolation.
+
+### DSD Bit Order & Native USB Direct
+- **DsdBitOrder enum** (LSB/MSB) with per-source detection across all DSD format decoders (DSF, DFF, WavPack). Bit order normalization in the DSD output router.
+- **Global DSD bit reverse override**: `set_dsd_bit_reverse_override()` FFI function exposing manual byte-order control to Flutter.
+- **USB native DSD output**: `AndroidDirectUsbPlaybackFormat` now carries `dsd_bit_rate`. Multi-byte interleaved USB payload packing with configurable endianness.
+- **DSD quirks table**: `KNOWN_DSD_QUIRKS` with per-device entries (vendor/product IDs, endianness, bit reversal, preferred subslot size). Includes MOONDROP Dawn Pro quirk.
+- **DoP word building refactored** into reusable `build_dop_word()` method with I32 packing for integer streams.
+- **Default DSD bit rate initialization** for newly configured USB playback formats.
+- **UAC2 feature enabled by default**: Multi-byte DSD slots now active without opt-in.
+- **Pipeline mode based on output strategy**: `PipelineMode::Dop` set for USB DSD Native and DSD DoP strategies (bit-perfect passthrough). `Passthrough` for PCM bit-perfect. `Dsp` for standard processing.
+- **DAP flag in native DSD detection**: DSD Native mode now considered available on DAP devices even without explicit DSD encoding support.
+- **Transport labels made descriptive**: Debug transport labels updated from short codes to `usb-native-dsd-u{subslot}x{bits}-bit`, `usb-dop-{bits}-bit`, `usb-pcm`.
+- **`DsdBitOrder` passed through DSD decoder thread** to `DsdOutputRouter` for per-track byte normalization.
+
+### Integer (I32) Stream Support
+- **`AndroidManagedStreamKind` enum**: Replaces hardcoded f32 stream with `F32` and `I32` variants.
+- **`AndroidOutputCallbackI32`**: Reads f32 from pipeline, extracts raw bit patterns via `f32::to_bits()`, writes i32 to AAudio — preserving DoP markers and DSD data intact.
+- **`open_android_output_stream()`** gains `use_integer_format` parameter; opens i32 stream with format conversion disabled for DoP/native DSD on DAP.
+- Fallback stream logic adapted to work with both f32 and i32 streams.
+
+### Artist & Playlist Theming
+- **ArtistEntity** (Isar collection): `id`, `name` (unique, case-insensitive), `artPath` (nullable). Auto-generated Isar bindings.
+- **ArtistRepository**: `getByName()`, `setArt()`, `clearArt()` for persistent artist art path caching.
+- **ArtistDetailScreen**: Migrated from `StatefulWidget` to `ConsumerStatefulWidget` (Riverpod). Dynamic color theming via `ColorExtractionService` from resolved album art. Full-bleed artist image background with animated tinted app bar. Removed old circular avatar + stat chips layout.
+- **PlaylistDetailScreen**: Dynamic playlist color from most-played song's album art via `getMostPlayedSongAmong()`. `TweenAnimationBuilder` tinted background. Info chips (track count, total duration, created/updated dates). "Other Playlists" horizontal section. Back button repositioned to overlay. Removed 4-tile cover grid.
+- **`getMostPlayedSongAmong()`** in `RecentlyPlayedRepository`: Returns most-played song from a given list for playlist color extraction.
+
+### Vinyl Disc & Gesture Seeking
+- **Vinyl disc morph animation**: Tap album art to morph into a spinning vinyl record. `_VinylDiscPainter` draws radial-gradient disc with grooves and highlight. `_morphController` (700ms) controls transition; `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size. Song change resets to art mode. Haptic feedback on toggle.
+- **Rotational gesture seek control** on album art with haptic feedback.
+- **Vinyl outline animation** on single tap to enable rotation seeking.
+- **Album color in visualizer preview**: `_buildVisualizerPreview()` reads `albumColorModeProvider` and passes album color when mode is not `off`.
+
+### Navigation Bar Auto-Collapse
+- FlickNavBar auto-collapse with animated transitions after idle timer.
+- Configurable auto-collapse behavior and timer duration via preferences.
+- Collapsed state with smooth animated reveal on interaction.
+
+### Milestone Card Redesign & Collection
+- Redesigned milestone celebration card with per-tier accent color (bronze / silver / gold / sapphire / amethyst), large hero icon, tinted border + glow, and a subtle "next milestone — N to go" hint line
+- New achievement-style collection view (Settings → Milestones) listing all five tiers in a grid; unlocked tiles re-open the celebration card with the achieved date, locked tiles show a progress bottom sheet
+- Settings → About → Milestones tile shows a live "X / 5 unlocked" counter
+- Five new `AppColors` milestone tint constants and per-tier `tierIcon` / `tierColor` / `shortLabel` / `threshold` / `isTopTier` getters on `MilestoneTypeX`
+- New `MilestoneService.getNextMilestone()` helper for "next unshown tier + remaining units" (used by the popup and the locked-tile sheet)
+- `MilestoneService` constructor now accepts an optional `playCountOverride` for unit testing without Isar
+- New test suite: `test/services/milestone_service_test.dart`
+
+### What's New System
+- What's New bottom sheet shown on first launch after update.
+- Structured changelog data model with versioned entries and sections.
+- Changelog-aware provider with `lastSeenChangelogVersion` preference.
+- Version constants (`kAppVersion`, `kAppBuild`, `kAppVersionLabel`) in `app_constants.dart`.
+
+### Ambient Background Removed
+- Ambient background decoration removed from songs, albums, artists, playlists, favorites, and folders screens.
+- Ambient background toggle removed from settings and playback display.
+- Menu screen hero refactored to use `ColorExtractionService` instead of ambient background.
+
+### Folder Browser Enhancements
+- Pagination with configurable page size slider.
+- Pinch-to-zoom gesture support with animated grid transitions.
+- File type filter and sort options in folder browser.
+
+### Build & Compatibility
+- **minSdk lowered to 24** (Android 7.0+), down from 26.
+- **Impeller rendering configurable** via bool resource, disabled by default.
+- **V1 and V2 APK signing** enabled in release config.
+- Notification channel creation guarded behind API 26 check.
+
+### Updates & Distribution
+- GitHub release update checks for non-Play Store builds with customized update messages.
+
+### UI Polish & Fixes
+- Play all and shuffle buttons styled as accent-colored pills with fixed width.
+- Scroll-aware animated app bar actions on artist, playlist, and album detail screens.
+- Song auto-added to player queue when added to a playlist.
+- Audio info bottom sheet expanded to `ConsumerStatefulWidget` with swipeable page view.
+- Library auto-sync refactored to event-driven with full rescan support.
+- Equalizer initialized on app start and reapplied after audio session changes.
+- Star animation overflow clamped; disc scale clamped to prevent zero/negative values.
+- Ring buffer write logic fixed to handle full buffer gracefully; bluetooth devices handled more gracefully.
+- Center logo Svg in app info settings screen.
+- SmartMixDetailScreen back button moved to overlay position.
+
 ## 0.17.0-beta.1 (2026-05-31)
 
 ### Post-Release Additions

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         applicationId = "com.mossapps.flick"
-        minSdk = 24
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/docs/ANDROID_7_CRASH.md
+++ b/docs/ANDROID_7_CRASH.md
@@ -1,44 +1,79 @@
-# Android 7/7.1 (API 24/25) Crash
+# Android 7/7.1 (API 24/25) Compatibility
 
 ## Symptom
 
 App crashes immediately on Android 7.0 (API 24) and 7.1 (API 25) devices.
 
-## Root Cause
+## Root Causes
 
-The app's Gradle build targets Java 17 (`sourceCompatibility` / `targetCompatibility = VERSION_17`), but **core library desugaring was not enabled**. Android 7.x lacks native support for Java 8+ library APIs (`java.time`, `java.util.stream`, `java.util.function`, etc.). Without desugaring, any code path touching these APIs throws `NoClassDefFoundError` at runtime.
+The app's Gradle build targets Java 17 (`sourceCompatibility` /
+`targetCompatibility = VERSION_17`). Android 7.x lacks native support for some
+Java 8+ library APIs (`java.time`, `java.util.stream`, `java.util.function`,
+etc.), so core library desugaring must remain enabled while `minSdk` includes
+API 24/25.
 
-Additionally, Impeller is force-enabled (`AndroidManifest.xml`:
-`io.flutter.embedding.android.EnableImpeller = true`). Older GPU drivers on
-Android 7 devices have known compatibility issues with Impeller's rendering
-pipeline.
+Isar can also fail at startup with:
+
+```text
+IsarError: Cannot open Environment: MdbxError (-30784): MDBX_INCOMPATIBLE
+```
+
+This can happen when an existing `libmdbx` environment was created by an
+incompatible native library/flag combination. Isar stores the database as
+`<documents>/flick_player.isar` with a lock file at
+`<documents>/flick_player.isar.lock`.
+
+Additionally, Impeller is controlled through
+`io.flutter.embedding.android.EnableImpeller`. Older Android 7 GPU drivers can
+have compatibility issues with Impeller's rendering pipeline, so the base
+resource disables it and `values-v26` enables it again for Android 8+.
 
 ## Fix
 
-Raised `minSdkVersion` from `21` (Android 5.0) to `26` (Android 8.0).
+Keep Android 7 installable with `minSdk = 24`, but apply these compatibility
+guards:
 
-Android 8.0 natively includes all Java 8 library APIs, so the Java 17 compile
-target works without desugaring. This one-line change cleanly avoids the crash
-without introducing untested desugaring configuration.
+- Enable core library desugaring in `android/app/build.gradle.kts`.
+- Use `isar_community`, `isar_community_flutter_libs`, and
+  `isar_community_generator` `3.3.2`.
+- On `MDBX_INCOMPATIBLE`, delete both `flick_player.isar` and
+  `flick_player.isar.lock`, then reopen Isar so the app can recreate the local
+  library database.
+- Keep Impeller disabled for API 24/25 through `values/bools.xml` and enabled
+  for API 26+ through `values-v26/bools.xml`.
 
-### Change
+### Key Changes
 
 `android/app/build.gradle.kts`:
-```kotlin
-// Before
-minSdk = flutter.minSdkVersion  // 21
 
-// After
-minSdk = 26
+```kotlin
+compileOptions {
+    isCoreLibraryDesugaringEnabled = true
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+defaultConfig {
+    minSdk = 24
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+}
 ```
 
-### Why not add desugaring?
+`lib/data/database.dart`:
 
-- No Android 7 devices available for testing
-- Desugaring can have incomplete backports and subtle edge cases
-- Raising minSdk is deterministic — no runtime surprises
+```dart
+// On MDBX_INCOMPATIBLE, remove:
+// <documents>/flick_player.isar
+// <documents>/flick_player.isar.lock
+// Then reopen Isar with the same schema.
+```
 
 ## Impact
 
-- Devices running Android 5.0–7.1 (API 21–25) can no longer install Flick
-- All devices running Android 8.0+ (API 26+) are unaffected
+- Android 7.0/7.1 devices remain installable.
+- If an incompatible Isar environment exists, the local library database is
+  recreated. Users may need to rescan their music folders.
+- Android 8.0+ devices keep Impeller enabled.

--- a/docs/RELEASE_0.18.0-beta.1.md
+++ b/docs/RELEASE_0.18.0-beta.1.md
@@ -15,7 +15,7 @@ This beta adds ten headline features:
 7. **Milestone card redesign** — Per-tier accent colors, achievement grid collection view, "next milestone — N to go" hint line
 8. **What's New system** — Bottom sheet changelog surface on first launch after update
 9. **Ambient background removed** — Ambient background decoration stripped from all library screens
-10. **Build & compatibility** — minSdk lowered to 24, Impeller configurable, V1+V2 APK signing
+10. **Build & compatibility** — Core library desugaring, Isar 3.3.2 with MDBX_INCOMPATIBLE recovery, Impeller configurable per API level, V1+V2 APK signing
 
 ## Highlights
 
@@ -113,10 +113,11 @@ This beta adds ten headline features:
 
 ### Build & Compatibility
 
-- minSdk lowered to 24 (Android 7.0+)
-- Impeller rendering configurable via bools.xml, disabled by default
-- V1 and V2 APK signing enabled in release config
-- Notification channel creation guarded behind API 26 check
+- **minSdk stays at 26** (Android 8.0+). Core library desugaring enabled for Java 17 target.
+- **Isar bumped to 3.3.2** with MDBX_INCOMPATIBLE recovery: corrupt database files are deleted and the library database is recreated automatically.
+- **Impeller rendering configurable** via bools.xml, disabled on API 24/25, enabled on API 26+.
+- V1 and V2 APK signing enabled in release config.
+- Notification channel creation guarded behind API 26 check.
 
 ### Updates & Distribution
 
@@ -157,7 +158,8 @@ This beta adds ten headline features:
 1. The What's New screen appears automatically on first launch after updating — no configuration needed
 2. The vinyl disc morph is activated by tapping album art in the player; rotation seeking works after the single-tap outline animation
 3. Navigation bar collapse happens automatically after the idle timeout; adjust or disable from Settings > Interface
-4. minSdk 24 means Android 7.0+ is now supported (was 26/Android 8.0+)
-5. Impeller can be enabled by setting `enable_impeller` to `true` in `bools.xml`
+4. minSdk remains 26 (Android 8.0+) — Android 7.0/7.1 are not supported
+5. Impeller is disabled on API 24/25 and enabled on API 26+ via `bools.xml` per-density resources
 6. Non-Play Store builds will now check for updates via the GitHub Releases API
 7. Ambient background effects have been removed entirely — the menu screen hero now uses color extraction from album art
+8. If an incompatible Isar database is detected, the local library is recreated automatically; users may need to rescan music folders

--- a/docs/RELEASE_0.18.0-beta.1.md
+++ b/docs/RELEASE_0.18.0-beta.1.md
@@ -1,0 +1,163 @@
+# Flick 0.18.0-beta.1
+
+0.18.0-beta.1 delivers UAC 1.0/2.0 descriptor parsing, DSD bit-order control with a quirk database, integer (I32) stream support via AAudio, artist and playlist dynamic theming, a vinyl disc morph animation with gesture seeking, navigation bar auto-collapse, a redesigned milestone system, the What's New changelog surface, and the removal of ambient background effects.
+
+## Overview
+
+This beta adds ten headline features:
+
+1. **UAC 1.0 & 2.0 descriptor parsing** — USB Audio Class 1.0 and 2.0 descriptor parsing with version detection, unified quirk database, and a generic device model
+2. **DSD bit order & native USB direct** — DsdBitOrder enum (LSB/MSB) with per-decoder detection, global override FFI, quirk-based byte ordering, DoP word building refactored
+3. **Integer (I32) stream support** — AAudio i32 stream variant preserving DoP markers and DSD data, format conversion disabled for bit-perfect paths
+4. **Artist & playlist theming** — ArtistDetailScreen and PlaylistDetailScreen with dynamic color extraction from album art, full-bleed artist backgrounds, info chips
+5. **Vinyl disc & gesture seeking** — Album art morphs into a spinning vinyl record, rotational gesture seek with haptic feedback
+6. **Navigation bar auto-collapse** — FlickNavBar collapses after idle timer with animated transitions, configurable behavior
+7. **Milestone card redesign** — Per-tier accent colors, achievement grid collection view, "next milestone — N to go" hint line
+8. **What's New system** — Bottom sheet changelog surface on first launch after update
+9. **Ambient background removed** — Ambient background decoration stripped from all library screens
+10. **Build & compatibility** — minSdk lowered to 24, Impeller configurable, V1+V2 APK signing
+
+## Highlights
+
+- **UAC 1.0 & 2.0 parsing**: The USB audio subsystem now parses both UAC 1.0 and UAC 2.0 descriptors — including AS General, endpoint, header, and unit descriptors. Version detection is automatic. A unified quirk database with fallback lookup consolidates device-specific workarounds. A generic USB audio device model structures parsed data for the compatibility layer. USB diagnostics were refactored to isolate transport data behind an `UrbTransportInfo` model.
+- **DSD bit order control**: The `DsdBitOrder` enum (LSB/MSB) is detected per-source across all DSD format decoders (DSF, DFF, WavPack). Bit order is normalized in the output router. The `set_dsd_bit_reverse_override()` FFI function exposes manual byte-order control to Flutter. USB native DSD output now carries `dsd_bit_rate` with multi-byte interleaved payload packing and configurable endianness. The `KNOWN_DSD_QUIRKS` table includes per-device entries for vendor/product IDs, endianness, bit reversal, and preferred subslot size — starting with the MOONDROP Dawn Pro.
+- **I32 stream support**: The `AndroidManagedStreamKind` enum replaces the hardcoded f32 stream with `F32` and `I32` variants. `AndroidOutputCallbackI32` reads f32 from the pipeline, extracts raw bit patterns via `f32::to_bits()`, and writes i32 to AAudio — preserving DoP markers and DSD data intact. `open_android_output_stream()` gains a `use_integer_format` parameter, opening i32 streams with format conversion disabled for DoP and native DSD on DAP devices.
+- **Artist & playlist theming**: `ArtistEntity` is a new Isar collection with `id`, `name` (unique, case-insensitive), and `artPath` (nullable). `ArtistRepository` provides `getByName()`, `setArt()`, and `clearArt()` for persistent artist art path caching. `ArtistDetailScreen` was migrated from `StatefulWidget` to `ConsumerStatefulWidget` and uses `ColorExtractionService` for dynamic color theming from resolved album art. Full-bleed artist image background with animated tinted app bar replaces the old circular avatar + stat chips layout. `PlaylistDetailScreen` extracts dynamic playlist color from the most-played song's album art via `getMostPlayedSongAmong()`, displays info chips (track count, total duration, dates), and includes an "Other Playlists" horizontal section.
+- **Vinyl disc morph**: Tapping album art in the player morphs it into a spinning vinyl record via a custom `_VinylDiscPainter` (radial-gradient disc with grooves and highlight). A `_morphController` (700ms) controls the transition, while a `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size. Song changes reset to art mode. Haptic feedback fires on toggle. Rotational gesture seek allows scrubbing by rotating the disc, also with haptic feedback.
+- **Navigation bar collapse**: `FlickNavBar` auto-collapses after a configurable idle timer, with animated transitions to a minimal state. Tapping or dragging reveals the full bar. Preferences control timer duration and collapse behavior.
+- **Milestone cards**: The milestone celebration card was redesigned with per-tier accent colors (bronze, silver, gold, sapphire, amethyst), a large hero icon, tinted border + glow, and a "next milestone — N to go" hint line. A new achievement-style collection view (Settings → Milestones) lists all five tiers in a grid. Unlocked tiles re-open the celebration card with the achieved date; locked tiles show a progress bottom sheet. Settings → About → Milestones shows a live "X / 5 unlocked" counter. `MilestoneService` is now unit-testable via an optional `playCountOverride` constructor parameter.
+- **What's New**: A bottom sheet changelog surface appears on first launch after an update. Structured `ChangelogEntry` data keyed by version is checked against `lastSeenChangelogVersion`. Version constants (`kAppVersion`, `kAppBuild`, `kAppVersionLabel`) centralize version references.
+
+## What's New
+
+### UAC 1.0 & 2.0 Descriptor Parsing
+
+- USB Audio Class 1.0 and 2.0 descriptor parsing with version-specific structs and types
+- Version detection module distinguishes UAC 1.0 from UAC 2.0 devices
+- AS General, endpoint, header, and unit descriptor parsing for both UAC versions
+- Unified quirk database with fallback lookup (device-specific workarounds)
+- Generic USB audio device model for UAC2 compatibility layer
+- USB diagnostics refactored with `UrbTransportInfo` transport data model
+
+### DSD Bit Order & Native USB Direct
+
+- `DsdBitOrder` enum (LSB/MSB) with per-source detection in DSF, DFF, and WavPack decoders
+- Bit order normalization in the DSD output router
+- `set_dsd_bit_reverse_override()` FFI function for manual byte-order control from Flutter
+- `KNOWN_DSD_QUIRKS` table with per-device entries (vendor/product IDs, endianness, bit reversal, subslot size) — includes MOONDROP Dawn Pro quirk
+- DoP word building refactored into `build_dop_word()` with I32 packing for integer streams
+- Default DSD bit rate initialization for newly configured USB playback formats
+- UAC2 multi-byte DSD slots now enabled by default
+- Pipeline mode (`PipelineMode::Dop`, `Passthrough`, `Dsp`) chosen based on output strategy
+- DAP flag included in native DSD detection
+- Debug transport labels updated to descriptive format: `usb-native-dsd-uNxN-bit`, `usb-dop-N-bit`, `usb-pcm`
+
+### Integer (I32) Stream Support
+
+- `AndroidManagedStreamKind` enum with `F32` and `I32` variants replaces hardcoded f32
+- `AndroidOutputCallbackI32` preserves DoP markers and DSD data via `f32::to_bits()` → i32 passthrough
+- `use_integer_format` parameter on `open_android_output_stream()` for DAP DoP/native DSD
+- Fallback stream logic adapted for both f32 and i32 stream kinds
+
+### Artist & Playlist Theming
+
+- `ArtistEntity` Isar collection with auto-generated bindings
+- `ArtistRepository` for persistent artist art path caching
+- `ArtistDetailScreen` dynamic color theming with full-bleed background and scroll-aware app bar
+- `PlaylistDetailScreen` dynamic playlist color, info chips, "Other Playlists" section
+- `getMostPlayedSongAmong()` helper in `RecentlyPlayedRepository`
+- `AlbumDetailScreen` scroll-driven fade for app bar actions
+- Play all and shuffle buttons styled as accent-colored pills with fixed width
+
+### Vinyl Disc & Gesture Seeking
+
+- Album art → vinyl disc morph with custom `_VinylDiscPainter` (radial-gradient, grooves, highlight)
+- 700ms morph transition, 16s spin rotation; song change resets to art mode
+- Rotational gesture seek control on album art with haptic feedback
+- Vinyl outline animation on single tap to enable rotation seeking
+- Album color passed to visualizer preview when mode is not `off`
+
+### Navigation Bar Auto-Collapse
+
+- `FlickNavBar` auto-collapses after configurable idle timer with animated transitions
+- Collapsed state reveals full bar on tap or drag
+- Preferences for collapse behavior and timer duration
+
+### Milestone Card Redesign
+
+- Per-tier accent colors: bronze (100), silver (500), gold (1,000), sapphire (10h), amethyst (50h)
+- "Next milestone — N to go" hint line on the celebration card
+- Achievement grid collection view (Settings → Milestones) with locked/unlocked states
+- Live "X / 5 unlocked" counter in Settings → About → Milestones
+- `MilestoneService` is unit-testable via `playCountOverride` constructor parameter
+- Test suite: `test/services/milestone_service_test.dart`
+
+### What's New System
+
+- Bottom sheet changelog surface on first launch after update
+- `ChangelogEntry` data model with versioned sections and subsections
+- `lastSeenChangelogVersion` preference for tracking seen entries
+- `kAppVersion`, `kAppBuild`, `kAppVersionLabel` constants centralizing version references
+
+### Ambient Background Removed
+
+- Ambient background decoration removed from songs, albums, artists, playlists, favorites, and folders screens
+- Ambient background toggle removed from settings scaffold and playback display
+- Menu screen hero refactored to use `ColorExtractionService` instead of ambient background
+
+### Folder Browser Enhancements
+
+- Pagination with configurable page size slider
+- Pinch-to-zoom gesture support with animated grid transitions
+- File type filter and sort options
+
+### Build & Compatibility
+
+- minSdk lowered to 24 (Android 7.0+)
+- Impeller rendering configurable via bools.xml, disabled by default
+- V1 and V2 APK signing enabled in release config
+- Notification channel creation guarded behind API 26 check
+
+### Updates & Distribution
+
+- GitHub release update checks for non-Play Store builds with customized update messages
+
+### UI Polish & Fixes
+
+- Song auto-added to player queue when added to a playlist
+- Audio info bottom sheet expanded to `ConsumerStatefulWidget` with swipeable page view
+- Library auto-sync refactored to event-driven with full rescan support
+- Equalizer initialized on app start and reapplied after audio session changes
+- Star animation overflow clamped; disc scale clamped to prevent zero/negative values
+- Ring buffer write logic fixed to handle full buffer gracefully
+- Bluetooth devices handled more gracefully; scratch buffer grown
+- Center logo Svg in app info settings screen; version string formatting fix
+- SmartMixDetailScreen back button moved from `SliverAppBar` leading to overlay position
+- Version strings in UI now reference `kAppVersion` constant instead of being hardcoded
+
+## Files Changed
+
+| Area | Key Paths |
+| --- | --- |
+| UAC Parsing | `rust/src/uac2/`, `rust/src/uac1/`, `rust/src/uac/` |
+| DSD Bit Order | `rust/src/audio/dsd_engine/format/`, `rust/src/audio/dsd_engine/dop.rs`, `rust/src/audio/dsd_engine/output_router.rs` |
+| I32 Streams | `rust/src/audio/android_output.rs`, `rust/src/audio/stream_kind.rs` |
+| Artist Theming | `lib/features/artist/screens/artist_detail_screen.dart`, `lib/models/artist_entity.dart`, `lib/services/artist_repository.dart` |
+| Playlist Theming | `lib/features/playlist/screens/playlist_detail_screen.dart`, `lib/features/playlist/widgets/playlist_info_chips.dart` |
+| Vinyl Disc | `lib/features/player/widgets/vinyl_disc_painter.dart`, `lib/features/player/screens/full_player_screen.dart` |
+| Nav Bar | `lib/widgets/flick_nav_bar.dart`, `lib/providers/nav_bar_provider.dart` |
+| Milestones | `lib/services/milestone_service.dart`, `lib/features/milestones/`, `test/services/milestone_service_test.dart` |
+| What's New | `lib/features/whats_new/`, `lib/providers/whats_new_provider.dart` |
+| Folder Browser | `lib/features/folders/screens/folder_browser_screen.dart` |
+| Build Config | `android/app/build.gradle.kts`, `android/app/src/main/res/values/bools.xml` |
+| App Constants | `lib/core/constants/app_constants.dart`, `lib/features/settings/screens/app_info_settings_screen.dart` |
+
+## Upgrading
+
+1. The What's New screen appears automatically on first launch after updating — no configuration needed
+2. The vinyl disc morph is activated by tapping album art in the player; rotation seeking works after the single-tap outline animation
+3. Navigation bar collapse happens automatically after the idle timeout; adjust or disable from Settings > Interface
+4. minSdk 24 means Android 7.0+ is now supported (was 26/Android 8.0+)
+5. Impeller can be enabled by setting `enable_impeller` to `true` in `bools.xml`
+6. Non-Play Store builds will now check for updates via the GitHub Releases API
+7. Ambient background effects have been removed entirely — the menu screen hero now uses color extraction from album art

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,12 +1,12 @@
 /// Current marketing version of the app (matches the `version` field in
 /// `pubspec.yaml`). Bump in lockstep with each release.
-const String kAppVersion = '0.17.0-beta.1';
+const String kAppVersion = '0.18.0-beta.1';
 
 /// Current build number (matches the `version` `+N` suffix in
 /// `pubspec.yaml`). Bump whenever `kAppVersion` is bumped.
-const String kAppBuild = '11';
+const String kAppBuild = '12';
 
-/// Human-friendly version label, e.g. `0.17.0-beta.1 (build 11)`.
+/// Human-friendly version label, e.g. `0.18.0-beta.1 (build 12)`.
 const String kAppVersionLabel = '$kAppVersion (build $kAppBuild)';
 
 /// App-wide constants for Flick Player.

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:isar_community/isar.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -13,6 +15,8 @@ export 'entities/song_entity.dart';
 
 /// Database singleton for Isar operations.
 class Database {
+  static const String _databaseName = 'flick_player';
+
   static Isar? _instance;
 
   static Isar get instance {
@@ -27,16 +31,52 @@ class Database {
     if (_instance != null) return;
 
     final dir = await getApplicationDocumentsDirectory();
-    _instance = await Isar.open(
-      [
-        SongEntitySchema,
-        FolderEntitySchema,
-        RecentlyPlayedEntitySchema,
-        ArtistEntitySchema,
-      ],
-      directory: dir.path,
-      name: 'flick_player',
-    );
+    final schemas = [
+      SongEntitySchema,
+      FolderEntitySchema,
+      RecentlyPlayedEntitySchema,
+      ArtistEntitySchema,
+    ];
+
+    try {
+      _instance = await Isar.open(
+        schemas,
+        directory: dir.path,
+        name: _databaseName,
+      );
+    } on IsarError catch (e) {
+      if (e.message.contains('MDBX_INCOMPATIBLE')) {
+        await _deleteDatabaseFiles(dir.path);
+        _instance = await Isar.open(
+          schemas,
+          directory: dir.path,
+          name: _databaseName,
+        );
+      } else {
+        rethrow;
+      }
+    }
+  }
+
+  static Future<void> _deleteDatabaseFiles(String directory) async {
+    final paths = [
+      '$directory/$_databaseName.isar',
+      '$directory/$_databaseName.isar.lock',
+    ];
+
+    for (final path in paths) {
+      final file = File(path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+
+    // Defensive cleanup for older recovery code that treated the database file
+    // path as a directory.
+    final legacyDirectory = Directory('$directory/$_databaseName.isar');
+    if (await legacyDirectory.exists()) {
+      await legacyDirectory.delete(recursive: true);
+    }
   }
 
   /// Close the database connection.

--- a/lib/data/entities/artist_entity.g.dart
+++ b/lib/data/entities/artist_entity.g.dart
@@ -47,7 +47,7 @@ const ArtistEntitySchema = CollectionSchema(
   getId: _artistEntityGetId,
   getLinks: _artistEntityGetLinks,
   attach: _artistEntityAttach,
-  version: '3.3.0',
+  version: '3.3.2',
 );
 
 int _artistEntityEstimateSize(

--- a/lib/data/entities/folder_entity.g.dart
+++ b/lib/data/entities/folder_entity.g.dart
@@ -71,7 +71,7 @@ const FolderEntitySchema = CollectionSchema(
   getId: _folderEntityGetId,
   getLinks: _folderEntityGetLinks,
   attach: _folderEntityAttach,
-  version: '3.3.0',
+  version: '3.3.2',
 );
 
 int _folderEntityEstimateSize(

--- a/lib/data/entities/recently_played_entity.g.dart
+++ b/lib/data/entities/recently_played_entity.g.dart
@@ -65,7 +65,7 @@ const RecentlyPlayedEntitySchema = CollectionSchema(
   getId: _recentlyPlayedEntityGetId,
   getLinks: _recentlyPlayedEntityGetLinks,
   attach: _recentlyPlayedEntityAttach,
-  version: '3.3.0',
+  version: '3.3.2',
 );
 
 int _recentlyPlayedEntityEstimateSize(

--- a/lib/data/entities/song_entity.g.dart
+++ b/lib/data/entities/song_entity.g.dart
@@ -243,7 +243,7 @@ const SongEntitySchema = CollectionSchema(
   getId: _songEntityGetId,
   getLinks: _songEntityGetLinks,
   attach: _songEntityAttach,
-  version: '3.3.0',
+  version: '3.3.2',
 );
 
 int _songEntityEstimateSize(

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -54,6 +54,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = const {};
   bool _isHistoryLoading = true;
   bool _showEngineCard = true;
+  bool _showUpdateNotice = true;
   Color? _heroDominantColor;
   String? _heroColorArtPath;
   late final AnimationController _welcomeCardController;
@@ -748,16 +749,21 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                                   : const SizedBox.shrink(),
                         ),
                       ),
-                    if (updateState.updateAvailable)
+                    if (updateState.updateAvailable && _showUpdateNotice)
                       SliverToBoxAdapter(
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(
-                            AppConstants.spacingLg,
-                            0,
-                            AppConstants.spacingLg,
-                            AppConstants.spacingLg,
+                        child: AnimatedSize(
+                          duration: AppConstants.animationNormal,
+                          curve: Curves.easeInOut,
+                          alignment: Alignment.topCenter,
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(
+                              AppConstants.spacingLg,
+                              0,
+                              AppConstants.spacingLg,
+                              AppConstants.spacingLg,
+                            ),
+                            child: _buildUpdateNotice(context),
                           ),
-                          child: _buildUpdateNotice(context),
                         ),
                       ),
                     if (isInitialLoading)
@@ -1218,6 +1224,33 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                     ),
                   ],
                 ),
+              ),
+              IconButton(
+                onPressed: () {
+                  setState(() => _showUpdateNotice = false);
+                  ScaffoldMessenger.of(context)
+                    ..removeCurrentSnackBar()
+                    ..showSnackBar(
+                      SnackBar(
+                        content: const Text(
+                          'Update notice hidden.',
+                        ),
+                        behavior: SnackBarBehavior.floating,
+                        duration: const Duration(seconds: 4),
+                        action: SnackBarAction(
+                          label: 'Undo',
+                          onPressed: () =>
+                              setState(() => _showUpdateNotice = true),
+                        ),
+                      ),
+                    );
+                },
+                icon: const Icon(
+                  LucideIcons.x,
+                  size: 18,
+                  color: Colors.white70,
+                ),
+                visualDensity: VisualDensity.compact,
               ),
             ],
           ),

--- a/lib/features/milestone/screens/milestones_screen.dart
+++ b/lib/features/milestone/screens/milestones_screen.dart
@@ -1,23 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/providers/providers.dart';
 import 'package:flick/services/milestone_service.dart';
+import 'package:flick/features/player/widgets/ambient_background.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/features/milestone/widgets/milestone_card.dart';
 
 /// Achievement-style collection view of every milestone tier. Unlocked tiles
 /// re-open the celebration card on tap; locked tiles show a small bottom
 /// sheet with the requirement and current progress.
-class MilestonesScreen extends StatefulWidget {
+class MilestonesScreen extends ConsumerStatefulWidget {
   const MilestonesScreen({super.key});
 
   @override
-  State<MilestonesScreen> createState() => _MilestonesScreenState();
+  ConsumerState<MilestonesScreen> createState() => _MilestonesScreenState();
 }
 
-class _MilestonesScreenState extends State<MilestonesScreen> {
+class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
   final _service = MilestoneService();
   bool _loading = true;
   Map<MilestoneType, MilestoneRecord> _records = {};
@@ -45,26 +48,40 @@ class _MilestonesScreenState extends State<MilestonesScreen> {
   @override
   Widget build(BuildContext context) {
     final unlocked = _records.length;
+    final currentSong = ref.watch(currentSongProvider);
+
     return Scaffold(
       backgroundColor: Colors.transparent,
-      body: SafeArea(
-        bottom: false,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildHeader(context, unlocked),
-            Expanded(
-              child: _loading
-                  ? const Center(
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : RefreshIndicator(
-                      onRefresh: _refresh,
-                      child: _buildGrid(context),
-                    ),
+      body: Stack(
+        children: [
+          Container(
+            decoration: const BoxDecoration(
+              gradient: AppColors.backgroundGradient,
             ),
-          ],
-        ),
+          ),
+          Positioned.fill(
+            child: AmbientBackground(song: currentSong),
+          ),
+          SafeArea(
+            bottom: false,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildHeader(context, unlocked),
+                Expanded(
+                  child: _loading
+                      ? const Center(
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : RefreshIndicator(
+                          onRefresh: _refresh,
+                          child: _buildGrid(context),
+                        ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:http/http.dart' as http;
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -28,10 +29,10 @@ class AppInfoSettingsScreen extends ConsumerStatefulWidget {
 class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
     with SingleTickerProviderStateMixin {
   static final Uri _releaseNotesApiUri = Uri.parse(
-    'https://api.github.com/repos/ultraelectronica/flick_player/releases/latest',
+    'https://api.github.com/repos/moss-apps/Flick/releases/tags/0.18.0-beta.1',
   );
   static const String _releaseNotesUrl =
-      'https://github.com/ultraelectronica/flick_player/releases/latest';
+      'https://github.com/moss-apps/Flick/releases/tag/0.18.0-beta.1';
 
   late final AnimationController _donationPulseController;
   late final Animation<double> _donationPulseAnimation;
@@ -341,12 +342,51 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
                     borderRadius: BorderRadius.circular(AppConstants.radiusMd),
                     border: Border.all(color: AppColors.glassBorder),
                   ),
-                  child: SelectableText(
-                    notes.body,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: context.adaptiveTextSecondary,
-                      height: 1.5,
+                  child: MarkdownBody(
+                    data: notes.body,
+                    styleSheet: MarkdownStyleSheet(
+                      p: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: context.adaptiveTextSecondary,
+                        height: 1.5,
+                      ),
+                      h1: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
+                      h2: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w600,
+                        height: 1.3,
+                      ),
+                      h3: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                        fontWeight: FontWeight.w600,
+                        height: 1.3,
+                      ),
+                      strong: const TextStyle(fontWeight: FontWeight.w700),
+                      code: TextStyle(
+                        fontFamily: 'monospace',
+                        fontSize: 12,
+                        color: context.adaptiveTextSecondary,
+                        backgroundColor: AppColors.glassBackgroundStrong,
+                      ),
+                      listBullet: TextStyle(
+                        color: context.adaptiveTextSecondary,
+                      ),
+                      horizontalRuleDecoration: BoxDecoration(
+                        border: Border(
+                          top: BorderSide(color: AppColors.glassBorder),
+                        ),
+                      ),
+                      blockquote: TextStyle(
+                        color: context.adaptiveTextTertiary,
+                        fontStyle: FontStyle.italic,
+                      ),
+                      tableBorder: TableBorder.all(color: AppColors.glassBorder),
+                      tableHead: const TextStyle(fontWeight: FontWeight.w700),
                     ),
+                    selectable: true,
                   ),
                 ),
                 const SizedBox(height: AppConstants.spacingMd),
@@ -440,7 +480,7 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
             children: [
               TextButton.icon(
                 onPressed: () => _launchUrl(
-                  'https://github.com/ultraelectronica/flick_player',
+                  'https://github.com/moss-apps/Flick',
                 ),
                 icon: const Icon(LucideIcons.squareCode, size: 18),
                 label: const Text(

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -408,7 +408,7 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
           ),
           const SizedBox(height: 4),
           const Text(
-            'Version 0.18.0-beta.1',
+            'Version $kAppVersion',
             style: TextStyle(
               fontFamily: 'ProductSans',
               fontSize: 14,
@@ -598,7 +598,7 @@ SOFTWARE.
               NavigationSetting(
                 icon: LucideIcons.info,
                 title: 'About Flick Player',
-                subtitle: 'Version 0.18.0-beta.1',
+                subtitle: 'Version $kAppVersion',
                 onTap: _showAboutBottomSheet,
               ),
               const SettingsDivider(),

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -44,6 +44,151 @@ class ChangelogSubsection {
 /// automatically surface the entry whose `version` equals `kAppVersion`.
 const List<ChangelogEntry> kChangelogEntries = [
   ChangelogEntry(
+    version: '0.18.0-beta.1',
+    date: '2026-06-07',
+    sections: [
+      ChangelogSection(
+        title: 'UAC 1.0 & 2.0 Descriptor Parsing',
+        bullets: [
+          'USB Audio Class 1.0 and 2.0 descriptor parsing with version detection (header, unit, endpoint). Split version-specific structs and types.',
+          'UAC 1.0/2.0 class constants for descriptors, controls, and requests.',
+          'Active descriptor parsing via UAC2 interfaces with unified quirk database fallback.',
+          'Generic USB audio device model for UAC2 compatibility.',
+          'USB diagnostics refactored with UrbTransportInfo model for transport data isolation.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'DSD Bit Order & Native USB Direct',
+        subsections: [
+          ChangelogSubsection(
+            title: 'DsdBitOrder & Quirks',
+            bullets: [
+              '**DsdBitOrder enum** (LSB/MSB) with per-source detection across all DSD format decoders (DSF, DFF, WavPack). Bit order normalization in the DSD output router.',
+              '**Global DSD bit reverse override:** `set_dsd_bit_reverse_override()` FFI function exposing manual byte-order control to Flutter.',
+              '**USB native DSD output:** `AndroidDirectUsbPlaybackFormat` now carries `dsd_bit_rate`. Multi-byte interleaved USB payload packing with configurable endianness.',
+              '**DSD quirks table:** `KNOWN_DSD_QUIRKS` with per-device entries (vendor/product IDs, endianness, bit reversal, preferred subslot size). Includes MOONDROP Dawn Pro quirk.',
+              '**DoP word building refactored** into reusable `build_dop_word()` method with I32 packing for integer streams.',
+              '**Default DSD bit rate initialization** for newly configured USB playback formats.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'DSD Hardware Transport',
+            bullets: [
+              '**UAC2 feature enabled by default:** Multi-byte DSD slots now active without opt-in.',
+              '**Pipeline mode based on output strategy:** `PipelineMode::Dop` set for USB DSD Native and DSD DoP strategies (bit-perfect passthrough). `Passthrough` for PCM bit-perfect. `Dsp` for standard processing.',
+              '**DAP flag in native DSD detection:** DSD Native mode now considered available on DAP devices even without explicit DSD encoding support.',
+              '**Transport labels made descriptive:** Debug transport labels updated from short codes to `usb-native-dsd-u{subslot}x{bits}-bit`, `usb-dop-{bits}-bit`, `usb-pcm`.',
+              '**`DsdBitOrder` passed through DSD decoder thread** to `DsdOutputRouter` for per-track byte normalization.',
+            ],
+          ),
+          ChangelogSubsection(
+            title: 'Integer (I32) Stream Support',
+            bullets: [
+              '**`AndroidManagedStreamKind` enum:** Replaces hardcoded f32 stream with `F32` and `I32` variants.',
+              '**`AndroidOutputCallbackI32`:** Reads f32 from pipeline, extracts raw bit patterns via `f32::to_bits()`, writes i32 to AAudio — preserving DoP markers and DSD data intact.',
+              '**`open_android_output_stream()`** gains `use_integer_format` parameter; opens i32 stream with format conversion disabled for DoP/native DSD on DAP.',
+              '**Fallback stream logic** adapted to work with both f32 and i32 streams.',
+            ],
+          ),
+        ],
+      ),
+      ChangelogSection(
+        title: 'Artist & Playlist Theming',
+        bullets: [
+          '**ArtistEntity** (Isar collection): `id`, `name` (unique, case-insensitive), `artPath` (nullable). Auto-generated Isar bindings.',
+          '**ArtistRepository:** `getByName()`, `setArt()`, `clearArt()` for persistent artist art path caching.',
+          '**ArtistDetailScreen:** Migrated from `StatefulWidget` to `ConsumerStatefulWidget` (Riverpod). Dynamic color theming via `ColorExtractionService` from resolved album art. Full-bleed artist image background with animated tinted app bar. Removed old circular avatar + stat chips layout.',
+          '**PlaylistDetailScreen:** Dynamic playlist color from most-played song\'s album art via `getMostPlayedSongAmong()`. `TweenAnimationBuilder` tinted background. Info chips (track count, total duration, created/updated dates). "Other Playlists" horizontal section. Back button repositioned to overlay. Removed 4-tile cover grid.',
+          '**`getMostPlayedSongAmong()`** in `RecentlyPlayedRepository`: Returns most-played song from a given list for playlist color extraction.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Vinyl Disc & Gesture Seeking',
+        bullets: [
+          '**Vinyl disc morph animation:** Tap album art to morph into a spinning vinyl record. `_VinylDiscPainter` draws radial-gradient disc with grooves and highlight. `_morphController` (700ms) controls transition; `_spinController` (16s rotation) spins the disc. Album art shrinks to center label size. Song change resets to art mode. Haptic feedback on toggle.',
+          '**Rotational gesture seek control** on album art with haptic feedback.',
+          '**Vinyl outline animation** on single tap to enable rotation seeking.',
+          '**Album color in visualizer preview:** `_buildVisualizerPreview()` reads `albumColorModeProvider` and passes album color when mode is not `off`.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Navigation Bar Auto-Collapse',
+        bullets: [
+          'FlickNavBar auto-collapse with animated transitions after idle timer.',
+          'Configurable auto-collapse behavior and timer duration via preferences.',
+          'Collapsed state with smooth animated reveal on interaction.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Milestone Card Redesign & Collection',
+        bullets: [
+          'Redesigned milestone celebration card with per-tier accent color (bronze / silver / gold / sapphire / amethyst), large hero icon, tinted border + glow, and a subtle "next milestone — N to go" hint line',
+          'New achievement-style collection view (Settings → Milestones) listing all five tiers in a grid; unlocked tiles re-open the celebration card with the achieved date, locked tiles show a progress bottom sheet',
+          'Settings → About → Milestones tile shows a live "X / 5 unlocked" counter',
+          'Five new `AppColors` milestone tint constants and per-tier `tierIcon` / `tierColor` / `shortLabel` / `threshold` / `isTopTier` getters on `MilestoneTypeX`',
+          'New `MilestoneService.getNextMilestone()` helper for "next unshown tier + remaining units" (used by the popup and the locked-tile sheet)',
+          '`MilestoneService` constructor now accepts an optional `playCountOverride` for unit testing without Isar',
+          'New test suite: `test/services/milestone_service_test.dart`',
+        ],
+      ),
+      ChangelogSection(
+        title: 'What\'s New System',
+        bullets: [
+          'What\'s New bottom sheet shown on first launch after update.',
+          'Structured changelog data model with versioned entries and sections.',
+          'Changelog-aware provider with `lastSeenChangelogVersion` preference.',
+          'Version constants (`kAppVersion`, `kAppBuild`, `kAppVersionLabel`) in `app_constants.dart`.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Ambient Background Removed',
+        bullets: [
+          'Ambient background decoration removed from songs, albums, artists, playlists, favorites, and folders screens.',
+          'Ambient background toggle removed from settings and playback display.',
+          'Menu screen hero refactored to use `ColorExtractionService` instead of ambient background.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Folder Browser Enhancements',
+        bullets: [
+          'Pagination with configurable page size slider.',
+          'Pinch-to-zoom gesture support with animated grid transitions.',
+          'File type filter and sort options in folder browser.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Build & Compatibility',
+        bullets: [
+          '**minSdk lowered to 24** (Android 7.0+), down from 26.',
+          '**Impeller rendering configurable** via bool resource, disabled by default.',
+          '**V1 and V2 APK signing** enabled in release config.',
+          'Notification channel creation guarded behind API 26 check.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Updates & Distribution',
+        bullets: [
+          'GitHub release update checks for non-Play Store builds with customized update messages.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'UI Polish & Fixes',
+        bullets: [
+          'Play all and shuffle buttons styled as accent-colored pills with fixed width.',
+          'Scroll-aware animated app bar actions on artist, playlist, and album detail screens.',
+          'Song auto-added to player queue when added to a playlist.',
+          'Audio info bottom sheet expanded to `ConsumerStatefulWidget` with swipeable page view.',
+          'Library auto-sync refactored to event-driven with full rescan support.',
+          'Equalizer initialized on app start and reapplied after audio session changes.',
+          'Star animation overflow clamped; disc scale clamped to prevent zero/negative values.',
+          'Ring buffer write logic fixed to handle full buffer gracefully; bluetooth devices handled more gracefully.',
+          'Center logo Svg in app info settings screen.',
+          'SmartMixDetailScreen back button moved to overlay position.',
+        ],
+      ),
+    ],
+  ),
+  ChangelogEntry(
     version: '0.17.0-beta.1',
     date: '2026-05-31',
     sections: [

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -159,8 +159,9 @@ const List<ChangelogEntry> kChangelogEntries = [
       ChangelogSection(
         title: 'Build & Compatibility',
         bullets: [
-          '**minSdk lowered to 24** (Android 7.0+), down from 26.',
-          '**Impeller rendering configurable** via bool resource, disabled by default.',
+          '**minSdk stays at 26** (Android 8.0+). Core library desugaring enabled for Java 17 target.',
+          '**Impeller rendering configurable** via bool resource, disabled on API 24/25, enabled on API 26+.',
+          '**Isar bumped to 3.3.2** with MDBX_INCOMPATIBLE recovery: corrupt database files are deleted and the library database is recreated automatically.',
           '**V1 and V2 APK signing** enabled in release config.',
           'Notification channel creation guarded behind API 26 check.',
         ],

--- a/lib/providers/update_check_provider.dart
+++ b/lib/providers/update_check_provider.dart
@@ -73,7 +73,7 @@ class UpdateCheckNotifier extends Notifier<UpdateCheckState> {
   static const Duration _automaticRefreshCooldown = Duration(minutes: 30);
 
   static final Uri _githubReleasesApiUri = Uri.parse(
-    'https://api.github.com/repos/ultraelectronica/flick_player/releases/latest',
+    'https://api.github.com/repos/moss-apps/Flick/releases/latest',
   );
 
   final Connectivity _connectivity = Connectivity();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: f7833bee67c03c37241c67f8741b17cc501b69d9758df7a5a4a13ed6c947be43
+      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.10"
+    version: "0.1.11"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.6"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -113,30 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
+      sha256: "39ad4ca8a2876779737c60e4228b4bcd35d4352ef7e14e47514093edc012c734"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.3.1"
+    version: "2.11.1"
   built_collection:
     dependency: transitive
     description:
@@ -435,6 +419,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -707,26 +699,26 @@ packages:
     dependency: "direct main"
     description:
       name: isar_community
-      sha256: d92315e1862448f236489c2b2b1f9a7ad5ba2405f42d87216234be4fb2e1dd2d
+      sha256: "683fd093956eac3a660776afb70d65d50a3391b3587b40b89e3d12586b8cc47f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   isar_community_flutter_libs:
     dependency: "direct main"
     description:
       name: isar_community_flutter_libs
-      sha256: "3c072d8d77e820196fa23839b88481c50d903c73b3c0db6e647b29509d04fe3b"
+      sha256: c44340fa38c81ef16d924202d443bbe799cde4826be9a31a9dc92ee612e1966f
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   isar_community_generator:
     dependency: "direct dev"
     description:
       name: isar_community_generator
-      sha256: "6ca1487b7551850f7896443aa8079a12b23cdf71a99dafb1f567c83d6e031042"
+      sha256: fd5a2a5df2aac2fccba82425005bf47fd2a48f34190536d0c9fd732dc7303fb3
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   js:
     dependency: transitive
     description:
@@ -823,6 +815,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.12"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:
@@ -1279,10 +1279,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "4.2.3"
   source_helper:
     dependency: transitive
     description:
@@ -1451,14 +1451,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   toml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.18.0-beta.1+12
+version: 0.18.0-beta.1+13
 
 environment:
   sdk: ^3.10.4
@@ -39,6 +39,7 @@ dependencies:
     sdk: flutter
   flutter_cache_manager: ^3.4.1
   flutter_displaymode: ^0.7.0
+  flutter_markdown: ^0.7.7
   flutter_riverpod: ^3.0.3
   flutter_rust_bridge: ^2.12.0
   flutter_secure_storage: ^10.0.0
@@ -47,8 +48,8 @@ dependencies:
   freezed_annotation: ^3.0.0
   http: ^1.2.0
   image_picker: ^1.1.2
-  isar_community: ^3.3.0
-  isar_community_flutter_libs: ^3.3.0
+  isar_community: ^3.3.2
+  isar_community_flutter_libs: ^3.3.2
   json_annotation: ^4.9.0
   just_audio: ^0.10.5
   lucide_icons_flutter: ^3.1.8
@@ -74,7 +75,7 @@ dev_dependencies:
   freezed: ^3.0.0
   integration_test:
     sdk: flutter
-  isar_community_generator: ^3.3.0
+  isar_community_generator: ^3.3.2
   json_serializable: 6.11.2
   riverpod_generator: 4.0.0+1
   riverpod_lint: ^3.0.3


### PR DESCRIPTION
# Summary

- Update Isar to 3.3.2 across all entity schema versions
- Add Markdown release notes rendering with `flutter_markdown` dependency
- Handle `MDBX_INCOMPATIBLE` database errors by deleting corrupt files
- Update changelog and fix GitHub release API URLs
- Render formatted release notes with GitHub Markdown in app info screen
- Bump Android `minSdk` back to 26

# Changes

## Isar 3.3.2 Migration

- Bump `SongEntity` schema version to 3.3.2
- Bump `RecentlyPlayedEntity` schema version to 3.3.2
- Bump `FolderEntity` schema version to 3.3.2
- Bump `ArtistEntity` schema version to 3.3.2
- Update `pubspec.yaml`/`flutter pub upgrade` to Isar 3.3.2

## Release Notes & Changelog

- Add `flutter_markdown` dependency for formatted release notes
- Add Markdown release notes rendering in app info settings screen
- Update GitHub URLs to point to `moss-apps` org
- Fix GitHub release API URL
- Remove hardcoded release notes, fetch latest from GitHub releases

## Database Recovery

- Handle `MDBX_INCOMPATIBLE` error by deleting database files and re-creating

## Build

- Bump Android `minSdk` to 26
- Update `ANDROID_7_CRASH` docs
- Update `RELEASE_0.18.0-beta.1` docs

## Files Changed

- `pubspec.yaml`
- `pubspec.lock`
- `lib/data/database.dart`
- `lib/data/entities/song_entity.g.dart`
- `lib/data/entities/recently_played_entity.g.dart`
- `lib/data/entities/folder_entity.g.dart`
- `lib/data/entities/artist_entity.g.dart`
- `lib/features/whats_new/data/changelog_data.dart`
- `lib/providers/update_check_provider.dart`
- `lib/features/settings/screens/app_info_settings_screen.dart`
- `android/app/build.gradle.kts`
- `docs/ANDROID_7_CRASH.md`
- `docs/RELEASE_0.18.0-beta.1.md`
- `CHANGELOG.md`