### PR TITLE
Add ListenBrainz scrobbling, developer mode logging, recently played pagination, and song deletion improvements

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -875,6 +875,11 @@ class MainActivity: FlutterActivity() {
                     killIsochronousUsbOnQuit = enabled
                     result.success(true)
                 }
+                "setDeveloperMode" -> {
+                    val enabled = call.argument<Boolean>("enabled") ?: false
+                    nativeSetRustDeveloperMode(enabled)
+                    result.success(true)
+                }
                 "markDirectUsbFallback" -> {
                     val reason = call.argument<String>("reason")
                     result.success(nativeMarkRustDirectUsbFallback(reason))
@@ -4001,4 +4006,5 @@ class MainActivity: FlutterActivity() {
     private external fun nativeWaitRustDirectUsbSessionStopped(timeoutMs: Int): Boolean
     private external fun nativeIsRustDirectUsbSessionActive(): Boolean
     private external fun nativeMarkRustDirectUsbFallback(reason: String?): Boolean
+    private external fun nativeSetRustDeveloperMode(enabled: Boolean)
 }

--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -482,6 +482,24 @@ class MainActivity: FlutterActivity() {
                         result.error("INVALID_ARGUMENT", "folderTreeUri and filePath are required", null)
                     }
                 }
+                "removeFromMediaStore" -> {
+                    val filePath = call.argument<String>("filePath")
+                    if (filePath != null) {
+                        mainScope.launch {
+                            try {
+                                val removed = withContext(Dispatchers.IO) {
+                                    removeFromMediaStore(filePath)
+                                }
+                                result.success(removed)
+                            } catch (e: Exception) {
+                                Log.w("MainActivity", "[MethodChannel] removeFromMediaStore error: ${e.message}", e)
+                                result.success(false)
+                            }
+                        }
+                    } else {
+                        result.error("INVALID_ARGUMENT", "filePath is required", null)
+                    }
+                }
                 "writeFileBytesViaSaf" -> {
                     val folderTreeUri = call.argument<String>("folderTreeUri")
                     val filePath = call.argument<String>("filePath")
@@ -1299,50 +1317,87 @@ class MainActivity: FlutterActivity() {
     private fun deleteDocumentViaSaf(folderTreeUri: String, filePath: String): Boolean {
         return try {
             val fileUri = Uri.parse(filePath)
+
             if (fileUri.scheme == "content") {
-                DocumentsContract.deleteDocument(contentResolver, fileUri)
-            } else {
+                return try {
+                    DocumentsContract.deleteDocument(contentResolver, fileUri)
+                } catch (e: Exception) {
+                    Log.w("MainActivity", "content URI deletion failed: ${e.message}")
+                    false
+                }
+            }
+
+            if (removeFromMediaStore(filePath)) return true
+
+            try {
                 val treeUri = Uri.parse(folderTreeUri)
                 val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
                 val decodedId = Uri.decode(treeDocId)
                 val parts = decodedId.split(":", limit = 2)
-                if (parts.isEmpty()) return false
+                if (parts.isNotEmpty()) {
+                    val volumeId = parts[0]
+                    val relativeFolderPath = parts.getOrNull(1)?.trim('/') ?: ""
+                    val basePath = when (volumeId.lowercase()) {
+                        "primary" -> Environment.getExternalStorageDirectory().absolutePath
+                        "home" -> Environment.getExternalStoragePublicDirectory(
+                            Environment.DIRECTORY_DOCUMENTS
+                        ).absolutePath
+                        else -> "/storage/$volumeId"
+                    }
 
-                val volumeId = parts[0]
-                val relativeFolderPath = parts.getOrNull(1)?.trim('/') ?: ""
-                val basePath = when (volumeId.lowercase()) {
-                    "primary" -> Environment.getExternalStorageDirectory().absolutePath
-                    "home" -> Environment.getExternalStoragePublicDirectory(
-                        Environment.DIRECTORY_DOCUMENTS
-                    ).absolutePath
-                    else -> "/storage/$volumeId"
+                    val folderBase = if (relativeFolderPath.isEmpty()) {
+                        File(basePath)
+                    } else {
+                        File("$basePath/$relativeFolderPath")
+                    }
+                    val canonicalBase = folderBase.canonicalPath.trimEnd('/')
+                    val canonicalFile = File(filePath).canonicalPath.trimEnd('/')
+
+                    if (canonicalFile.startsWith("$canonicalBase/") || canonicalFile == canonicalBase) {
+                        val relativePath = if (canonicalFile == canonicalBase) {
+                            ""
+                        } else {
+                            canonicalFile.removePrefix("$canonicalBase/")
+                        }
+
+                        val childDocId = if (relativePath.isEmpty()) treeDocId else "$treeDocId/$relativePath"
+                        val childUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childDocId)
+                        if (DocumentsContract.deleteDocument(contentResolver, childUri)) return true
+                    }
                 }
-
-                val folderBase = if (relativeFolderPath.isEmpty()) {
-                    File(basePath)
-                } else {
-                    File("$basePath/$relativeFolderPath")
-                }
-                val canonicalBase = folderBase.canonicalPath.trimEnd('/')
-                val canonicalFile = File(filePath).canonicalPath.trimEnd('/')
-
-                if (!canonicalFile.startsWith("$canonicalBase/") && canonicalFile != canonicalBase) {
-                    Log.w("MainActivity", "deleteDocumentViaSaf: file $filePath is not under tree $folderTreeUri")
-                    return false
-                }
-
-                val relativePath = if (canonicalFile == canonicalBase) {
-                    ""
-                } else {
-                    canonicalFile.removePrefix("$canonicalBase/")
-                }
-
-                val childDocId = if (relativePath.isEmpty()) treeDocId else "$treeDocId/$relativePath"
-                val childUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, childDocId)
-                DocumentsContract.deleteDocument(contentResolver, childUri)
+            } catch (safEx: Exception) {
+                Log.w("MainActivity", "SAF deletion failed, trying File.delete: ${safEx.message}")
             }
+
+            try {
+                val file = File(filePath)
+                if (file.exists()) {
+                    if (file.delete()) return true
+                } else {
+                    return true
+                }
+            } catch (fileEx: Exception) {
+                Log.w("MainActivity", "File.delete failed: ${fileEx.message}")
+            }
+
+            false
         } catch (e: Exception) {
             Log.w("MainActivity", "deleteDocumentViaSaf failed: ${e.message}", e)
+            false
+        }
+    }
+
+    private fun removeFromMediaStore(filePath: String): Boolean {
+        return try {
+            val uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+            val rowsDeleted = contentResolver.delete(
+                uri,
+                "${MediaStore.Audio.Media.DATA} = ?",
+                arrayOf(filePath)
+            )
+            rowsDeleted > 0
+        } catch (e: Exception) {
+            Log.w("MainActivity", "removeFromMediaStore failed: ${e.message}", e)
             false
         }
     }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -522,6 +522,16 @@ class _MainShellState extends ConsumerState<MainShell>
               listenedSeconds: notifier.accumulatedListenSeconds,
               trackDurationSeconds: playerState.duration.inSeconds,
             );
+        ref
+            .read(listenBrainzScrobbleProvider.notifier)
+            .onTrackEnded(
+              artist: song.artist,
+              track: song.title,
+              album: song.album,
+              albumArtist: null,
+              listenedSeconds: notifier.accumulatedListenSeconds,
+              trackDurationSeconds: playerState.duration.inSeconds,
+            );
       }
     }
     if (state == AppLifecycleState.resumed) {
@@ -530,6 +540,9 @@ class _MainShellState extends ConsumerState<MainShell>
       ref.read(updateCheckProvider.notifier).refreshIfOnline();
       ref.read(lastFmScrobbleQueueProvider).flush().catchError((e) {
         devLog('[LastFm] queue flush on resume failed: $e');
+      });
+      ref.read(listenbrainzScrobbleQueueProvider).flush().catchError((e) {
+        devLog('[ListenBrainz] queue flush on resume failed: $e');
       });
       ref.read(autoLibrarySyncServiceProvider).notifyResumed();
     }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -40,6 +40,7 @@ import 'package:flick/services/widget_intent_handler.dart';
 import 'package:flick/models/nav_bar_config.dart';
 import 'package:flick/features/milestone/widgets/milestone_card.dart';
 import 'package:flick/features/whats_new/widgets/whats_new_bottom_sheet.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Main application widget for Flick Player.
 class FlickPlayerApp extends StatelessWidget {
@@ -324,7 +325,7 @@ class _MainShellState extends ConsumerState<MainShell>
         ref.invalidate(musicFoldersProvider);
       }
     } catch (e) {
-      debugPrint('Library deletion refresh failed: $e');
+      devLog('Library deletion refresh failed: $e');
     }
   }
 
@@ -528,7 +529,7 @@ class _MainShellState extends ConsumerState<MainShell>
       unawaited(ref.read(playerServiceProvider).onAppResumed());
       ref.read(updateCheckProvider.notifier).refreshIfOnline();
       ref.read(lastFmScrobbleQueueProvider).flush().catchError((e) {
-        debugPrint('[LastFm] queue flush on resume failed: $e');
+        devLog('[LastFm] queue flush on resume failed: $e');
       });
       ref.read(autoLibrarySyncServiceProvider).notifyResumed();
     }

--- a/lib/core/utils/dev_log.dart
+++ b/lib/core/utils/dev_log.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+import 'package:flick/services/uac2_preferences_service.dart';
+
+void devLog(String message) {
+  if (Uac2PreferencesService.isDeveloperModeEnabledSync) {
+    debugPrint(message);
+  }
+}

--- a/lib/data/repositories/recently_played_repository.dart
+++ b/lib/data/repositories/recently_played_repository.dart
@@ -313,11 +313,22 @@ class RecentlyPlayedRepository {
 
   /// Get flat list of recently played entries (most recent first).
   Future<List<RecentlyPlayedEntry>> getRecentHistory({int limit = 50}) async {
+    return getRecentHistoryPaginated(offset: 0, limit: limit);
+  }
+
+  /// Get a paginated slice of recently played entries (most recent first).
+  Future<List<RecentlyPlayedEntry>> getRecentHistoryPaginated({
+    int offset = 0,
+    int limit = 50,
+  }) async {
     final entries = await _isar.recentlyPlayedEntitys
         .where()
         .sortByPlayedAtDesc()
+        .offset(offset)
         .limit(limit)
         .findAll();
+
+    if (entries.isEmpty) return const [];
 
     final allSongEntities = await _songRepository.getAllSongEntities();
     final songMap = {for (var e in allSongEntities) e.id: e};

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1280,263 +1280,276 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (sheetContext) => SafeArea(
-        top: false,
-        child: Container(
-          constraints: BoxConstraints(
-            maxHeight: MediaQuery.of(sheetContext).size.height * 0.5,
-          ),
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-            border: Border.all(color: AppColors.glassBorder),
-          ),
-          padding: EdgeInsets.fromLTRB(
-            context.responsive(16.0, 18.0, 20.0),
-            context.responsive(10.0, 11.0, 12.0),
-            context.responsive(16.0, 18.0, 20.0),
-            context.responsive(20.0, 22.0, 24.0),
-          ),
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-              Container(
-                width: 40,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: AppColors.glassBorderStrong,
-                  borderRadius: BorderRadius.circular(4),
-                ),
+      builder: (sheetContext) => ValueListenableBuilder<Song?>(
+        valueListenable: _playerService.currentSongNotifier,
+        builder: (sheetContext, currentSong, _) {
+          final activeSong = currentSong ?? song;
+          return SafeArea(
+            top: false,
+            child: Container(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(sheetContext).size.height * 0.5,
               ),
-              const SizedBox(height: 16),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+                border: Border.all(color: AppColors.glassBorder),
+              ),
+              padding: EdgeInsets.fromLTRB(
+                context.responsive(16.0, 18.0, 20.0),
+                context.responsive(10.0, 11.0, 12.0),
+                context.responsive(16.0, 18.0, 20.0),
+                context.responsive(20.0, 22.0, 24.0),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(
-                      context.responsive(10.0, 11.0, 12.0),
+                  Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppColors.glassBorderStrong,
+                      borderRadius: BorderRadius.circular(4),
                     ),
-                    child: SizedBox(
-                      width: context.responsive(56.0, 62.0, 68.0),
-                      height: context.responsive(56.0, 62.0, 68.0),
-                      child: CachedImageWidget(
-                        imagePath: song.albumArt,
-                        audioSourcePath: song.filePath,
-                        fit: BoxFit.cover,
-                        useThumbnail: true,
-                        thumbnailWidth: 136,
-                        thumbnailHeight: 136,
-                        placeholder: Container(
-                          color: AppColors.surfaceLight,
-                          child: const Icon(
-                            LucideIcons.music,
-                            color: AppColors.textTertiary,
-                            size: 24,
-                          ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(
+                          context.responsive(10.0, 11.0, 12.0),
                         ),
-                        errorWidget: Container(
-                          color: AppColors.surfaceLight,
-                          child: const Icon(
-                            LucideIcons.music,
-                            color: AppColors.textTertiary,
-                            size: 24,
+                        child: SizedBox(
+                          width: context.responsive(56.0, 62.0, 68.0),
+                          height: context.responsive(56.0, 62.0, 68.0),
+                          child: CachedImageWidget(
+                            imagePath: activeSong.albumArt,
+                            audioSourcePath: activeSong.filePath,
+                            fit: BoxFit.cover,
+                            useThumbnail: true,
+                            thumbnailWidth: 136,
+                            thumbnailHeight: 136,
+                            placeholder: Container(
+                              color: AppColors.surfaceLight,
+                              child: const Icon(
+                                LucideIcons.music,
+                                color: AppColors.textTertiary,
+                                size: 24,
+                              ),
+                            ),
+                            errorWidget: Container(
+                              color: AppColors.surfaceLight,
+                              child: const Icon(
+                                LucideIcons.music,
+                                color: AppColors.textTertiary,
+                                size: 24,
+                              ),
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          song.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontFamily: 'ProductSans',
-                            fontSize: context.responsive(16.0, 17.0, 18.0),
-                            fontWeight: FontWeight.w600,
-                            color: sheetContext.adaptiveTextPrimary,
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          song.artist,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontFamily: 'ProductSans',
-                            fontSize: context.responsive(12.0, 13.0, 14.0),
-                            color: sheetContext.adaptiveTextSecondary,
-                          ),
-                        ),
-                        const SizedBox(height: 10),
-                        Wrap(
-                          spacing: 8,
-                          runSpacing: 8,
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            _buildSongInfoChip(
-                              sheetContext,
-                              song.formattedDuration,
+                            Text(
+                              activeSong.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontFamily: 'ProductSans',
+                                fontSize: context.responsive(16.0, 17.0, 18.0),
+                                fontWeight: FontWeight.w600,
+                                color: sheetContext.adaptiveTextPrimary,
+                              ),
                             ),
-                            _buildSongInfoChip(
-                              sheetContext,
-                              song.fileType.toUpperCase(),
+                            const SizedBox(height: 4),
+                            Text(
+                              activeSong.artist,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                fontFamily: 'ProductSans',
+                                fontSize: context.responsive(12.0, 13.0, 14.0),
+                                color: sheetContext.adaptiveTextSecondary,
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            Wrap(
+                              spacing: 8,
+                              runSpacing: 8,
+                              children: [
+                                _buildSongInfoChip(
+                                  sheetContext,
+                                  activeSong.formattedDuration,
+                                ),
+                                _buildSongInfoChip(
+                                  sheetContext,
+                                  activeSong.fileType.toUpperCase(),
+                                ),
+                              ],
                             ),
                           ],
                         ),
-                      ],
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Flexible(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                  if (!activeSong.isFromLocker)
+                    _buildSongActionTile(
+                      context: sheetContext,
+                      icon: LucideIcons.listPlus,
+                      label: 'Add to Queue',
+                      onTap: () async {
+                        Navigator.pop(sheetContext);
+                        await _queueSong(context, activeSong);
+                      },
+                    ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.listMusic,
+                    label: 'Add to Playlist',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _showAddToPlaylistDialog(context, activeSong);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.image,
+                    label: 'Set Album Art',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      unawaited(
+                        Future<void>.delayed(
+                          Duration.zero,
+                          () => AlbumArtPickerBottomSheet.show(context, activeSong),
+                        ),
+                      );
+                    },
+                  ),
+                  if (activeSong.filePath != null &&
+                      activeSong.startOffsetMs == null &&
+                      !activeSong.isExternal)
+                    _buildSongActionTile(
+                      context: sheetContext,
+                      icon: LucideIcons.pencil,
+                      label: 'Edit Metadata',
+                      onTap: () {
+                        Navigator.pop(sheetContext);
+                        Navigator.of(context).push<bool>(
+                          MaterialPageRoute(
+                            builder: (_) => MetadataEditorScreen(song: activeSong),
+                          ),
+                        ).then((saved) {
+                          if (saved == true) {
+                            ref.invalidate(songsProvider);
+                          }
+                        });
+                      },
+                    ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.info,
+                    label: 'View Metadata',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _showSongMetadataBottomSheet(context, activeSong);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.fileText,
+                    label: 'Lyrics',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _setLyricsMode(true);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: Icons.graphic_eq_rounded,
+                    label: _isVisualizationMode ? 'Hide Visualizer' : 'Visualizer',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _setVisualizationMode(!_isVisualizationMode);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.user,
+                    label: 'Go to Artist',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _openArtistFromSong(context, activeSong);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.disc,
+                    label: 'Go to Album',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _openAlbumFromSong(context, activeSong);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: Icons.dashboard_customize_rounded,
+                    label: 'Player Layout',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _showPlayerLayoutBottomSheet(context);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.gauge,
+                    label: 'Playback Speed',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _showSpeedBottomSheet(context);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.moonStar,
+                    label: 'Sleep Timer',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      _showSleepTimerBottomSheet(context);
+                    },
+                  ),
+                  _buildSongActionTile(
+                    context: sheetContext,
+                    icon: LucideIcons.share2,
+                    label: 'Share',
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      showModalBottomSheet(
+                        context: context,
+                        backgroundColor: Colors.transparent,
+                        isScrollControlled: true,
+                        builder: (_) => ShareBottomSheet(song: activeSong),
+                      );
+                    },
+                  ),
+                        ],
+                      ),
                     ),
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
-              if (!song.isFromLocker)
-                _buildSongActionTile(
-                  context: sheetContext,
-                  icon: LucideIcons.listPlus,
-                  label: 'Add to Queue',
-                  onTap: () async {
-                    Navigator.pop(sheetContext);
-                    await _queueSong(context, song);
-                  },
-                ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.listMusic,
-                label: 'Add to Playlist',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showAddToPlaylistDialog(context, song);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.image,
-                label: 'Set Album Art',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  unawaited(
-                    Future<void>.delayed(
-                      Duration.zero,
-                      () => AlbumArtPickerBottomSheet.show(context, song),
-                    ),
-                  );
-                },
-              ),
-              if (song.filePath != null &&
-                  song.startOffsetMs == null &&
-                  !song.isExternal)
-                _buildSongActionTile(
-                  context: sheetContext,
-                  icon: LucideIcons.pencil,
-                  label: 'Edit Metadata',
-                  onTap: () {
-                    Navigator.pop(sheetContext);
-                    Navigator.of(context).push<bool>(
-                      MaterialPageRoute(
-                        builder: (_) => MetadataEditorScreen(song: song),
-                      ),
-                    ).then((saved) {
-                      if (saved == true) {
-                        ref.invalidate(songsProvider);
-                      }
-                    });
-                  },
-                ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.info,
-                label: 'View Metadata',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showSongMetadataBottomSheet(context, song);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.fileText,
-                label: 'Lyrics',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _setLyricsMode(true);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: Icons.graphic_eq_rounded,
-                label: _isVisualizationMode ? 'Hide Visualizer' : 'Visualizer',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _setVisualizationMode(!_isVisualizationMode);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.user,
-                label: 'Go to Artist',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openArtistFromSong(context, song);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.disc,
-                label: 'Go to Album',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _openAlbumFromSong(context, song);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: Icons.dashboard_customize_rounded,
-                label: 'Player Layout',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showPlayerLayoutBottomSheet(context);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.gauge,
-                label: 'Playback Speed',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showSpeedBottomSheet(context);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.moonStar,
-                label: 'Sleep Timer',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  _showSleepTimerBottomSheet(context);
-                },
-              ),
-              _buildSongActionTile(
-                context: sheetContext,
-                icon: LucideIcons.share2,
-                label: 'Share',
-                onTap: () {
-                  Navigator.pop(sheetContext);
-                  showModalBottomSheet(
-                    context: context,
-                    backgroundColor: Colors.transparent,
-                    isScrollControlled: true,
-                    builder: (_) => ShareBottomSheet(song: song),
-                  );
-                },
-              ),
-            ],
             ),
-          ),
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/features/player/widgets/ambient_background.dart
+++ b/lib/features/player/widgets/ambient_background.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/album_art_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 // ---------------------------------------------------------------------------
 // AmbientBackground
@@ -179,7 +180,7 @@ class _AmbientBackgroundState extends State<AmbientBackground> {
         _currentPath = resolvedPath;
       });
     } catch (e) {
-      debugPrint('[AmbientBackground] blur failed: $e');
+      devLog('[AmbientBackground] blur failed: $e');
     } finally {
       _computing = false;
     }

--- a/lib/features/recently_played/screens/recently_played_screen.dart
+++ b/lib/features/recently_played/screens/recently_played_screen.dart
@@ -14,7 +14,13 @@ import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/glass_dialog.dart';
 
-/// Recently Played screen with timeline-style layout.
+/// Number of history entries fetched per page.
+const int _kPageSize = 50;
+
+/// Pixels from the bottom of the list that trigger the next page load.
+const double _kLoadMoreThreshold = 300;
+
+/// Recently Played screen with a grouped list layout and paginated loading.
 class RecentlyPlayedScreen extends StatefulWidget {
   const RecentlyPlayedScreen({super.key});
 
@@ -26,17 +32,23 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
   final PlayerService _playerService = PlayerService();
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
+  final ScrollController _scrollController = ScrollController();
 
-  bool _isLoading = true;
+  List<RecentlyPlayedEntry> _entries = [];
   Map<String, List<RecentlyPlayedEntry>> _groupedHistory = {};
+  bool _isLoading = true;
+  bool _isLoadingMore = false;
+  bool _hasMore = true;
+  int _totalCount = 0;
   StreamSubscription<void>? _historySubscription;
 
   @override
   void initState() {
     super.initState();
-    // Defer data loading to avoid jank during navigation
+    _scrollController.addListener(_onScroll);
+    // Defer data loading to avoid jank during navigation.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _loadHistory();
+      _loadInitialHistory();
       _watchHistory();
     });
   }
@@ -44,36 +56,135 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
   @override
   void dispose() {
     _historySubscription?.cancel();
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
     super.dispose();
   }
 
   void _watchHistory() {
     _historySubscription = _recentlyPlayedRepository.watchHistory().listen((_) {
-      _loadHistory();
+      _resetPagination();
+      _loadInitialHistory();
     });
   }
 
-  Future<void> _loadHistory() async {
+  Future<void> _loadInitialHistory() async {
     if (!mounted) return;
 
-    setState(() => _isLoading = true);
+    setState(() {
+      _isLoading = true;
+      _hasMore = true;
+    });
 
     try {
-      final grouped = await _recentlyPlayedRepository.getGroupedHistory();
+      final count = await _recentlyPlayedRepository.getHistoryCount();
+      final entries = await _recentlyPlayedRepository.getRecentHistoryPaginated(
+        offset: 0,
+        limit: _kPageSize,
+      );
       if (mounted) {
         setState(() {
-          _groupedHistory = grouped;
+          _entries = entries;
+          _groupedHistory = _groupEntries(entries);
+          _totalCount = count;
+          _hasMore = entries.length < count;
           _isLoading = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
+          _entries = [];
           _groupedHistory = {};
+          _totalCount = 0;
+          _hasMore = false;
           _isLoading = false;
         });
       }
     }
+  }
+
+  Future<void> _loadMoreHistory() async {
+    if (!mounted || _isLoadingMore || !_hasMore) return;
+
+    setState(() => _isLoadingMore = true);
+
+    try {
+      final nextEntries = await _recentlyPlayedRepository
+          .getRecentHistoryPaginated(
+            offset: _entries.length,
+            limit: _kPageSize,
+          );
+      if (mounted) {
+        setState(() {
+          _entries.addAll(nextEntries);
+          _groupedHistory = _groupEntries(_entries);
+          _hasMore = _entries.length < _totalCount;
+          _isLoadingMore = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isLoadingMore = false);
+      }
+    }
+  }
+
+  void _resetPagination() {
+    _entries = [];
+    _groupedHistory = {};
+    _hasMore = true;
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (position.pixels >= position.maxScrollExtent - _kLoadMoreThreshold) {
+      _loadMoreHistory();
+    }
+  }
+
+  Map<String, List<RecentlyPlayedEntry>> _groupEntries(
+    List<RecentlyPlayedEntry> entries,
+  ) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final thisWeekStart = today.subtract(Duration(days: today.weekday - 1));
+    final lastWeekStart = thisWeekStart.subtract(const Duration(days: 7));
+    final thisMonthStart = DateTime(now.year, now.month, 1);
+
+    final grouped = <String, List<RecentlyPlayedEntry>>{};
+
+    for (final entry in entries) {
+      final playedDate = DateTime(
+        entry.playedAt.year,
+        entry.playedAt.month,
+        entry.playedAt.day,
+      );
+
+      final String groupKey;
+      if (playedDate == today) {
+        groupKey = 'Today';
+      } else if (playedDate == yesterday) {
+        groupKey = 'Yesterday';
+      } else if (playedDate.isAfter(thisWeekStart) ||
+          playedDate == thisWeekStart) {
+        groupKey = 'This Week';
+      } else if (playedDate.isAfter(lastWeekStart) ||
+          playedDate == lastWeekStart) {
+        groupKey = 'Last Week';
+      } else if (playedDate.isAfter(thisMonthStart) ||
+          playedDate == thisMonthStart) {
+        groupKey = 'This Month';
+      } else {
+        groupKey = 'Earlier';
+      }
+
+      grouped.putIfAbsent(groupKey, () => []).add(entry);
+    }
+
+    return grouped;
   }
 
   Future<void> _clearHistory() async {
@@ -171,7 +282,7 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
                   ),
                 ),
                 Text(
-                  'Your listening history',
+                  '$_totalCount ${_totalCount == 1 ? 'song' : 'songs'} played',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: context.adaptiveTextTertiary,
                   ),
@@ -281,7 +392,6 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
   }
 
   Widget _buildHistoryList() {
-    // Define the order we want sections to appear
     const sectionOrder = [
       'Today',
       'Yesterday',
@@ -291,7 +401,6 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
       'Earlier',
     ];
 
-    // Sort sections according to our defined order
     final sortedSections = _groupedHistory.entries.toList()
       ..sort((a, b) {
         final aIndex = sectionOrder.indexOf(a.key);
@@ -299,73 +408,37 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
         return aIndex.compareTo(bIndex);
       });
 
+    // Compute how many list items we need, including section headers and
+    // the optional bottom loading indicator.
+    var itemCount = 0;
+    for (final section in sortedSections) {
+      itemCount += 1 + section.value.length;
+    }
+    if (_isLoadingMore) itemCount += 1;
+
     return ListView.builder(
+      controller: _scrollController,
       padding: EdgeInsets.only(
         left: AppConstants.spacingMd,
         right: AppConstants.spacingMd,
         bottom: AppConstants.navBarHeight + 120,
       ),
-      itemCount: sortedSections.length,
-      itemBuilder: (context, sectionIndex) {
-        final section = sortedSections[sectionIndex];
-        return _buildTimeSection(section.key, section.value);
-      },
-    );
-  }
+      itemCount: itemCount,
+      itemBuilder: (context, index) {
+        var currentIndex = 0;
+        for (final section in sortedSections) {
+          if (index == currentIndex) {
+            return _buildSectionHeader(section.key, section.value.length);
+          }
+          currentIndex++;
 
-  Widget _buildTimeSection(String title, List<RecentlyPlayedEntry> entries) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // Section header
-        Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppConstants.spacingSm,
-            vertical: AppConstants.spacingMd,
-          ),
-          child: Row(
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: context.adaptiveTextSecondary,
-                ),
+          if (index < currentIndex + section.value.length) {
+            final entryIndex = index - currentIndex;
+            final entry = section.value[entryIndex];
+            return _RecentlyPlayedTile(
+              key: ValueKey(
+                'recent_${entry.song.id}_${entry.playedAt.millisecondsSinceEpoch}',
               ),
-              const SizedBox(width: AppConstants.spacingSm),
-              Text(
-                title,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: context.adaptiveTextSecondary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const Spacer(),
-              Text(
-                '${entries.length} ${entries.length == 1 ? 'song' : 'songs'}',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.adaptiveTextTertiary,
-                ),
-              ),
-            ],
-          ),
-        ),
-        // 2-column grid
-        GridView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          padding: EdgeInsets.zero,
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            childAspectRatio: 0.85,
-            crossAxisSpacing: AppConstants.spacingMd,
-            mainAxisSpacing: AppConstants.spacingMd,
-          ),
-          itemCount: entries.length,
-          itemBuilder: (context, index) {
-            final entry = entries[index];
-            return _RecentlyPlayedCard(
               song: entry.song,
               playedAt: entry.playedAt,
               onTap: () async {
@@ -378,34 +451,95 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
                 }
               },
             );
-          },
+          }
+          currentIndex += section.value.length;
+        }
+
+        // Bottom loading indicator
+        if (_isLoadingMore && index == currentIndex) {
+          return _buildLoadMoreIndicator();
+        }
+
+        return const SizedBox.shrink();
+      },
+    );
+  }
+
+  Widget _buildSectionHeader(String title, int count) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppConstants.spacingSm,
+        AppConstants.spacingLg,
+        AppConstants.spacingSm,
+        AppConstants.spacingMd,
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: context.adaptiveTextSecondary,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: context.adaptiveTextSecondary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const Spacer(),
+          Text(
+            '$count ${count == 1 ? 'song' : 'songs'}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadMoreIndicator() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppConstants.spacingLg),
+      child: Center(
+        child: SizedBox(
+          width: 24,
+          height: 24,
+          child: CircularProgressIndicator(
+            strokeWidth: 2.5,
+            color: context.adaptiveTextSecondary,
+          ),
         ),
-        const SizedBox(height: AppConstants.spacingLg),
-      ],
+      ),
     );
   }
 }
 
-class _RecentlyPlayedCard extends StatefulWidget {
+class _RecentlyPlayedTile extends StatefulWidget {
   final Song song;
   final DateTime playedAt;
   final VoidCallback onTap;
 
-  const _RecentlyPlayedCard({
+  const _RecentlyPlayedTile({
+    super.key,
     required this.song,
     required this.playedAt,
     required this.onTap,
   });
 
   @override
-  State<_RecentlyPlayedCard> createState() => _RecentlyPlayedCardState();
+  State<_RecentlyPlayedTile> createState() => _RecentlyPlayedTileState();
 }
 
-class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
+class _RecentlyPlayedTileState extends State<_RecentlyPlayedTile>
     with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _scaleAnimation;
-  late Animation<double> _tiltAnimation;
 
   @override
   void initState() {
@@ -416,11 +550,7 @@ class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
     );
     _scaleAnimation = Tween<double>(
       begin: 1.0,
-      end: 0.95,
-    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
-    _tiltAnimation = Tween<double>(
-      begin: 0.0,
-      end: 0.02,
+      end: 0.98,
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
   }
 
@@ -434,20 +564,32 @@ class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
     final now = DateTime.now();
     final diff = now.difference(time);
 
-    if (diff.inMinutes < 60) {
+    if (diff.inMinutes < 1) {
+      return 'Just now';
+    } else if (diff.inMinutes < 60) {
       return '${diff.inMinutes}m ago';
     } else if (diff.inHours < 24) {
       return '${diff.inHours}h ago';
+    } else if (diff.inDays < 7) {
+      return '${diff.inDays}d ago';
     } else {
-      return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+      return '${time.day.toString().padLeft(2, '0')}/'
+          '${time.month.toString().padLeft(2, '0')}/'
+          '${time.year}';
     }
+  }
+
+  String _formatTimestamp(DateTime time) {
+    final hour = time.hour.toString().padLeft(2, '0');
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
   }
 
   @override
   Widget build(BuildContext context) {
     final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
-    final cardWidth = context.scaleSize(AppConstants.cardWidthMd);
-    final artworkTargetWidth = (cardWidth * devicePixelRatio).round();
+    final artSize = context.scaleSize(56);
+    final artworkTargetSize = (artSize * devicePixelRatio).round();
 
     return GestureDetector(
       onTapDown: (_) => _controller.forward(),
@@ -459,73 +601,95 @@ class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
       child: AnimatedBuilder(
         animation: _controller,
         builder: (context, child) {
-          return Transform(
+          return Transform.scale(
+            scale: _scaleAnimation.value,
             alignment: Alignment.center,
-            transform: Matrix4.diagonal3Values(
-              _scaleAnimation.value,
-              _scaleAnimation.value,
-              1.0,
-            )..rotateZ(_tiltAnimation.value),
             child: child,
           );
         },
         child: RepaintBoundary(
-          child: Material(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-            child: InkWell(
-              onTap: widget.onTap,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
+            child: Material(
+              color: AppColors.surface,
               borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-              child: ClipRRect(
+              child: InkWell(
+                onTap: widget.onTap,
                 borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Album art
-                    Expanded(
-                      child: Container(
-                        width: double.infinity,
-                        decoration: const BoxDecoration(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppConstants.spacingMd),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: artSize,
+                        height: artSize,
+                        decoration: BoxDecoration(
                           color: AppColors.surfaceLight,
-                          borderRadius: BorderRadius.vertical(
-                            top: Radius.circular(AppConstants.radiusLg),
+                          borderRadius: BorderRadius.circular(
+                            AppConstants.radiusMd,
                           ),
                         ),
                         child: ClipRRect(
-                          borderRadius: const BorderRadius.vertical(
-                            top: Radius.circular(AppConstants.radiusLg),
+                          borderRadius: BorderRadius.circular(
+                            AppConstants.radiusMd,
                           ),
                           child: CachedImageWidget(
                             imagePath: widget.song.albumArt,
                             audioSourcePath: widget.song.filePath,
                             fit: BoxFit.cover,
                             useThumbnail: true,
-                            thumbnailWidth: artworkTargetWidth,
-                            thumbnailHeight: artworkTargetWidth,
+                            thumbnailWidth: artworkTargetSize,
+                            thumbnailHeight: artworkTargetSize,
                             placeholder: _buildPlaceholder(context),
                             errorWidget: _buildPlaceholder(context),
                           ),
                         ),
                       ),
-                    ),
-                    // Song info
-                    Padding(
-                      padding: const EdgeInsets.all(AppConstants.spacingSm),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                      const SizedBox(width: AppConstants.spacingMd),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              widget.song.title,
+                              style: Theme.of(context).textTheme.titleSmall
+                                  ?.copyWith(
+                                    color: context.adaptiveTextPrimary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            const SizedBox(height: AppConstants.spacingXxs),
+                            Text(
+                              widget.song.artist,
+                              style: Theme.of(context).textTheme.bodySmall
+                                  ?.copyWith(
+                                    color: context.adaptiveTextTertiary,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            const SizedBox(height: AppConstants.spacingXs),
+                            Row(
+                              children: [
+                                _MetadataChip(text: widget.song.fileType),
+                                if (widget.song.resolution != null &&
+                                    widget.song.resolution != 'Unknown') ...[
+                                  const SizedBox(width: AppConstants.spacingXs),
+                                  _MetadataChip(text: widget.song.resolution!),
+                                ],
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: AppConstants.spacingSm),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
-                          Text(
-                            widget.song.title,
-                            style: Theme.of(context).textTheme.titleSmall
-                                ?.copyWith(
-                                  color: context.adaptiveTextPrimary,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 2),
                           Row(
+                            mainAxisSize: MainAxisSize.min,
                             children: [
                               Icon(
                                 LucideIcons.clock,
@@ -535,23 +699,26 @@ class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
                                 color: context.adaptiveTextTertiary,
                               ),
                               const SizedBox(width: 4),
-                              Expanded(
-                                child: Text(
-                                  _formatTime(widget.playedAt),
-                                  style: Theme.of(context).textTheme.bodySmall
-                                      ?.copyWith(
-                                        color: context.adaptiveTextTertiary,
-                                      ),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
+                              Text(
+                                _formatTime(widget.playedAt),
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: context.adaptiveTextSecondary,
+                                      fontWeight: FontWeight.w500,
+                                    ),
                               ),
                             ],
                           ),
+                          const SizedBox(height: AppConstants.spacingXxs),
+                          Text(
+                            _formatTimestamp(widget.playedAt),
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: context.adaptiveTextTertiary),
+                          ),
                         ],
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -565,8 +732,37 @@ class _RecentlyPlayedCardState extends State<_RecentlyPlayedCard>
     return Center(
       child: Icon(
         LucideIcons.music,
-        size: context.responsiveIcon(AppConstants.containerSizeSm),
+        size: context.responsiveIcon(AppConstants.iconSizeLg),
         color: context.adaptiveTextTertiary.withValues(alpha: 0.5),
+      ),
+    );
+  }
+}
+
+class _MetadataChip extends StatelessWidget {
+  final String text;
+
+  const _MetadataChip({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingXs,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackground,
+        borderRadius: BorderRadius.circular(AppConstants.radiusXs),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          fontSize: AppConstants.fontSizeXs,
+          color: context.adaptiveTextTertiary,
+          fontWeight: FontWeight.w500,
+        ),
       ),
     );
   }

--- a/lib/features/settings/screens/integrations_settings_screen.dart
+++ b/lib/features/settings/screens/integrations_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/features/settings/widgets/lastfm_settings_tile.dart';
+import 'package:flick/features/settings/widgets/listenbrainz_settings_tile.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 
 class IntegrationsSettingsScreen extends StatelessWidget {
@@ -15,7 +16,7 @@ class IntegrationsSettingsScreen extends StatelessWidget {
         children: [
           const SettingsSectionHeader('Integrations'),
           const SettingsCard(
-            children: [LastFmSettingsTile()],
+            children: [LastFmSettingsTile(), ListenBrainzSettingsTile()],
           ),
           const SizedBox(height: AppConstants.spacingLg),
           const SizedBox(height: AppConstants.navBarHeight + 40),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -158,7 +158,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           iconBg: const Color(0xFF6F2D4A),
                           iconFg: const Color(0xFFFF8BB8),
                           title: 'Integrations',
-                          subtitle: 'Last.fm scrobbling',
+                          subtitle: 'Last.fm & ListenBrainz scrobbling',
                           onTap: () => _navigate(
                             context,
                             const IntegrationsSettingsScreen(),

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -1410,6 +1410,10 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
               'Experimental — down-tune playback by 432/440. This disables bit-perfect passthrough and runs the DSP path.',
           value: enabled,
           onChanged: (value) async {
+            if (value && !enabled && !_awaiting432HzConfirm) {
+              final confirmed = await _confirmEnable432HzTuning(context);
+              if (!confirmed || !context.mounted) return;
+            }
             await service.set432HzTuningEnabled(value);
             rust_audio.audioSet432HzTuningEnabled(enabled: value);
             ref.invalidate(uac2432HzTuningEnabledProvider);
@@ -1419,6 +1423,58 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
         error: (_, _) => _buildErrorTile(context),
       ),
     );
+  }
+
+  bool _awaiting432HzConfirm = false;
+
+  Future<bool> _confirmEnable432HzTuning(BuildContext context) {
+    if (_awaiting432HzConfirm) return Future.value(false);
+    _awaiting432HzConfirm = true;
+    const warnColor = Colors.amber;
+    return showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+        ),
+        title: Row(
+          children: [
+            Icon(Icons.warning_amber_rounded, color: warnColor, size: 22),
+            const SizedBox(width: AppConstants.spacingSm),
+            Expanded(
+              child: Text(
+                'Enable 432 Hz Tuning?',
+                style: TextStyle(color: context.adaptiveTextPrimary),
+              ),
+            ),
+          ],
+        ),
+        content: Text(
+          'This slows playback to 432/440 (~1.8% lower pitch and tempo) and '
+          'disables bit-perfect passthrough. Music will sound slightly lower '
+          'in tone. Only enable this if you intentionally want A=432 tuning.',
+          style: TextStyle(color: context.adaptiveTextSecondary, fontSize: 13),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel', style: TextStyle(color: AppColors.accent)),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: warnColor,
+              foregroundColor: Colors.black,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    ).then((result) {
+      _awaiting432HzConfirm = false;
+      return result ?? false;
+    });
   }
 
   Widget _buildExperimentalWarning(BuildContext context) {

--- a/lib/features/settings/widgets/lastfm_settings_tile.dart
+++ b/lib/features/settings/widgets/lastfm_settings_tile.dart
@@ -8,6 +8,7 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/providers/lastfm_provider.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Self-contained Last.fm connect/disconnect tile.
 class LastFmSettingsTile extends ConsumerStatefulWidget {
@@ -35,25 +36,25 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    debugPrint('[LastFm] App lifecycle changed: $state, _awaitingCallback=$_awaitingCallback');
+    devLog('[LastFm] App lifecycle changed: $state, _awaitingCallback=$_awaitingCallback');
     if (state == AppLifecycleState.resumed && _awaitingCallback) {
-      debugPrint('[LastFm] App resumed after auth, completing authentication');
+      devLog('[LastFm] App resumed after auth, completing authentication');
       _awaitingCallback = false;
       _completeAuth();
     }
   }
 
   Future<void> _startAuth() async {
-    debugPrint('[LastFm] _startAuth: Starting authentication flow');
+    devLog('[LastFm] _startAuth: Starting authentication flow');
     final auth = ref.read(lastFmAuthServiceProvider);
 
     // Check if API credentials are configured
-    debugPrint('[LastFm] _startAuth: Checking API credentials');
+    devLog('[LastFm] _startAuth: Checking API credentials');
     final hasCredentials = await auth.hasValidApiCredentials();
-    debugPrint('[LastFm] _startAuth: Has valid credentials: $hasCredentials');
+    devLog('[LastFm] _startAuth: Has valid credentials: $hasCredentials');
     
     if (!hasCredentials) {
-      debugPrint('[LastFm] _startAuth: Missing credentials, showing error');
+      devLog('[LastFm] _startAuth: Missing credentials, showing error');
       _showError(
         'Please configure your Last.fm API key and shared secret first.',
       );
@@ -61,17 +62,17 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
     }
 
     try {
-      debugPrint('[LastFm] _startAuth: Calling getTokenAndLaunchAuth');
+      devLog('[LastFm] _startAuth: Calling getTokenAndLaunchAuth');
       await auth.getTokenAndLaunchAuth();
-      debugPrint('[LastFm] _startAuth: Successfully launched auth, mounted=$mounted');
+      devLog('[LastFm] _startAuth: Successfully launched auth, mounted=$mounted');
       
       if (mounted) {
         setState(() => _awaitingCallback = true);
-        debugPrint('[LastFm] _startAuth: Set _awaitingCallback=true');
+        devLog('[LastFm] _startAuth: Set _awaitingCallback=true');
       }
     } catch (e, stackTrace) {
-      debugPrint('[LastFm] _startAuth: ERROR - $e');
-      debugPrint('[LastFm] _startAuth: Stack trace: $stackTrace');
+      devLog('[LastFm] _startAuth: ERROR - $e');
+      devLog('[LastFm] _startAuth: Stack trace: $stackTrace');
       
       if (mounted) {
         // Provide more specific error message for network issues
@@ -82,22 +83,22 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
         
         _showError(errorMessage);
       } else {
-        debugPrint('[LastFm] _startAuth: Widget not mounted, skipping error display');
+        devLog('[LastFm] _startAuth: Widget not mounted, skipping error display');
       }
     }
   }
 
   Future<void> _completeAuth() async {
-    debugPrint('[LastFm] _completeAuth: Starting token exchange');
+    devLog('[LastFm] _completeAuth: Starting token exchange');
     final auth = ref.read(lastFmAuthServiceProvider);
     try {
       await auth.exchangeTokenForSession();
-      debugPrint('[LastFm] _completeAuth: Token exchange successful');
+      devLog('[LastFm] _completeAuth: Token exchange successful');
       ref.invalidate(lastFmSessionProvider);
       _showSuccess('Last.fm connected!');
     } catch (e, stackTrace) {
-      debugPrint('[LastFm] _completeAuth: ERROR - $e');
-      debugPrint('[LastFm] _completeAuth: Stack trace: $stackTrace');
+      devLog('[LastFm] _completeAuth: ERROR - $e');
+      devLog('[LastFm] _completeAuth: Stack trace: $stackTrace');
       _showError(
         'Authorization failed. Make sure you approved access on Last.fm.',
       );
@@ -594,45 +595,45 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
                             flex: 2,
                             child: ElevatedButton(
                               onPressed: () async {
-                                debugPrint('[LastFm] Save & Connect button pressed');
+                                devLog('[LastFm] Save & Connect button pressed');
                                 
                                 if (apiKeyController.text.isEmpty ||
                                     sharedSecretController.text.isEmpty) {
-                                  debugPrint('[LastFm] Empty credentials provided');
+                                  devLog('[LastFm] Empty credentials provided');
                                   _showError(
                                     'Please enter both API key and shared secret',
                                   );
                                   return;
                                 }
                                 
-                                debugPrint('[LastFm] Saving credentials...');
+                                devLog('[LastFm] Saving credentials...');
                                 await auth.setApiCredentials(
                                   apiKeyController.text,
                                   sharedSecretController.text,
                                 );
-                                debugPrint('[LastFm] Credentials saved, mounted=$mounted');
+                                devLog('[LastFm] Credentials saved, mounted=$mounted');
                                 
                                 if (mounted) {
                                   Navigator.pop(ctx);
-                                  debugPrint('[LastFm] Dialog closed');
+                                  devLog('[LastFm] Dialog closed');
                                   
                                   _showSuccess(
                                     'Credentials saved successfully!',
                                   );
                                   
                                   if (autoConnectAfterSave && mounted) {
-                                    debugPrint('[LastFm] Auto-connect enabled, waiting 300ms...');
+                                    devLog('[LastFm] Auto-connect enabled, waiting 300ms...');
                                     // Small delay to ensure dialog is fully closed
                                     await Future.delayed(
                                       const Duration(milliseconds: 300),
                                     );
-                                    debugPrint('[LastFm] Delay complete, mounted=$mounted');
+                                    devLog('[LastFm] Delay complete, mounted=$mounted');
                                     
                                     if (mounted) {
-                                      debugPrint('[LastFm] Calling _startAuth()');
+                                      devLog('[LastFm] Calling _startAuth()');
                                       await _startAuth();
                                     } else {
-                                      debugPrint('[LastFm] Widget unmounted, skipping auth');
+                                      devLog('[LastFm] Widget unmounted, skipping auth');
                                     }
                                   }
                                 }

--- a/lib/features/settings/widgets/listenbrainz_settings_tile.dart
+++ b/lib/features/settings/widgets/listenbrainz_settings_tile.dart
@@ -1,0 +1,793 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/providers/listenbrainz_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Self-contained ListenBrainz connect/disconnect tile.
+class ListenBrainzSettingsTile extends ConsumerStatefulWidget {
+  const ListenBrainzSettingsTile({super.key});
+
+  @override
+  ConsumerState<ListenBrainzSettingsTile> createState() =>
+      _ListenBrainzSettingsTileState();
+}
+
+class _ListenBrainzSettingsTileState
+    extends ConsumerState<ListenBrainzSettingsTile> {
+  Future<void> _showTokenDialog() async {
+    final auth = ref.read(listenbrainzAuthServiceProvider);
+    final existing = await auth.getSession();
+
+    final tokenController = TextEditingController(
+      text: existing?.token ?? '',
+    );
+
+    if (!mounted) return;
+
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => _TokenInputSheet(
+        tokenController: tokenController,
+        onConnect: (token) async {
+          await auth.connect(token);
+          ref.invalidate(listenbrainzSessionProvider);
+        },
+      ),
+    );
+
+    tokenController.dispose();
+  }
+
+  Future<void> _disconnect() async {
+    final confirmed = await showModalBottomSheet<bool>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => Container(
+        decoration: BoxDecoration(
+          color: Theme.of(ctx).scaffoldBackgroundColor,
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(AppConstants.radiusLg),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: const EdgeInsets.only(top: 12),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.adaptiveTextTertiary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
+              child: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: Colors.red.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(
+                      Icons.warning_rounded,
+                      color: Colors.red,
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Disconnect ListenBrainz?',
+                          style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
+                            color: context.adaptiveTextPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: AppColors.glassBackgroundStrong,
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusMd,
+                      ),
+                      border: Border.all(
+                        color: context.adaptiveTextTertiary.withValues(
+                          alpha: 0.1,
+                        ),
+                      ),
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.info_outline,
+                          color: context.adaptiveTextSecondary,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            'Your listens will remain on ListenBrainz, but Flick will stop submitting them.',
+                            style: Theme.of(ctx).textTheme.bodyMedium?.copyWith(
+                              color: context.adaptiveTextSecondary,
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            side: BorderSide(
+                              color: context.adaptiveTextTertiary.withValues(
+                                alpha: 0.3,
+                              ),
+                            ),
+                            foregroundColor: context.adaptiveTextPrimary,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(
+                                AppConstants.radiusMd,
+                              ),
+                            ),
+                          ),
+                          child: const Text(
+                            'Cancel',
+                            style: TextStyle(fontWeight: FontWeight.w600),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.red,
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                            elevation: 0,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(
+                                AppConstants.radiusMd,
+                              ),
+                            ),
+                          ),
+                          child: const Text(
+                            'Disconnect',
+                            style: TextStyle(fontWeight: FontWeight.w600),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    final auth = ref.read(listenbrainzAuthServiceProvider);
+    await auth.disconnect();
+    ref.invalidate(listenbrainzSessionProvider);
+  }
+
+  Future<void> _showConnectedBottomSheet(String username) async {
+    await showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => Container(
+        decoration: BoxDecoration(
+          color: Theme.of(ctx).scaffoldBackgroundColor,
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(AppConstants.radiusLg),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              margin: const EdgeInsets.only(top: 12),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.adaptiveTextTertiary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 20, 24, 8),
+              child: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF4CAF50).withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Icon(
+                      Icons.check_circle,
+                      color: Color(0xFF4CAF50),
+                      size: 24,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'ListenBrainz Connected',
+                          style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
+                            color: context.adaptiveTextPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          'Your music is being submitted',
+                          style: Theme.of(ctx).textTheme.bodySmall?.copyWith(
+                            color: context.adaptiveTextSecondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: AppColors.glassBackgroundStrong,
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusMd,
+                      ),
+                      border: Border.all(
+                        color: context.adaptiveTextTertiary.withValues(
+                          alpha: 0.1,
+                        ),
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF353070).withValues(
+                              alpha: 0.15,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(
+                            Icons.person,
+                            color: Color(0xFF353070),
+                            size: 20,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Connected Account',
+                                style: Theme.of(ctx).textTheme.bodySmall
+                                    ?.copyWith(
+                                      color: context.adaptiveTextSecondary,
+                                    ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                username,
+                                style: Theme.of(ctx).textTheme.bodyLarge
+                                    ?.copyWith(
+                                      color: context.adaptiveTextPrimary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Navigator.pop(ctx);
+                        _showTokenDialog();
+                      },
+                      icon: const Icon(Icons.edit, size: 18),
+                      label: const Text('Edit Token'),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        side: BorderSide(
+                          color: context.adaptiveTextTertiary.withValues(
+                            alpha: 0.3,
+                          ),
+                        ),
+                        foregroundColor: context.adaptiveTextPrimary,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(
+                            AppConstants.radiusMd,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: () {
+                        Navigator.pop(ctx);
+                        _disconnect();
+                      },
+                      icon: const Icon(Icons.logout, size: 18),
+                      label: const Text('Disconnect'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red.withValues(alpha: 0.1),
+                        foregroundColor: Colors.red,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        elevation: 0,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(
+                            AppConstants.radiusMd,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionAsync = ref.watch(listenbrainzSessionProvider);
+
+    return sessionAsync.when(
+      loading: () => _buildLoadingTile(context),
+      error: (error, stackTrace) => _buildErrorTile(context),
+      data: (session) {
+        if (session != null) {
+          return _buildConnectedTile(context, username: session.username);
+        }
+        return _buildDisconnectedTile(context);
+      },
+    );
+  }
+
+  Widget _buildLoadingTile(BuildContext context) {
+    return _buildTileContainer(
+      context,
+      child: Row(
+        children: [
+          _buildLeadingIcon(context, Icons.radio_button_unchecked),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'ListenBrainz',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Loading session...',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorTile(BuildContext context) {
+    return _buildTapTile(
+      context,
+      icon: Icons.error_outline,
+      title: 'ListenBrainz',
+      subtitle: 'Could not load session',
+      onTap: _showTokenDialog,
+      trailing: Icon(
+        Icons.chevron_right,
+        color: context.adaptiveTextTertiary,
+        size: 20,
+      ),
+    );
+  }
+
+  Widget _buildConnectedTile(BuildContext context, {required String username}) {
+    return _buildTapTile(
+      context,
+      icon: Icons.radio_button_checked,
+      title: 'ListenBrainz',
+      subtitle: 'Connected as $username',
+      onTap: () => _showConnectedBottomSheet(username),
+      trailing: Icon(
+        Icons.check_circle,
+        color: const Color(0xFF4CAF50),
+        size: 20,
+      ),
+    );
+  }
+
+  Widget _buildDisconnectedTile(BuildContext context) {
+    return _buildTapTile(
+      context,
+      icon: Icons.radio_button_unchecked,
+      title: 'ListenBrainz',
+      subtitle: 'Connect to submit your listening history',
+      onTap: _showTokenDialog,
+      trailing: Icon(
+        Icons.chevron_right,
+        color: context.adaptiveTextTertiary,
+        size: 20,
+      ),
+    );
+  }
+
+  Widget _buildTapTile(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback? onTap,
+    required Widget trailing,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: _buildTileContainer(
+          context,
+          child: Row(
+            children: [
+              _buildLeadingIcon(context, icon),
+              const SizedBox(width: AppConstants.spacingMd),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.adaptiveTextTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              trailing,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTileContainer(BuildContext context, {required Widget child}) {
+    return Padding(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      child: child,
+    );
+  }
+
+  Widget _buildLeadingIcon(BuildContext context, IconData icon) {
+    return Container(
+      width: context.scaleSize(AppConstants.containerSizeSm),
+      height: context.scaleSize(AppConstants.containerSizeSm),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackgroundStrong,
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+      ),
+      child: Icon(
+        icon,
+        color: context.adaptiveTextSecondary,
+        size: context.responsiveIcon(AppConstants.iconSizeMd),
+      ),
+    );
+  }
+}
+
+/// Internal bottom sheet for entering and validating a ListenBrainz token.
+class _TokenInputSheet extends StatefulWidget {
+  const _TokenInputSheet({
+    required this.tokenController,
+    required this.onConnect,
+  });
+
+  final TextEditingController tokenController;
+  final Future<void> Function(String token) onConnect;
+
+  @override
+  State<_TokenInputSheet> createState() => _TokenInputSheetState();
+}
+
+class _TokenInputSheetState extends State<_TokenInputSheet> {
+  bool _isConnecting = false;
+  bool _obscureToken = true;
+  String? _errorMessage;
+
+  Future<void> _connect() async {
+    final token = widget.tokenController.text.trim();
+
+    if (token.isEmpty) {
+      setState(() => _errorMessage = 'Please enter your ListenBrainz user token.');
+      return;
+    }
+
+    setState(() {
+      _isConnecting = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await widget.onConnect(token);
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('ListenBrainz connected!'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        final message = e.toString().contains('SocketException') ||
+                e.toString().contains('Failed host lookup')
+            ? 'No internet connection. Please check your network and try again.'
+            : 'Could not connect to ListenBrainz. Check your token and try again.';
+        setState(() {
+          _isConnecting = false;
+          _errorMessage = message;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).scaffoldBackgroundColor,
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(AppConstants.radiusLg),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Handle bar
+            Center(
+              child: Container(
+                margin: const EdgeInsets.only(top: 12),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: context.adaptiveTextTertiary.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
+              child: Text(
+                'Connect ListenBrainz',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: Text(
+                      'Copy your user token from ListenBrainz settings and paste it below.',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: context.adaptiveTextSecondary,
+                        height: 1.4,
+                      ),
+                    ),
+                  ),
+
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    child: InkWell(
+                      onTap: () async {
+                        final uri = Uri.parse('https://listenbrainz.org/settings/');
+                        try {
+                          final launched = await launchUrl(
+                            uri,
+                            mode: LaunchMode.externalApplication,
+                          );
+                          if (!launched && context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Could not open browser.'),
+                                behavior: SnackBarBehavior.floating,
+                              ),
+                            );
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('Could not open link: $e'),
+                                behavior: SnackBarBehavior.floating,
+                              ),
+                            );
+                          }
+                        }
+                      },
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusSm,
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 4,
+                          horizontal: 4,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.open_in_new,
+                              size: 16,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              'Open listenbrainz.org/settings',
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: Theme.of(context).colorScheme.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: TextField(
+                controller: widget.tokenController,
+                obscureText: _obscureToken,
+                autocorrect: false,
+                enableSuggestions: false,
+                decoration: InputDecoration(
+                  labelText: 'User Token',
+                  hintText: 'Paste your ListenBrainz token',
+                  errorText: _errorMessage,
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                      _obscureToken ? Icons.visibility_off : Icons.visibility,
+                      color: context.adaptiveTextTertiary,
+                    ),
+                    onPressed: () {
+                      setState(() => _obscureToken = !_obscureToken);
+                    },
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                  ),
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 24),
+
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isConnecting ? null : _connect,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusMd,
+                      ),
+                    ),
+                  ),
+                  child: _isConnecting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Text(
+                          'Connect',
+                          style: TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -27,6 +27,7 @@ import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Main songs screen with orbital scrolling.
 class SongsScreen extends ConsumerStatefulWidget {
@@ -1147,7 +1148,7 @@ void _openFolderDetail(FolderGroup folder) {
       try {
         await ref.read(favoritesServiceProvider).addFavorite(song.id);
       } catch (error, stackTrace) {
-        debugPrint('Failed to add favorite for ${song.id}: $error');
+        devLog('Failed to add favorite for ${song.id}: $error');
         debugPrintStack(stackTrace: stackTrace);
         if (!mounted) return;
         _showSongActionSnackBar('Failed to add "${song.title}" to favorites');

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -764,6 +764,8 @@ class SongActionsBottomSheet extends ConsumerWidget {
       ),
     );
 
+    await repository.deleteSong(songId);
+
     if (deleteFile && song.filePath != null) {
       var deleted = false;
       try {
@@ -783,18 +785,10 @@ class SongActionsBottomSheet extends ConsumerWidget {
         } catch (_) {}
       }
 
-      if (!deleted && rootContext.mounted) {
-        ScaffoldMessenger.of(rootContext).showSnackBar(
-          const SnackBar(
-            content: Text(
-              'Could not delete the file. Removing from library instead.',
-            ),
-          ),
-        );
+      if (deleted) {
+        await MusicFolderService.removeFromMediaStore(song.filePath!);
       }
     }
-
-    await repository.deleteSong(songId);
 
     if (rootContext.mounted) {
       Navigator.of(rootContext).pop();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flick/data/database.dart';
 import 'package:flick/services/external_playback_service.dart';
 import 'package:flick/services/permission_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -38,12 +39,12 @@ Future<void> _bootstrapAppAfterFirstFrame() async {
   unawaited(_setOptimalDisplayMode());
   unawaited(
     _requestNotificationPermission().catchError(
-      (Object e) => debugPrint('Notification permission request failed: $e'),
+      (Object e) => devLog('Notification permission request failed: $e'),
     ),
   );
   unawaited(
     PlayerService().prepareForAppLaunch().catchError(
-      (Object e) => debugPrint('Audio prewarm failed: $e'),
+      (Object e) => devLog('Audio prewarm failed: $e'),
     ),
   );
 }
@@ -52,7 +53,7 @@ Future<void> _setOptimalDisplayMode() async {
   try {
     await FlutterDisplayMode.setHighRefreshRate();
   } catch (e) {
-    debugPrint('Display mode not supported: $e');
+    devLog('Display mode not supported: $e');
   }
 }
 
@@ -70,6 +71,6 @@ Future<void> _restoreLastPlayedSong() async {
     await playerService.restorePlaybackModes();
     await playerService.restoreLastPlayed();
   } catch (e) {
-    debugPrint('Failed to restore last played song: $e');
+    devLog('Failed to restore last played song: $e');
   }
 }

--- a/lib/providers/lastfm_provider.dart
+++ b/lib/providers/lastfm_provider.dart
@@ -7,6 +7,7 @@ import 'package:flick/services/lastfm/lastfm_credentials.dart';
 import 'package:flick/services/lastfm/lastfm_models.dart';
 import 'package:flick/services/lastfm/lastfm_scrobble_queue.dart';
 import 'package:flick/services/lastfm/lastfm_scrobble_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 part 'lastfm_provider.g.dart';
 
@@ -180,7 +181,7 @@ class LastFmScrobbleNotifier extends _$LastFmScrobbleNotifier {
         ? trackDurationSeconds
         : entry.durationSeconds;
     if (durationSeconds == null || durationSeconds <= 0) {
-      debugPrint('[LastFm] scrobble skipped: missing or zero duration');
+      devLog('[LastFm] scrobble skipped: missing or zero duration');
       return;
     }
 
@@ -198,7 +199,7 @@ class LastFmScrobbleNotifier extends _$LastFmScrobbleNotifier {
       await queue.flush();
     } catch (e) {
       // Offline or transient failure. Keep queued for later retry.
-      debugPrint('[LastFm] flush failed: $e');
+      devLog('[LastFm] flush failed: $e');
     }
   }
 

--- a/lib/providers/lastfm_provider.g.dart
+++ b/lib/providers/lastfm_provider.g.dart
@@ -322,7 +322,7 @@ final class LastFmScrobbleNotifierProvider
 }
 
 String _$lastFmScrobbleNotifierHash() =>
-    r'3ec46a417464b44215dfa967ce307ec5f59e9307';
+    r'57b4ffb4a492cb9ec4bef9c67d4cb97c2f58dffc';
 
 /// Handles Last.fm scrobbling lifecycle hooks from playback events.
 

--- a/lib/providers/listenbrainz_provider.dart
+++ b/lib/providers/listenbrainz_provider.dart
@@ -1,0 +1,229 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_api_client.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_auth_service.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_credentials.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_models.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_scrobble_queue.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_scrobble_service.dart';
+
+part 'listenbrainz_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+ListenBrainzCredentials listenbrainzCredentials(Ref ref) {
+  return ListenBrainzCredentials();
+}
+
+@Riverpod(keepAlive: true)
+ListenBrainzApiClient listenbrainzApiClient(Ref ref) {
+  final credentials = ref.watch(listenbrainzCredentialsProvider);
+  return ListenBrainzApiClient(credentials: credentials);
+}
+
+@Riverpod(keepAlive: true)
+ListenBrainzAuthService listenbrainzAuthService(Ref ref) {
+  final credentials = ref.watch(listenbrainzCredentialsProvider);
+  final client = ref.watch(listenbrainzApiClientProvider);
+  return ListenBrainzAuthService(client: client, credentials: credentials);
+}
+
+@Riverpod(keepAlive: true)
+ListenBrainzScrobbleService listenbrainzScrobbleService(Ref ref) {
+  final auth = ref.watch(listenbrainzAuthServiceProvider);
+  return ListenBrainzScrobbleService(auth: auth);
+}
+
+@Riverpod(keepAlive: true)
+ListenBrainzScrobbleQueue listenbrainzScrobbleQueue(Ref ref) {
+  final service = ref.watch(listenbrainzScrobbleServiceProvider);
+  return ListenBrainzScrobbleQueue(service: service);
+}
+
+/// Watches the current ListenBrainz session (null = not connected).
+@riverpod
+Future<ListenBrainzSession?> listenbrainzSession(Ref ref) async {
+  final auth = ref.watch(listenbrainzAuthServiceProvider);
+  return auth.getSession();
+}
+
+/// Handles ListenBrainz scrobbling lifecycle hooks from playback events.
+@Riverpod(keepAlive: true)
+class ListenBrainzScrobbleNotifier extends _$ListenBrainzScrobbleNotifier {
+  DateTime? _playbackStart;
+  ListenBrainzListenEntry? _currentEntry;
+  bool _hasScrobbledCurrent = false;
+
+  /// Monotonic counter to cancel stale playing-now calls during rapid
+  /// track changes (e.g. gapless transitions).
+  int _trackGeneration = 0;
+
+  @override
+  void build() {}
+
+  Future<void> onTrackStarted({
+    required String artist,
+    required String track,
+    String? album,
+    String? albumArtist,
+    int? durationSeconds,
+  }) async {
+    final gen = ++_trackGeneration;
+    _playbackStart = DateTime.now();
+    _hasScrobbledCurrent = false;
+
+    // Validate metadata is not corrupted (mojibake/encoding issues)
+    if (!_isValidMetadata(artist) || !_isValidMetadata(track)) {
+      _currentEntry = null;
+      return;
+    }
+
+    _currentEntry = ListenBrainzListenEntry(
+      artistName: artist,
+      trackName: track,
+      releaseName: album,
+      listenedAt: _playbackStart!.millisecondsSinceEpoch ~/ 1000,
+      durationSeconds: durationSeconds,
+    );
+
+    // Skip playing-now if a newer onTrackStarted already fired
+    if (gen != _trackGeneration) return;
+
+    final scrobbler = ref.read(listenbrainzScrobbleServiceProvider);
+    await scrobbler.updateNowPlaying(_currentEntry!);
+  }
+
+  /// Called while playback is in progress. Not used for scrobbling—we only
+  /// scrobble on explicit track end/skip events to avoid API spam from
+  /// repeated progress updates.
+  Future<void> onPlaybackProgress({
+    String? artist,
+    String? track,
+    String? album,
+    String? albumArtist,
+    required int listenedSeconds,
+    int? trackDurationSeconds,
+  }) async {
+    // Scrobbling is triggered only on track-end/skip, not progress updates.
+    // This prevents submitting the same track multiple times per second.
+  }
+
+  Future<void> onTrackEnded({
+    String? artist,
+    String? track,
+    String? album,
+    String? albumArtist,
+    required int listenedSeconds,
+    int? trackDurationSeconds,
+  }) async {
+    // Skip scrobbling if metadata is corrupted
+    if ((artist != null && !_isValidMetadata(artist)) ||
+        (track != null && !_isValidMetadata(track))) {
+      _currentEntry = null;
+      _playbackStart = null;
+      return;
+    }
+    await _tryScrobble(
+      fallbackArtist: artist,
+      fallbackTrack: track,
+      fallbackAlbum: album,
+      fallbackAlbumArtist: albumArtist,
+      listenedSeconds: listenedSeconds,
+      trackDurationSeconds: trackDurationSeconds,
+    );
+
+    _currentEntry = null;
+    _playbackStart = null;
+  }
+
+  Future<void> _tryScrobble({
+    String? fallbackArtist,
+    String? fallbackTrack,
+    String? fallbackAlbum,
+    String? fallbackAlbumArtist,
+    required int listenedSeconds,
+    int? trackDurationSeconds,
+  }) async {
+    if (_hasScrobbledCurrent) {
+      return;
+    }
+
+    final start = _playbackStart;
+    var entry = _currentEntry;
+
+    // Prefer fresh fallback metadata (from track-end) over potentially stale
+    // _currentEntry. This handles the case where player metadata is corrected
+    // between track-start and track-end.
+    if (fallbackArtist != null && fallbackTrack != null) {
+      final timestamp = DateTime.now()
+              .subtract(Duration(seconds: listenedSeconds))
+              .millisecondsSinceEpoch ~/
+          1000;
+      entry = ListenBrainzListenEntry(
+        artistName: fallbackArtist,
+        trackName: fallbackTrack,
+        releaseName: fallbackAlbum,
+        listenedAt: timestamp,
+        durationSeconds: trackDurationSeconds,
+      );
+    } else if (entry == null || start == null) {
+      return;
+    }
+
+    final scrobbler = ref.read(listenbrainzScrobbleServiceProvider);
+    final queue = ref.read(listenbrainzScrobbleQueueProvider);
+
+    final durationSeconds =
+        (trackDurationSeconds != null && trackDurationSeconds > 0)
+            ? trackDurationSeconds
+            : entry.durationSeconds;
+    if (durationSeconds == null || durationSeconds <= 0) {
+      devLog('[ListenBrainz] scrobble skipped: missing or zero duration');
+      return;
+    }
+
+    final eligible = scrobbler.isEligibleToScrobble(
+      trackDurationSeconds: durationSeconds,
+      listenedSeconds: listenedSeconds,
+    );
+
+    if (!eligible) {
+      return;
+    }
+    await queue.enqueue(entry);
+    _hasScrobbledCurrent = true;
+    try {
+      await queue.flush();
+    } catch (e) {
+      // Offline or transient failure. Keep queued for later retry.
+      devLog('[ListenBrainz] flush failed: $e');
+    }
+  }
+
+  /// Check if metadata looks valid or corrupted (mojibake pattern detection).
+  /// Returns false for garbled text with suspicious UTF-8 sequences.
+  bool _isValidMetadata(String text) {
+    if (text.isEmpty) return false;
+
+    // Check for mojibake patterns: high density of replacement characters
+    // that indicate encoding corruption. Only flag U+FFFD and letterlike
+    // symbols — avoid false-positives on legitimate non-Latin scripts
+    // (Japanese, Korean, Greek, etc.).
+    int suspiciousCharCount = 0;
+    for (final char in text.runes) {
+      if (char == 0xFFFD || // Replacement char (invalid UTF-8)
+          (char >= 0x2100 && char <= 0x214F)) {
+        // Letterlike symbols (suspicious)
+        suspiciousCharCount++;
+      }
+    }
+
+    // If more than 40% of characters are suspicious, likely mojibake
+    final suspicionRatio = suspiciousCharCount / text.length;
+    if (suspicionRatio > 0.4) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/lib/providers/listenbrainz_provider.g.dart
+++ b/lib/providers/listenbrainz_provider.g.dart
@@ -1,0 +1,357 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'listenbrainz_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(listenbrainzCredentials)
+final listenbrainzCredentialsProvider = ListenbrainzCredentialsProvider._();
+
+final class ListenbrainzCredentialsProvider
+    extends
+        $FunctionalProvider<
+          ListenBrainzCredentials,
+          ListenBrainzCredentials,
+          ListenBrainzCredentials
+        >
+    with $Provider<ListenBrainzCredentials> {
+  ListenbrainzCredentialsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzCredentialsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzCredentialsHash();
+
+  @$internal
+  @override
+  $ProviderElement<ListenBrainzCredentials> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ListenBrainzCredentials create(Ref ref) {
+    return listenbrainzCredentials(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ListenBrainzCredentials value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ListenBrainzCredentials>(value),
+    );
+  }
+}
+
+String _$listenbrainzCredentialsHash() =>
+    r'c2295e4bf2cd98273f92d3c55526c027185ea81e';
+
+@ProviderFor(listenbrainzApiClient)
+final listenbrainzApiClientProvider = ListenbrainzApiClientProvider._();
+
+final class ListenbrainzApiClientProvider
+    extends
+        $FunctionalProvider<
+          ListenBrainzApiClient,
+          ListenBrainzApiClient,
+          ListenBrainzApiClient
+        >
+    with $Provider<ListenBrainzApiClient> {
+  ListenbrainzApiClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzApiClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzApiClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<ListenBrainzApiClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ListenBrainzApiClient create(Ref ref) {
+    return listenbrainzApiClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ListenBrainzApiClient value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ListenBrainzApiClient>(value),
+    );
+  }
+}
+
+String _$listenbrainzApiClientHash() =>
+    r'9658d314c569f03db941cbbccf8b3d6a221fe477';
+
+@ProviderFor(listenbrainzAuthService)
+final listenbrainzAuthServiceProvider = ListenbrainzAuthServiceProvider._();
+
+final class ListenbrainzAuthServiceProvider
+    extends
+        $FunctionalProvider<
+          ListenBrainzAuthService,
+          ListenBrainzAuthService,
+          ListenBrainzAuthService
+        >
+    with $Provider<ListenBrainzAuthService> {
+  ListenbrainzAuthServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzAuthServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzAuthServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<ListenBrainzAuthService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ListenBrainzAuthService create(Ref ref) {
+    return listenbrainzAuthService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ListenBrainzAuthService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ListenBrainzAuthService>(value),
+    );
+  }
+}
+
+String _$listenbrainzAuthServiceHash() =>
+    r'5fc5674a3beb2df270fbfc7a73aabc8668436f5d';
+
+@ProviderFor(listenbrainzScrobbleService)
+final listenbrainzScrobbleServiceProvider =
+    ListenbrainzScrobbleServiceProvider._();
+
+final class ListenbrainzScrobbleServiceProvider
+    extends
+        $FunctionalProvider<
+          ListenBrainzScrobbleService,
+          ListenBrainzScrobbleService,
+          ListenBrainzScrobbleService
+        >
+    with $Provider<ListenBrainzScrobbleService> {
+  ListenbrainzScrobbleServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzScrobbleServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzScrobbleServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<ListenBrainzScrobbleService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ListenBrainzScrobbleService create(Ref ref) {
+    return listenbrainzScrobbleService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ListenBrainzScrobbleService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ListenBrainzScrobbleService>(value),
+    );
+  }
+}
+
+String _$listenbrainzScrobbleServiceHash() =>
+    r'aa182aa383e6cbe73aca87164b1255ea97c6c2cc';
+
+@ProviderFor(listenbrainzScrobbleQueue)
+final listenbrainzScrobbleQueueProvider = ListenbrainzScrobbleQueueProvider._();
+
+final class ListenbrainzScrobbleQueueProvider
+    extends
+        $FunctionalProvider<
+          ListenBrainzScrobbleQueue,
+          ListenBrainzScrobbleQueue,
+          ListenBrainzScrobbleQueue
+        >
+    with $Provider<ListenBrainzScrobbleQueue> {
+  ListenbrainzScrobbleQueueProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzScrobbleQueueProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzScrobbleQueueHash();
+
+  @$internal
+  @override
+  $ProviderElement<ListenBrainzScrobbleQueue> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ListenBrainzScrobbleQueue create(Ref ref) {
+    return listenbrainzScrobbleQueue(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ListenBrainzScrobbleQueue value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ListenBrainzScrobbleQueue>(value),
+    );
+  }
+}
+
+String _$listenbrainzScrobbleQueueHash() =>
+    r'a3310163112bd8c91fe51027b48502892f6c46b6';
+
+/// Watches the current ListenBrainz session (null = not connected).
+
+@ProviderFor(listenbrainzSession)
+final listenbrainzSessionProvider = ListenbrainzSessionProvider._();
+
+/// Watches the current ListenBrainz session (null = not connected).
+
+final class ListenbrainzSessionProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<ListenBrainzSession?>,
+          ListenBrainzSession?,
+          FutureOr<ListenBrainzSession?>
+        >
+    with
+        $FutureModifier<ListenBrainzSession?>,
+        $FutureProvider<ListenBrainzSession?> {
+  /// Watches the current ListenBrainz session (null = not connected).
+  ListenbrainzSessionProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenbrainzSessionProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenbrainzSessionHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<ListenBrainzSession?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<ListenBrainzSession?> create(Ref ref) {
+    return listenbrainzSession(ref);
+  }
+}
+
+String _$listenbrainzSessionHash() =>
+    r'ec2f3d4fcfe132f4231956f680c4a62daebaea30';
+
+/// Handles ListenBrainz scrobbling lifecycle hooks from playback events.
+
+@ProviderFor(ListenBrainzScrobbleNotifier)
+final listenBrainzScrobbleProvider = ListenBrainzScrobbleNotifierProvider._();
+
+/// Handles ListenBrainz scrobbling lifecycle hooks from playback events.
+final class ListenBrainzScrobbleNotifierProvider
+    extends $NotifierProvider<ListenBrainzScrobbleNotifier, void> {
+  /// Handles ListenBrainz scrobbling lifecycle hooks from playback events.
+  ListenBrainzScrobbleNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'listenBrainzScrobbleProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$listenBrainzScrobbleNotifierHash();
+
+  @$internal
+  @override
+  ListenBrainzScrobbleNotifier create() => ListenBrainzScrobbleNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$listenBrainzScrobbleNotifierHash() =>
+    r'bb4be72d2372babaa7cd47294ea215bb4a3a1fde';
+
+/// Handles ListenBrainz scrobbling lifecycle hooks from playback events.
+
+abstract class _$ListenBrainzScrobbleNotifier extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -8,6 +8,7 @@ import '../models/playback_context.dart';
 import '../models/shuffle_mode.dart';
 import '../models/song.dart';
 import '../services/player_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 // Re-export LoopMode from player_service
 export '../services/player_service.dart' show LoopMode;
@@ -284,7 +285,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
             albumArtist: null,
             durationSeconds: song.duration.inSeconds,
           )
-          .catchError((e) => debugPrint('[LastFm] onTrackStarted error: $e')),
+          .catchError((e) => devLog('[LastFm] onTrackStarted error: $e')),
     );
   }
 
@@ -307,7 +308,7 @@ class PlayerNotifier extends Notifier<PlayerState> {
             listenedSeconds: listenedSeconds,
             trackDurationSeconds: trackDurationSeconds,
           )
-          .catchError((e) => debugPrint('[LastFm] onTrackEnded error: $e')),
+          .catchError((e) => devLog('[LastFm] onTrackEnded error: $e')),
     );
   }
 

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'lastfm_provider.dart';
+import 'listenbrainz_provider.dart';
 import '../models/playback_context.dart';
 import '../models/shuffle_mode.dart';
 import '../models/song.dart';
@@ -287,6 +288,18 @@ class PlayerNotifier extends Notifier<PlayerState> {
           )
           .catchError((e) => devLog('[LastFm] onTrackStarted error: $e')),
     );
+    unawaited(
+      ref
+          .read(listenBrainzScrobbleProvider.notifier)
+          .onTrackStarted(
+            artist: song.artist,
+            track: song.title,
+            album: song.album,
+            albumArtist: null,
+            durationSeconds: song.duration.inSeconds,
+          )
+          .catchError((e) => devLog('[ListenBrainz] onTrackStarted error: $e')),
+    );
   }
 
   void _handleTrackEnded({
@@ -309,6 +322,19 @@ class PlayerNotifier extends Notifier<PlayerState> {
             trackDurationSeconds: trackDurationSeconds,
           )
           .catchError((e) => devLog('[LastFm] onTrackEnded error: $e')),
+    );
+    unawaited(
+      ref
+          .read(listenBrainzScrobbleProvider.notifier)
+          .onTrackEnded(
+            artist: endedSong.artist,
+            track: endedSong.title,
+            album: endedSong.album,
+            albumArtist: null,
+            listenedSeconds: listenedSeconds,
+            trackDurationSeconds: trackDurationSeconds,
+          )
+          .catchError((e) => devLog('[ListenBrainz] onTrackEnded error: $e')),
     );
   }
 

--- a/lib/providers/providers.dart
+++ b/lib/providers/providers.dart
@@ -9,6 +9,7 @@ export 'favorites_provider.dart';
 export 'library_scanner_provider.dart';
 export 'library_scan_preferences_provider.dart';
 export 'lastfm_provider.dart';
+export 'listenbrainz_provider.dart';
 export 'navigation_provider.dart';
 export 'playlist_provider.dart';
 export 'songs_view_mode_provider.dart';

--- a/lib/services/alac_converter_service.dart
+++ b/lib/services/alac_converter_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 import '../src/rust/api/alac_converter_api.dart' as alac_api;
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Service for converting ALAC/M4A/AIFF files to WAV/PCM format
 ///
@@ -226,7 +227,7 @@ class AlacAudioSource {
           await file.delete();
         }
       } catch (e) {
-        debugPrint('Failed to delete converted file: $e');
+        devLog('Failed to delete converted file: $e');
       }
       _convertedPath = null;
     }

--- a/lib/services/android_audio_device_service.dart
+++ b/lib/services/android_audio_device_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flick/services/uac2_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class AndroidPlaybackDeviceInfo {
   const AndroidPlaybackDeviceInfo({
@@ -145,7 +146,7 @@ class AndroidAudioDeviceService {
       _channelConfigured = true;
       _channel.setMethodCallHandler((call) async {
         if (call.method == 'onPlaybackDevicesChanged') {
-          debugPrint('[Engine] Audio device change detected');
+          devLog('[Engine] Audio device change detected');
           if (Uac2Service.instance.shouldFreezeAndroidDirectUsbSessionQueries) {
             return;
           }
@@ -168,7 +169,7 @@ class AndroidAudioDeviceService {
       deviceInfoNotifier.value = info;
       return info;
     } catch (e) {
-      debugPrint('AndroidAudioDeviceService.refresh failed: $e');
+      devLog('AndroidAudioDeviceService.refresh failed: $e');
       deviceInfoNotifier.value = AndroidPlaybackDeviceInfo.unknown;
       return AndroidPlaybackDeviceInfo.unknown;
     }

--- a/lib/services/android_audio_engine.dart
+++ b/lib/services/android_audio_engine.dart
@@ -6,6 +6,7 @@ import 'package:flick/models/audio_engine_type.dart';
 import 'package:flick/models/playback_state.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/audio_engine.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 typedef AndroidAudioSourcesBuilder =
     Future<just_audio.AudioSource> Function();
@@ -244,12 +245,12 @@ class AndroidAudioEngine implements AudioEngine {
     if (canReusePlaylist &&
         player.sequence.isNotEmpty &&
         !_loadedSingleTrackOnly) {
-      debugPrint(
+      devLog(
         '[Playback] Android load(${track.id}) using existing playlist',
       );
       await player.seek(Duration.zero, index: index);
     } else if (shouldFastStartCurrentTrackOnly) {
-      debugPrint(
+      devLog(
         '[Playback] Android load(${track.id}) fast-starting current track',
       );
       _awaitingInitialSeek = true;
@@ -263,7 +264,7 @@ class AndroidAudioEngine implements AudioEngine {
       _loadedSingleTrackOnly = true;
       _playlistSignature = const <String>[];
     } else {
-      debugPrint('[Playback] Android load(${track.id}) rebuilding playlist');
+      devLog('[Playback] Android load(${track.id}) rebuilding playlist');
       _awaitingInitialSeek = true;
       try {
         final source = await _sourcesBuilder();
@@ -305,12 +306,12 @@ class AndroidAudioEngine implements AudioEngine {
       final playback = player.play();
       unawaited(
         playback.catchError((Object error, StackTrace stackTrace) {
-          debugPrint('[Playback] Android play() failed: $error');
+          devLog('[Playback] Android play() failed: $error');
           debugPrintStack(stackTrace: stackTrace);
         }),
       );
     } catch (error, stackTrace) {
-      debugPrint('[Playback] Android play() failed immediately: $error');
+      devLog('[Playback] Android play() failed immediately: $error');
       debugPrintStack(stackTrace: stackTrace);
       rethrow;
     }

--- a/lib/services/audio_engine_manager.dart
+++ b/lib/services/audio_engine_manager.dart
@@ -5,6 +5,7 @@ import 'package:flick/models/audio_engine_type.dart';
 import 'package:flick/models/playback_state.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/audio_engine.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class AudioEngineManager {
   final StreamController<PlaybackState> _controller =
@@ -52,7 +53,7 @@ class AudioEngineManager {
     _currentEngineType = engineType;
     _engineInitialized = true;
     _engineHasLoadedTrack = false;
-    debugPrint('[Engine] Attached: $engineLabel');
+    devLog('[Engine] Attached: $engineLabel');
 
     if (engineType != null) {
       // Preserve the last-known track while the engine is initialising so the
@@ -83,13 +84,13 @@ class AudioEngineManager {
     if (_engineInitialized &&
         _currentEngine != null &&
         _currentEngineType == engineType) {
-      debugPrint('[Engine] Prevented duplicate initialization');
+      devLog('[Engine] Prevented duplicate initialization');
       return;
     }
 
     final inFlight = _transitionInFlight;
     if (inFlight != null) {
-      debugPrint(
+      devLog(
         '[Engine] Waiting for in-flight engine transition to complete',
       );
       await inFlight;
@@ -125,14 +126,14 @@ class AudioEngineManager {
     bool autoPlay = true,
   }) async {
     final engine = _requireEngine();
-    debugPrint('[Playback] load(${track.id})');
+    devLog('[Playback] load(${track.id})');
     await engine.load(track);
     _engineHasLoadedTrack = true;
     if (initialPosition > Duration.zero) {
       await engine.seek(initialPosition);
     }
     if (autoPlay) {
-      debugPrint('[Playback] play()');
+      devLog('[Playback] play()');
       await engine.play();
     }
   }
@@ -154,20 +155,20 @@ class AudioEngineManager {
 
   Future<void> load(Song track) async {
     final engine = _requireEngine();
-    debugPrint('[Playback] load(${track.id})');
+    devLog('[Playback] load(${track.id})');
     await engine.load(track);
     _engineHasLoadedTrack = true;
   }
 
   Future<void> play() async {
     final engine = _requireEngine();
-    debugPrint('[Playback] play()');
+    devLog('[Playback] play()');
     await engine.play();
   }
 
   Future<void> pause() async {
     final engine = _requireEngine();
-    debugPrint('[Playback] pause()');
+    devLog('[Playback] pause()');
     await engine.pause();
   }
 

--- a/lib/services/audio_playback_service.dart
+++ b/lib/services/audio_playback_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:flick/services/alac_converter_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Enhanced audio playback service with lossless conversion support.
 ///
@@ -24,19 +25,19 @@ class AudioPlaybackService {
 
       // Check if WAV conversion is needed.
       if (AlacConverterService.requiresWavConversion(filePath)) {
-        debugPrint('Lossless source detected, converting to WAV...');
+        devLog('Lossless source detected, converting to WAV...');
 
         // Check cache first
         if (_conversionCache.containsKey(filePath)) {
           playablePath = _conversionCache[filePath]!;
-          debugPrint('Using cached conversion: $playablePath');
+          devLog('Using cached conversion: $playablePath');
         } else {
           // Convert file
           final alacSource = AlacAudioSource(filePath);
           playablePath = await alacSource.getPlayablePath();
           _currentAlacSource = alacSource;
           _conversionCache[filePath] = playablePath;
-          debugPrint('Converted to: $playablePath');
+          devLog('Converted to: $playablePath');
         }
       }
 
@@ -44,7 +45,7 @@ class AudioPlaybackService {
       await _player.setFilePath(playablePath);
       await _player.play();
     } catch (e) {
-      debugPrint('Error playing file: $e');
+      devLog('Error playing file: $e');
       rethrow;
     }
   }
@@ -79,7 +80,7 @@ class AudioPlaybackService {
           await file.delete();
         }
       } catch (e) {
-        debugPrint('Failed to delete cached file: $e');
+        devLog('Failed to delete cached file: $e');
       }
     }
     _conversionCache.clear();

--- a/lib/services/audio_session_manager.dart
+++ b/lib/services/audio_session_manager.dart
@@ -6,6 +6,7 @@ import 'package:flick/services/android_audio_device_service.dart';
 import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/services/uac2_service.dart';
 import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
+import 'package:flick/core/utils/dev_log.dart';
 
 typedef AudioSessionSwitchHandler =
     Future<void> Function({
@@ -64,9 +65,7 @@ class AudioSessionManager {
   String? get fallbackReason => fallbackReasonNotifier.value;
 
   void _debugLog(String message) {
-    if (Uac2PreferencesService.isDeveloperModeEnabledSync) {
-      debugPrint(message);
-    }
+    devLog(message);
   }
 
   Future<void> initialize() async {

--- a/lib/services/auto_library_sync_service.dart
+++ b/lib/services/auto_library_sync_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'mediastore_observer_service.dart';
 import 'background_metadata_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class AutoLibrarySyncService {
   final MediaStoreObserverService? _observerService;
@@ -19,7 +20,7 @@ class AutoLibrarySyncService {
     if (_isRunning) return;
 
     _isRunning = true;
-    debugPrint('Auto library sync started (event-driven)');
+    devLog('Auto library sync started (event-driven)');
 
     if (Platform.isAndroid && _observerService != null) {
       _observerService.start();
@@ -32,7 +33,7 @@ class AutoLibrarySyncService {
     _observerService?.stop();
     _backgroundMetadataService?.stop();
     _isRunning = false;
-    debugPrint('Auto library sync stopped');
+    devLog('Auto library sync stopped');
   }
 
   void notifyResumed() {

--- a/lib/services/background_metadata_service.dart
+++ b/lib/services/background_metadata_service.dart
@@ -4,6 +4,7 @@ import 'music_folder_service.dart';
 import '../data/repositories/song_repository.dart';
 import '../data/entities/song_entity.dart';
 import 'uac2_preferences_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class BackgroundMetadataService {
   final MusicFolderService _musicFolderService;
@@ -32,7 +33,7 @@ class BackgroundMetadataService {
 
   void _logTiming(String label, Duration elapsed) {
     if (!Uac2PreferencesService.isDeveloperModeEnabledSync) return;
-    debugPrint('[BackgroundMetadata] $label: ${elapsed.inMilliseconds}ms');
+    devLog('[BackgroundMetadata] $label: ${elapsed.inMilliseconds}ms');
   }
 
   Future<int> extractPendingMetadata() async {
@@ -113,7 +114,7 @@ class BackgroundMetadataService {
             chunkStopwatch.elapsed,
           );
         } catch (e) {
-          debugPrint('BackgroundMetadataService batch failed: $e');
+          devLog('BackgroundMetadataService batch failed: $e');
         }
       }
 

--- a/lib/services/color_extraction_service.dart
+++ b/lib/services/color_extraction_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Service to extract dominant colors from images for adaptive theming.
 ///
@@ -60,7 +61,7 @@ class ColorExtractionService {
 
       return color;
     } catch (e) {
-      debugPrint('ColorExtractionService: Failed to extract color: $e');
+      devLog('ColorExtractionService: Failed to extract color: $e');
       return null;
     }
   }

--- a/lib/services/display_mode_service.dart
+++ b/lib/services/display_mode_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class DisplayModeService {
   static final DisplayModeService _instance = DisplayModeService._internal();
@@ -23,7 +24,7 @@ class DisplayModeService {
       _currentMode = await FlutterDisplayMode.active;
       _preferredMode = await FlutterDisplayMode.preferred;
     } catch (e) {
-      debugPrint('Failed to initialize display modes: $e');
+      devLog('Failed to initialize display modes: $e');
     }
   }
 
@@ -33,7 +34,7 @@ class DisplayModeService {
       await FlutterDisplayMode.setHighRefreshRate();
       _currentMode = await FlutterDisplayMode.active;
     } catch (e) {
-      debugPrint('Failed to set high refresh rate: $e');
+      devLog('Failed to set high refresh rate: $e');
     }
   }
 
@@ -43,7 +44,7 @@ class DisplayModeService {
       await FlutterDisplayMode.setLowRefreshRate();
       _currentMode = await FlutterDisplayMode.active;
     } catch (e) {
-      debugPrint('Failed to set low refresh rate: $e');
+      devLog('Failed to set low refresh rate: $e');
     }
   }
 
@@ -54,7 +55,7 @@ class DisplayModeService {
       _currentMode = await FlutterDisplayMode.active;
       _preferredMode = mode;
     } catch (e) {
-      debugPrint('Failed to set preferred mode: $e');
+      devLog('Failed to set preferred mode: $e');
     }
   }
 

--- a/lib/services/duplicate_cleaner_service.dart
+++ b/lib/services/duplicate_cleaner_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import '../core/utils/audio_metadata_utils.dart';
 import '../data/repositories/song_repository.dart';
 import '../data/entities/song_entity.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Represents a group of duplicate songs.
 class DuplicateGroup {
@@ -101,7 +102,7 @@ class DuplicateCleanerService {
   /// Scan the library for duplicate songs.
   /// Duplicates are identified by matching title and artist (case-insensitive).
   Future<DuplicateScanResult> scanForDuplicates() async {
-    debugPrint('Starting duplicate scan...');
+    devLog('Starting duplicate scan...');
 
     final allSongs = await _songRepository.getAllSongEntities();
     final duplicateMap = <String, List<SongEntity>>{};
@@ -126,7 +127,7 @@ class DuplicateCleanerService {
       (sum, group) => sum + group.songsToRemove.length,
     );
 
-    debugPrint(
+    devLog(
       'Duplicate scan complete: Found $totalDuplicates duplicates in ${duplicateGroups.length} groups',
     );
 
@@ -141,7 +142,7 @@ class DuplicateCleanerService {
   Future<DuplicateRemovalResult> removeAllDuplicates(
     List<DuplicateGroup> groups,
   ) async {
-    debugPrint('Starting duplicate removal...');
+    devLog('Starting duplicate removal...');
 
     int removedCount = 0;
     int keptCount = 0;
@@ -157,17 +158,17 @@ class DuplicateCleanerService {
         }
 
         keptCount++;
-        debugPrint(
+        devLog(
           'Removed ${toRemove.length} duplicates of "${group.songToKeep.title}"',
         );
       } catch (e) {
         final error = 'Failed to remove duplicates for "${group.key}": $e';
         errors.add(error);
-        debugPrint(error);
+        devLog(error);
       }
     }
 
-    debugPrint(
+    devLog(
       'Duplicate removal complete: Removed $removedCount songs, kept $keptCount',
     );
 
@@ -187,7 +188,7 @@ class DuplicateCleanerService {
         await _songRepository.deleteSong(id);
         removedCount++;
       } catch (e) {
-        debugPrint('Failed to remove song $id: $e');
+        devLog('Failed to remove song $id: $e');
       }
     }
 

--- a/lib/services/external_playback_service.dart
+++ b/lib/services/external_playback_service.dart
@@ -6,6 +6,7 @@ import 'package:flick/core/utils/audio_metadata_utils.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/music_folder_service.dart';
 import 'package:flick/services/player_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class ExternalPlaybackService {
   ExternalPlaybackService._();
@@ -34,7 +35,7 @@ class ExternalPlaybackService {
     try {
       return await _channel.invokeMethod<bool>('returnToLocker') ?? false;
     } on PlatformException catch (e) {
-      debugPrint('Failed to return to Locker: ${e.message}');
+      devLog('Failed to return to Locker: ${e.message}');
       return false;
     }
   }
@@ -49,7 +50,7 @@ class ExternalPlaybackService {
       }
       return _playExternalPayload(payload.cast<String, dynamic>());
     } on PlatformException catch (e) {
-      debugPrint('Failed to consume pending external playback: ${e.message}');
+      devLog('Failed to consume pending external playback: ${e.message}');
       return false;
     }
   }
@@ -111,7 +112,7 @@ class ExternalPlaybackService {
       await PlayerService().play(song, playlist: [song]);
       return true;
     } catch (e, stackTrace) {
-      debugPrint('Failed to start external playback for $uri: $e');
+      devLog('Failed to start external playback for $uri: $e');
       debugPrintStack(stackTrace: stackTrace);
       return false;
     }

--- a/lib/services/fingerprint_cache_service.dart
+++ b/lib/services/fingerprint_cache_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Caches file fingerprints (path -> lastModifiedMs) per folder,
 /// so re-scans can diff against disk without loading the full song DB.
@@ -34,7 +35,7 @@ class FileFingerprintCache {
       _cache[folderUri] = map;
       return map;
     } catch (e) {
-      debugPrint('[FingerprintCache] Load error: $e');
+      devLog('[FingerprintCache] Load error: $e');
       return null;
     }
   }
@@ -51,7 +52,7 @@ class FileFingerprintCache {
       final file = File('$dir/$key.json');
       await file.writeAsString(jsonEncode(fingerprints));
     } catch (e) {
-      debugPrint('[FingerprintCache] Save error: $e');
+      devLog('[FingerprintCache] Save error: $e');
     }
   }
 
@@ -77,7 +78,7 @@ class FileFingerprintCache {
       final file = File('$dir/$key.json');
       if (file.existsSync()) await file.delete();
     } catch (e) {
-      debugPrint('[FingerprintCache] Remove error: $e');
+      devLog('[FingerprintCache] Remove error: $e');
     }
   }
 }

--- a/lib/services/floating_player_service.dart
+++ b/lib/services/floating_player_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Flutter service to communicate with the native Android floating
 /// mini-player overlay (WindowManager TYPE_APPLICATION_OVERLAY).
@@ -18,7 +19,7 @@ class FloatingPlayerService {
       final result = await _channel.invokeMethod<bool>('canDrawOverlays');
       return result ?? false;
     } catch (e) {
-      debugPrint('canDrawOverlays failed: $e');
+      devLog('canDrawOverlays failed: $e');
       return false;
     }
   }
@@ -31,7 +32,7 @@ class FloatingPlayerService {
           await _channel.invokeMethod<bool>('requestOverlayPermission');
       return result ?? false;
     } catch (e) {
-      debugPrint('requestOverlayPermission failed: $e');
+      devLog('requestOverlayPermission failed: $e');
       return false;
     }
   }
@@ -54,7 +55,7 @@ class FloatingPlayerService {
       if (position != null) args['position'] = position.inMilliseconds;
       await _channel.invokeMethod('showFloatingPlayer', args);
     } catch (e) {
-      debugPrint('Failed to show floating player: $e');
+      devLog('Failed to show floating player: $e');
     }
   }
 
@@ -63,7 +64,7 @@ class FloatingPlayerService {
     try {
       await _channel.invokeMethod('hideFloatingPlayer');
     } catch (e) {
-      debugPrint('Failed to hide floating player: $e');
+      devLog('Failed to hide floating player: $e');
     }
   }
 }

--- a/lib/services/lastfm/lastfm_auth_service.dart
+++ b/lib/services/lastfm/lastfm_auth_service.dart
@@ -4,6 +4,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flick/services/lastfm/lastfm_api_client.dart';
 import 'package:flick/services/lastfm/lastfm_models.dart';
 import 'package:flick/services/lastfm/lastfm_credentials.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Manages the Last.fm web auth flow and persists the session key securely.
 class LastFmAuthService {
@@ -17,86 +18,86 @@ class LastFmAuthService {
   /// Step 1: Request a token and open the Last.fm authorization page.
   /// Requires API key and shared secret to be set first.
   Future<void> getTokenAndLaunchAuth() async {
-    debugPrint('[LastFm] getTokenAndLaunchAuth: Starting');
+    devLog('[LastFm] getTokenAndLaunchAuth: Starting');
     
     final apiKey = await _credentials.getApiKey();
     final sharedSecret = await _credentials.getSharedSecret();
     
-    debugPrint('[LastFm] getTokenAndLaunchAuth: API key length: ${apiKey?.length ?? 0}');
-    debugPrint('[LastFm] getTokenAndLaunchAuth: Shared secret length: ${sharedSecret?.length ?? 0}');
+    devLog('[LastFm] getTokenAndLaunchAuth: API key length: ${apiKey?.length ?? 0}');
+    devLog('[LastFm] getTokenAndLaunchAuth: Shared secret length: ${sharedSecret?.length ?? 0}');
 
     if (apiKey == null || apiKey.isEmpty) {
-      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - API key not configured');
+      devLog('[LastFm] getTokenAndLaunchAuth: ERROR - API key not configured');
       throw Exception(
         'Last.fm API key not configured. Please set your API key in settings.',
       );
     }
     if (sharedSecret == null || sharedSecret.isEmpty) {
-      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - Shared secret not configured');
+      devLog('[LastFm] getTokenAndLaunchAuth: ERROR - Shared secret not configured');
       throw Exception(
         'Last.fm shared secret not configured. Please set your shared secret in settings.',
       );
     }
 
-    debugPrint('[LastFm] getTokenAndLaunchAuth: Requesting token from Last.fm API');
+    devLog('[LastFm] getTokenAndLaunchAuth: Requesting token from Last.fm API');
     try {
       final data = await _client.post({'method': 'auth.getToken'});
       final token = data['token'] as String;
-      debugPrint('[LastFm] getTokenAndLaunchAuth: Token received: ${token.substring(0, 8)}...');
+      devLog('[LastFm] getTokenAndLaunchAuth: Token received: ${token.substring(0, 8)}...');
 
       await _credentials.setPendingToken(token);
-      debugPrint('[LastFm] getTokenAndLaunchAuth: Pending token saved');
+      devLog('[LastFm] getTokenAndLaunchAuth: Pending token saved');
 
       final authUri = Uri.parse(
         'https://www.last.fm/api/auth/'
         '?api_key=$apiKey&token=$token',
       );
-      debugPrint('[LastFm] getTokenAndLaunchAuth: Auth URL: ${authUri.toString()}');
+      devLog('[LastFm] getTokenAndLaunchAuth: Auth URL: ${authUri.toString()}');
 
       try {
-        debugPrint('[LastFm] getTokenAndLaunchAuth: Attempting to launch URL');
+        devLog('[LastFm] getTokenAndLaunchAuth: Attempting to launch URL');
         final launched = await launchUrl(
           authUri,
           mode: LaunchMode.externalApplication,
         );
-        debugPrint('[LastFm] getTokenAndLaunchAuth: Launch result: $launched');
+        devLog('[LastFm] getTokenAndLaunchAuth: Launch result: $launched');
 
         if (!launched) {
-          debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR - launchUrl returned false');
+          devLog('[LastFm] getTokenAndLaunchAuth: ERROR - launchUrl returned false');
           // Clean up pending token if launch failed
           await _credentials.deletePendingToken();
           throw Exception('Could not launch Last.fm authorization page.');
         }
         
-        debugPrint('[LastFm] getTokenAndLaunchAuth: Successfully launched browser');
+        devLog('[LastFm] getTokenAndLaunchAuth: Successfully launched browser');
       } catch (e, stackTrace) {
-        debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR during launch - $e');
-        debugPrint('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
+        devLog('[LastFm] getTokenAndLaunchAuth: ERROR during launch - $e');
+        devLog('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
         // Clean up pending token on any launch error
         await _credentials.deletePendingToken();
         rethrow;
       }
     } catch (e, stackTrace) {
-      debugPrint('[LastFm] getTokenAndLaunchAuth: ERROR during token request - $e');
-      debugPrint('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
+      devLog('[LastFm] getTokenAndLaunchAuth: ERROR during token request - $e');
+      devLog('[LastFm] getTokenAndLaunchAuth: Stack trace: $stackTrace');
       rethrow;
     }
   }
 
   /// Step 2: Exchange pending token for a permanent session key.
   Future<LastFmSession> exchangeTokenForSession() async {
-    debugPrint('[LastFm] exchangeTokenForSession: Starting');
+    devLog('[LastFm] exchangeTokenForSession: Starting');
     
     final token = await _credentials.getPendingToken();
-    debugPrint('[LastFm] exchangeTokenForSession: Pending token exists: ${token != null}');
+    devLog('[LastFm] exchangeTokenForSession: Pending token exists: ${token != null}');
     
     if (token == null) {
-      debugPrint('[LastFm] exchangeTokenForSession: ERROR - No pending token');
+      devLog('[LastFm] exchangeTokenForSession: ERROR - No pending token');
       throw Exception('No pending Last.fm token found. Start auth again.');
     }
 
     try {
-      debugPrint('[LastFm] exchangeTokenForSession: Requesting session from Last.fm API');
+      devLog('[LastFm] exchangeTokenForSession: Requesting session from Last.fm API');
       final data = await _client.post({
         'method': 'auth.getSession',
         'token': token,
@@ -108,18 +109,18 @@ class LastFmAuthService {
         username: raw['name'] as String,
       );
       
-      debugPrint('[LastFm] exchangeTokenForSession: Session received for user: ${session.username}');
+      devLog('[LastFm] exchangeTokenForSession: Session received for user: ${session.username}');
 
       await _credentials.setSessionKey(session.sessionKey);
       await _credentials.setUsername(session.username);
       await _credentials.deletePendingToken();
       
-      debugPrint('[LastFm] exchangeTokenForSession: Session saved successfully');
+      devLog('[LastFm] exchangeTokenForSession: Session saved successfully');
 
       return session;
     } catch (e, stackTrace) {
-      debugPrint('[LastFm] exchangeTokenForSession: ERROR - $e');
-      debugPrint('[LastFm] exchangeTokenForSession: Stack trace: $stackTrace');
+      devLog('[LastFm] exchangeTokenForSession: ERROR - $e');
+      devLog('[LastFm] exchangeTokenForSession: Stack trace: $stackTrace');
       // Clean up stale pending token on failure so it doesn't linger
       await _credentials.deletePendingToken();
       rethrow;
@@ -148,10 +149,10 @@ class LastFmAuthService {
 
   /// Sets the API key and shared secret for the current user.
   Future<void> setApiCredentials(String apiKey, String sharedSecret) async {
-    debugPrint('[LastFm] setApiCredentials: Saving credentials (key length: ${apiKey.length}, secret length: ${sharedSecret.length})');
+    devLog('[LastFm] setApiCredentials: Saving credentials (key length: ${apiKey.length}, secret length: ${sharedSecret.length})');
     await _credentials.setApiKey(apiKey);
     await _credentials.setSharedSecret(sharedSecret);
-    debugPrint('[LastFm] setApiCredentials: Credentials saved successfully');
+    devLog('[LastFm] setApiCredentials: Credentials saved successfully');
   }
 
   /// Gets both API key and shared secret.

--- a/lib/services/lastfm/lastfm_scrobble_queue.dart
+++ b/lib/services/lastfm/lastfm_scrobble_queue.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flick/services/lastfm/lastfm_api_client.dart';
 import 'package:flick/services/lastfm/lastfm_models.dart';
 import 'package:flick/services/lastfm/lastfm_scrobble_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Offline-safe scrobble queue persisted in SharedPreferences.
 class LastFmScrobbleQueue {
@@ -23,9 +24,9 @@ class LastFmScrobbleQueue {
     if (queue.length > _kMaxQueueSize) {
       final dropped = queue.length - _kMaxQueueSize;
       queue.removeRange(0, dropped);
-      debugPrint('[LastFm] queue overflow: dropped $dropped oldest entries');
+      devLog('[LastFm] queue overflow: dropped $dropped oldest entries');
     }
-    debugPrint(
+    devLog(
       '[LastFm] queue enqueue artist="${entry.artist}" track="${entry.track}" pending=${queue.length}',
     );
     await _save(queue);
@@ -36,11 +37,11 @@ class LastFmScrobbleQueue {
   Future<void> flush() async {
     final raw = await _load();
     if (raw.isEmpty) {
-      debugPrint('[LastFm] queue flush skipped: empty');
+      devLog('[LastFm] queue flush skipped: empty');
       return;
     }
 
-    debugPrint('[LastFm] queue flush start pending=${raw.length}');
+    devLog('[LastFm] queue flush start pending=${raw.length}');
 
     final entries = raw
         .map(
@@ -52,23 +53,23 @@ class LastFmScrobbleQueue {
     try {
       await _service.scrobbleBatch(entries);
       await _clear();
-      debugPrint('[LastFm] queue flush success; queue cleared');
+      devLog('[LastFm] queue flush success; queue cleared');
     } on LastFmNoSessionException {
       // No active session — keep queue intact for later retry after login
-      debugPrint('[LastFm] queue flush skipped: no session; queue retained');
+      devLog('[LastFm] queue flush skipped: no session; queue retained');
       return;
     } on LastFmApiException catch (e) {
       if (e.code == 9) {
         // Invalid session key — keep queue; user must re-auth before retry
-        debugPrint(
+        devLog(
           '[LastFm] queue flush failed: session expired (code 9); queue retained until re-auth',
         );
         return;
       }
-      debugPrint('[LastFm] queue flush failed; queue retained');
+      devLog('[LastFm] queue flush failed; queue retained');
       rethrow;
     } catch (_) {
-      debugPrint('[LastFm] queue flush failed; queue retained');
+      devLog('[LastFm] queue flush failed; queue retained');
       rethrow;
     }
   }
@@ -87,7 +88,7 @@ class LastFmScrobbleQueue {
       return jsonDecode(raw) as List<dynamic>;
     } catch (e) {
       // Malformed or incompatible JSON; clear stored queue and start fresh
-      debugPrint('[LastFm] queue load failed; clearing corrupt data: $e');
+      devLog('[LastFm] queue load failed; clearing corrupt data: $e');
       await prefs.remove(_kQueueKey);
       return [];
     }

--- a/lib/services/lastfm/lastfm_scrobble_service.dart
+++ b/lib/services/lastfm/lastfm_scrobble_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flick/services/lastfm/lastfm_api_client.dart';
 import 'package:flick/services/lastfm/lastfm_auth_service.dart';
 import 'package:flick/services/lastfm/lastfm_models.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Handles Now Playing updates and scrobble submissions to Last.fm.
 class LastFmScrobbleService {
@@ -30,12 +31,12 @@ class LastFmScrobbleService {
   Future<void> updateNowPlaying(ScrobbleEntry entry) async {
     final session = await _auth.getSession();
     if (session == null) {
-      debugPrint('[LastFm] now-playing skipped: no session');
+      devLog('[LastFm] now-playing skipped: no session');
       return;
     }
 
     try {
-      debugPrint(
+      devLog(
         '[LastFm] now-playing send artist="${entry.artist}" track="${entry.track}"',
       );
       await _client.post({
@@ -48,10 +49,10 @@ class LastFmScrobbleService {
         if (entry.durationSeconds != null)
           'duration': entry.durationSeconds.toString(),
       });
-      debugPrint('[LastFm] now-playing success');
+      devLog('[LastFm] now-playing success');
     } catch (_) {
       // Now Playing is non-critical; failures are intentionally ignored.
-      debugPrint('[LastFm] now-playing failed');
+      devLog('[LastFm] now-playing failed');
     }
   }
 
@@ -62,20 +63,20 @@ class LastFmScrobbleService {
   /// Batch scrobble up to 50 tracks per API call.
   Future<void> scrobbleBatch(List<ScrobbleEntry> entries) async {
     if (entries.isEmpty) {
-      debugPrint('[LastFm] scrobble skipped: empty batch');
+      devLog('[LastFm] scrobble skipped: empty batch');
       return;
     }
 
     final session = await _auth.getSession();
     if (session == null) {
-      debugPrint('[LastFm] scrobble skipped: no session');
+      devLog('[LastFm] scrobble skipped: no session');
       throw LastFmNoSessionException();
     }
 
     const maxBatch = 50;
     for (var i = 0; i < entries.length; i += maxBatch) {
       final batch = entries.skip(i).take(maxBatch).toList();
-      debugPrint('[LastFm] scrobble send batchSize=${batch.length}');
+      devLog('[LastFm] scrobble send batchSize=${batch.length}');
       final params = <String, String>{
         'method': 'track.scrobble',
         'sk': session.sessionKey,
@@ -101,7 +102,7 @@ class LastFmScrobbleService {
       }
 
       await _client.post(params);
-      debugPrint('[LastFm] scrobble batch success');
+      devLog('[LastFm] scrobble batch success');
     }
   }
 }

--- a/lib/services/library_scanner_service.dart
+++ b/lib/services/library_scanner_service.dart
@@ -14,6 +14,7 @@ import '../services/rip_log_service.dart';
 import '../services/fingerprint_cache_service.dart';
 import '../services/uac2_preferences_service.dart';
 import '../src/rust/api/scanner.dart'; // Rust bridge
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Progress update during library scanning.
 class ScanProgress {
@@ -72,7 +73,7 @@ class LibraryScannerService {
     final scanPreferences = await _scanPreferencesService.getPreferences();
 
     if (_currentlyScanning.contains(scanKey)) {
-      debugPrint('Folder $displayName is already being scanned, skipping...');
+      devLog('Folder $displayName is already being scanned, skipping...');
       return;
     }
 
@@ -101,13 +102,13 @@ class LibraryScannerService {
               );
               return;
             } catch (e) {
-              debugPrint(
+              devLog(
                 'Rust deep scan failed for $displayName at $resolvedScanRoot: $e, '
                 'falling back to SAF',
               );
             }
           } else {
-            debugPrint(
+            devLog(
               'Deep scan requested for $displayName but no filesystem path '
               'resolvable, falling back to SAF',
             );
@@ -131,7 +132,7 @@ class LibraryScannerService {
               );
               return;
             } catch (e) {
-              debugPrint(
+              devLog(
                 'MediaStore scan failed for $displayName at $resolvedScanRoot: $e, '
                 'falling back to SAF',
               );
@@ -182,7 +183,7 @@ class LibraryScannerService {
       ]);
       _logScanTiming(displayName, 'MediaStore audio query', stopwatch.elapsed);
     } catch (e) {
-      debugPrint("MediaStore audio query failed for $displayName: $e");
+      devLog("MediaStore audio query failed for $displayName: $e");
       return;
     }
 
@@ -487,7 +488,7 @@ class LibraryScannerService {
         stopwatch.elapsed,
       );
     } catch (e) {
-      debugPrint('MediaStore non-audio query failed for $displayName: $e');
+      devLog('MediaStore non-audio query failed for $displayName: $e');
       return;
     }
 
@@ -638,7 +639,7 @@ class LibraryScannerService {
       );
       _logScanTiming(displayName, 'SAF fast scan', stopwatch.elapsed);
     } catch (e) {
-      debugPrint("Error scanning Android folder: $e");
+      devLog("Error scanning Android folder: $e");
       return;
     }
 
@@ -1402,7 +1403,7 @@ class LibraryScannerService {
           scanPreferences,
         );
       } catch (e) {
-        debugPrint('Deletion refresh failed for ${folder.displayName}: $e');
+        devLog('Deletion refresh failed for ${folder.displayName}: $e');
       }
     }
 
@@ -1443,7 +1444,7 @@ class LibraryScannerService {
           scanPreferences,
         );
       } else {
-        debugPrint(
+        devLog(
           'Skipping deletion check for $displayName: '
           'cannot resolve filesystem path',
         );
@@ -1470,7 +1471,7 @@ class LibraryScannerService {
         await _songRepository.deleteSongsByPath(deletedPaths);
       }
 
-      debugPrint(
+      devLog(
         'Deleted ${deletedPaths.length} missing songs from $displayName',
       );
     }
@@ -1505,14 +1506,14 @@ class LibraryScannerService {
           filePaths,
         );
         if (Uac2PreferencesService.isDeveloperModeEnabledSync) {
-          debugPrint(
+          devLog(
             '[LibraryScanner] MediaStore deletion check (${filePaths.length} paths): '
             '${stopwatch.elapsed.inMilliseconds}ms, ${result.length} deleted',
           );
         }
         return result;
       } catch (e) {
-        debugPrint('MediaStore deletion check failed, falling back to SAF: $e');
+        devLog('MediaStore deletion check failed, falling back to SAF: $e');
       }
     }
 
@@ -1550,7 +1551,7 @@ class LibraryScannerService {
       ),
     );
     if (Uac2PreferencesService.isDeveloperModeEnabledSync) {
-      debugPrint(
+      devLog(
         '[LibraryScanner] Rust deletion check (${knownFiles.length} known): '
         '${stopwatch.elapsed.inMilliseconds}ms, ${result.length} deleted',
       );
@@ -1581,7 +1582,7 @@ class LibraryScannerService {
             isSameOrDescendantFolder(root, normalized),
       );
       if (overlapsExisting) {
-        debugPrint(
+        devLog(
           'Skipping overlapping scan root ${folder.displayName} (${folder.uri})',
         );
         continue;
@@ -1607,7 +1608,7 @@ class LibraryScannerService {
     try {
       return await _musicFolderService.fetchMetadata(chunkUris);
     } catch (e) {
-      debugPrint(
+      devLog(
         'Error fetching metadata chunk (${chunkUris.length} files): $e',
       );
       return null;
@@ -1624,7 +1625,7 @@ class LibraryScannerService {
       try {
         await task();
       } catch (e) {
-        debugPrint('[LibraryScanner] $label failed for $displayName: $e');
+        devLog('[LibraryScanner] $label failed for $displayName: $e');
       } finally {
         _logScanTiming(displayName, label, stopwatch.elapsed);
       }
@@ -1633,7 +1634,7 @@ class LibraryScannerService {
 
   void _logScanTiming(String displayName, String label, Duration elapsed) {
     if (!Uac2PreferencesService.isDeveloperModeEnabledSync) return;
-    debugPrint(
+    devLog(
       '[LibraryScanner] $displayName $label: ${elapsed.inMilliseconds}ms',
     );
   }
@@ -1762,7 +1763,7 @@ class LibraryScannerService {
 
       await _playlistService.syncPlaylistsFromSources(sources);
     } catch (e) {
-      debugPrint('Failed to sync playlists from $folderUri: $e');
+      devLog('Failed to sync playlists from $folderUri: $e');
     }
   }
 
@@ -1811,7 +1812,7 @@ class LibraryScannerService {
         'uri': uri,
       });
     } catch (e) {
-      debugPrint('[LibraryScanner] Failed to read text file $uri: $e');
+      devLog('[LibraryScanner] Failed to read text file $uri: $e');
       return null;
     }
   }
@@ -1940,7 +1941,7 @@ class LibraryScannerService {
         }
       }
     } catch (e) {
-      debugPrint('[LibraryScanner] Error scanning for CUE/log files: $e');
+      devLog('[LibraryScanner] Error scanning for CUE/log files: $e');
     }
     return (cueMap: cueMap, logMap: result);
   }

--- a/lib/services/listenbrainz/listenbrainz_api_client.dart
+++ b/lib/services/listenbrainz/listenbrainz_api_client.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_credentials.dart';
+
+/// ListenBrainz API configuration.
+class ListenBrainzConfig {
+  static const String baseUrl = 'https://api.listenbrainz.org';
+}
+
+/// Thrown when ListenBrainz returns an error response.
+class ListenBrainzApiException implements Exception {
+  const ListenBrainzApiException(this.statusCode, this.message);
+
+  final int statusCode;
+  final String message;
+
+  @override
+  String toString() => 'ListenBrainzApiException($statusCode): $message';
+}
+
+/// Thrown when the caller is rate limited (HTTP 429).
+class ListenBrainzRateLimitException implements Exception {
+  const ListenBrainzRateLimitException(this.retryAfterSeconds);
+
+  final int retryAfterSeconds;
+
+  @override
+  String toString() =>
+      'ListenBrainzRateLimitException: retry after $retryAfterSeconds seconds';
+}
+
+/// Thrown when a ListenBrainz operation requires a token but none is available.
+class ListenBrainzNoTokenException implements Exception {
+  @override
+  String toString() => 'ListenBrainzNoTokenException: no user token configured';
+}
+
+/// Tracks ListenBrainz rate limit headers across requests.
+class _RateLimitTracker {
+  int? _remaining;
+  DateTime? _resetAt;
+
+  /// Updates state from response headers.
+  void update(Map<String, String> headers) {
+    final remainingRaw = headers['x-ratelimit-remaining'];
+    final resetInRaw = headers['x-ratelimit-reset-in'];
+
+    if (remainingRaw != null) {
+      _remaining = int.tryParse(remainingRaw);
+    }
+
+    if (resetInRaw != null) {
+      final resetInSeconds = int.tryParse(resetInRaw);
+      if (resetInSeconds != null) {
+        _resetAt = DateTime.now().add(Duration(seconds: resetInSeconds));
+      }
+    }
+  }
+
+  /// Waits until the current rate limit window resets if we are out of calls.
+  Future<void> maybeWait() async {
+    if (_remaining == null || _remaining! > 0) return;
+
+    final resetAt = _resetAt;
+    if (resetAt == null) return;
+
+    final wait = resetAt.difference(DateTime.now());
+    if (wait.inMilliseconds > 0) {
+      devLog(
+        '[ListenBrainz] rate limit hit, waiting ${wait.inSeconds}s until reset',
+      );
+      await Future<void>.delayed(wait + const Duration(milliseconds: 100));
+    }
+  }
+}
+
+/// Low-level HTTP client for ListenBrainz API.
+/// Handles `Authorization: Token <token>` headers and rate limit tracking.
+class ListenBrainzApiClient {
+  ListenBrainzApiClient({ListenBrainzCredentials? credentials})
+    : _credentials = credentials ?? ListenBrainzCredentials();
+
+  final ListenBrainzCredentials _credentials;
+  final _rateLimit = _RateLimitTracker();
+
+  Future<String> _getToken() async {
+    final token = await _credentials.getUserToken();
+    if (token == null || token.isEmpty) {
+      throw ListenBrainzNoTokenException();
+    }
+    return token;
+  }
+
+  Map<String, String> _headers(String token) => {
+    'Authorization': 'Token $token',
+    'Content-Type': 'application/json',
+  };
+
+  Future<Map<String, dynamic>> get(String path) async {
+    await _rateLimit.maybeWait();
+    final token = await _getToken();
+
+    final response = await http.get(
+      Uri.parse('${ListenBrainzConfig.baseUrl}$path'),
+      headers: {'Authorization': 'Token $token'},
+    );
+
+    _rateLimit.update(response.headers);
+    return _parse(response);
+  }
+
+  Future<Map<String, dynamic>> post(
+    String path, {
+    Map<String, dynamic>? body,
+  }) async {
+    await _rateLimit.maybeWait();
+    final token = await _getToken();
+
+    final response = await http.post(
+      Uri.parse('${ListenBrainzConfig.baseUrl}$path'),
+      headers: _headers(token),
+      body: body == null ? null : jsonEncode(body),
+    );
+
+    _rateLimit.update(response.headers);
+    return _parse(response);
+  }
+
+  Map<String, dynamic> _parse(http.Response response) {
+    if (response.statusCode == 429) {
+      final retryAfter = int.tryParse(response.headers['retry-after'] ?? '') ??
+          int.tryParse(response.headers['x-ratelimit-reset-in'] ?? '') ??
+          60;
+      throw ListenBrainzRateLimitException(retryAfter);
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ListenBrainzApiException(
+        response.statusCode,
+        'HTTP ${response.statusCode}: ${response.reasonPhrase}',
+      );
+    }
+
+    if (response.body.isEmpty) {
+      return {};
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+
+    // Some LB error responses still come back with HTTP 200 and a message/code.
+    if (data['valid'] == false) {
+      throw ListenBrainzApiException(
+        401,
+        data['message'] as String? ?? 'Invalid token',
+      );
+    }
+
+    return data;
+  }
+}

--- a/lib/services/listenbrainz/listenbrainz_auth_service.dart
+++ b/lib/services/listenbrainz/listenbrainz_auth_service.dart
@@ -1,0 +1,74 @@
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_api_client.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_credentials.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_models.dart';
+
+/// Manages ListenBrainz token validation and session persistence.
+class ListenBrainzAuthService {
+  ListenBrainzAuthService({
+    ListenBrainzApiClient? client,
+    ListenBrainzCredentials? credentials,
+  }) : _client = client ?? ListenBrainzApiClient(),
+       _credentials = credentials ?? ListenBrainzCredentials();
+
+  final ListenBrainzApiClient _client;
+  final ListenBrainzCredentials _credentials;
+
+  /// Validates the user token against ListenBrainz and returns the username.
+  Future<String> validateToken(String token) async {
+    devLog('[ListenBrainz] validateToken: validating token');
+
+    // Temporarily set the token so the client can call validate-token.
+    await _credentials.setUserToken(token);
+
+    try {
+      final data = await _client.get('/1/validate-token');
+      final valid = data['valid'] as bool? ?? false;
+      final username = data['user_name'] as String?;
+
+      if (!valid || username == null) {
+        throw Exception('Invalid ListenBrainz user token.');
+      }
+
+      devLog('[ListenBrainz] validateToken: token valid for user $username');
+      return username;
+    } catch (e) {
+      // Rollback temporary token on failure.
+      await _credentials.clearSession();
+      rethrow;
+    }
+  }
+
+  /// Saves the token and username after validation.
+  Future<ListenBrainzSession> connect(String token) async {
+    final username = await validateToken(token);
+
+    await _credentials.setUserToken(token);
+    await _credentials.setUsername(username);
+
+    final session = ListenBrainzSession(token: token, username: username);
+    devLog('[ListenBrainz] connect: session saved for $username');
+    return session;
+  }
+
+  Future<ListenBrainzSession?> getSession() async {
+    final token = await _credentials.getUserToken();
+    final username = await _credentials.getUsername();
+
+    if (token == null || token.isEmpty || username == null) {
+      return null;
+    }
+
+    return ListenBrainzSession(token: token, username: username);
+  }
+
+  Future<bool> isConnected() async {
+    return (await getSession()) != null;
+  }
+
+  /// Clears stored token and username (disconnect/logout).
+  Future<void> disconnect() async {
+    await _credentials.clearSession();
+    devLog('[ListenBrainz] disconnect: session cleared');
+  }
+}

--- a/lib/services/listenbrainz/listenbrainz_credentials.dart
+++ b/lib/services/listenbrainz/listenbrainz_credentials.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Manages ListenBrainz user token and username storage.
+class ListenBrainzCredentials {
+  ListenBrainzCredentials({FlutterSecureStorage? storage})
+    : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  static const _kUserToken = 'listenbrainz_user_token';
+  static const _kUsername = 'listenbrainz_username';
+
+  Future<void> setUserToken(String token) async {
+    await _storage.write(key: _kUserToken, value: token);
+  }
+
+  Future<String?> getUserToken() async {
+    return _storage.read(key: _kUserToken);
+  }
+
+  Future<void> setUsername(String username) async {
+    await _storage.write(key: _kUsername, value: username);
+  }
+
+  Future<String?> getUsername() async {
+    return _storage.read(key: _kUsername);
+  }
+
+  bool hasValidToken({String? token}) {
+    final t = token ?? '';
+    return t.isNotEmpty;
+  }
+
+  Future<void> clearAll() async {
+    await _storage.delete(key: _kUserToken);
+    await _storage.delete(key: _kUsername);
+  }
+
+  Future<void> clearSession() async {
+    await clearAll();
+  }
+}

--- a/lib/services/listenbrainz/listenbrainz_models.dart
+++ b/lib/services/listenbrainz/listenbrainz_models.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'listenbrainz_models.freezed.dart';
+part 'listenbrainz_models.g.dart';
+
+/// Represents a ListenBrainz session after token validation.
+@freezed
+abstract class ListenBrainzSession with _$ListenBrainzSession {
+  const factory ListenBrainzSession({
+    required String token,
+    required String username,
+  }) = _ListenBrainzSession;
+
+  factory ListenBrainzSession.fromJson(Map<String, dynamic> json) =>
+      _$ListenBrainzSessionFromJson(json);
+}
+
+/// A single track ready to be submitted to ListenBrainz.
+/// Stored flat for queue persistence; the service maps it to LB's nested
+/// JSON shape when submitting.
+@freezed
+abstract class ListenBrainzListenEntry with _$ListenBrainzListenEntry {
+  const factory ListenBrainzListenEntry({
+    required String artistName,
+    required String trackName,
+    required int listenedAt,
+    String? releaseName,
+    int? durationSeconds,
+  }) = _ListenBrainzListenEntry;
+
+  factory ListenBrainzListenEntry.fromJson(Map<String, dynamic> json) =>
+      _$ListenBrainzListenEntryFromJson(json);
+}

--- a/lib/services/listenbrainz/listenbrainz_models.freezed.dart
+++ b/lib/services/listenbrainz/listenbrainz_models.freezed.dart
@@ -1,0 +1,555 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'listenbrainz_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ListenBrainzSession {
+
+ String get token; String get username;
+/// Create a copy of ListenBrainzSession
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ListenBrainzSessionCopyWith<ListenBrainzSession> get copyWith => _$ListenBrainzSessionCopyWithImpl<ListenBrainzSession>(this as ListenBrainzSession, _$identity);
+
+  /// Serializes this ListenBrainzSession to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ListenBrainzSession&&(identical(other.token, token) || other.token == token)&&(identical(other.username, username) || other.username == username));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,username);
+
+@override
+String toString() {
+  return 'ListenBrainzSession(token: $token, username: $username)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ListenBrainzSessionCopyWith<$Res>  {
+  factory $ListenBrainzSessionCopyWith(ListenBrainzSession value, $Res Function(ListenBrainzSession) _then) = _$ListenBrainzSessionCopyWithImpl;
+@useResult
+$Res call({
+ String token, String username
+});
+
+
+
+
+}
+/// @nodoc
+class _$ListenBrainzSessionCopyWithImpl<$Res>
+    implements $ListenBrainzSessionCopyWith<$Res> {
+  _$ListenBrainzSessionCopyWithImpl(this._self, this._then);
+
+  final ListenBrainzSession _self;
+  final $Res Function(ListenBrainzSession) _then;
+
+/// Create a copy of ListenBrainzSession
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? token = null,Object? username = null,}) {
+  return _then(_self.copyWith(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ListenBrainzSession].
+extension ListenBrainzSessionPatterns on ListenBrainzSession {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ListenBrainzSession value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ListenBrainzSession() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ListenBrainzSession value)  $default,){
+final _that = this;
+switch (_that) {
+case _ListenBrainzSession():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ListenBrainzSession value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ListenBrainzSession() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String token,  String username)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ListenBrainzSession() when $default != null:
+return $default(_that.token,_that.username);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String token,  String username)  $default,) {final _that = this;
+switch (_that) {
+case _ListenBrainzSession():
+return $default(_that.token,_that.username);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String token,  String username)?  $default,) {final _that = this;
+switch (_that) {
+case _ListenBrainzSession() when $default != null:
+return $default(_that.token,_that.username);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ListenBrainzSession implements ListenBrainzSession {
+  const _ListenBrainzSession({required this.token, required this.username});
+  factory _ListenBrainzSession.fromJson(Map<String, dynamic> json) => _$ListenBrainzSessionFromJson(json);
+
+@override final  String token;
+@override final  String username;
+
+/// Create a copy of ListenBrainzSession
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ListenBrainzSessionCopyWith<_ListenBrainzSession> get copyWith => __$ListenBrainzSessionCopyWithImpl<_ListenBrainzSession>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ListenBrainzSessionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ListenBrainzSession&&(identical(other.token, token) || other.token == token)&&(identical(other.username, username) || other.username == username));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,token,username);
+
+@override
+String toString() {
+  return 'ListenBrainzSession(token: $token, username: $username)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ListenBrainzSessionCopyWith<$Res> implements $ListenBrainzSessionCopyWith<$Res> {
+  factory _$ListenBrainzSessionCopyWith(_ListenBrainzSession value, $Res Function(_ListenBrainzSession) _then) = __$ListenBrainzSessionCopyWithImpl;
+@override @useResult
+$Res call({
+ String token, String username
+});
+
+
+
+
+}
+/// @nodoc
+class __$ListenBrainzSessionCopyWithImpl<$Res>
+    implements _$ListenBrainzSessionCopyWith<$Res> {
+  __$ListenBrainzSessionCopyWithImpl(this._self, this._then);
+
+  final _ListenBrainzSession _self;
+  final $Res Function(_ListenBrainzSession) _then;
+
+/// Create a copy of ListenBrainzSession
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? token = null,Object? username = null,}) {
+  return _then(_ListenBrainzSession(
+token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ListenBrainzListenEntry {
+
+ String get artistName; String get trackName; int get listenedAt; String? get releaseName; int? get durationSeconds;
+/// Create a copy of ListenBrainzListenEntry
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ListenBrainzListenEntryCopyWith<ListenBrainzListenEntry> get copyWith => _$ListenBrainzListenEntryCopyWithImpl<ListenBrainzListenEntry>(this as ListenBrainzListenEntry, _$identity);
+
+  /// Serializes this ListenBrainzListenEntry to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ListenBrainzListenEntry&&(identical(other.artistName, artistName) || other.artistName == artistName)&&(identical(other.trackName, trackName) || other.trackName == trackName)&&(identical(other.listenedAt, listenedAt) || other.listenedAt == listenedAt)&&(identical(other.releaseName, releaseName) || other.releaseName == releaseName)&&(identical(other.durationSeconds, durationSeconds) || other.durationSeconds == durationSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,artistName,trackName,listenedAt,releaseName,durationSeconds);
+
+@override
+String toString() {
+  return 'ListenBrainzListenEntry(artistName: $artistName, trackName: $trackName, listenedAt: $listenedAt, releaseName: $releaseName, durationSeconds: $durationSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ListenBrainzListenEntryCopyWith<$Res>  {
+  factory $ListenBrainzListenEntryCopyWith(ListenBrainzListenEntry value, $Res Function(ListenBrainzListenEntry) _then) = _$ListenBrainzListenEntryCopyWithImpl;
+@useResult
+$Res call({
+ String artistName, String trackName, int listenedAt, String? releaseName, int? durationSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class _$ListenBrainzListenEntryCopyWithImpl<$Res>
+    implements $ListenBrainzListenEntryCopyWith<$Res> {
+  _$ListenBrainzListenEntryCopyWithImpl(this._self, this._then);
+
+  final ListenBrainzListenEntry _self;
+  final $Res Function(ListenBrainzListenEntry) _then;
+
+/// Create a copy of ListenBrainzListenEntry
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? artistName = null,Object? trackName = null,Object? listenedAt = null,Object? releaseName = freezed,Object? durationSeconds = freezed,}) {
+  return _then(_self.copyWith(
+artistName: null == artistName ? _self.artistName : artistName // ignore: cast_nullable_to_non_nullable
+as String,trackName: null == trackName ? _self.trackName : trackName // ignore: cast_nullable_to_non_nullable
+as String,listenedAt: null == listenedAt ? _self.listenedAt : listenedAt // ignore: cast_nullable_to_non_nullable
+as int,releaseName: freezed == releaseName ? _self.releaseName : releaseName // ignore: cast_nullable_to_non_nullable
+as String?,durationSeconds: freezed == durationSeconds ? _self.durationSeconds : durationSeconds // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ListenBrainzListenEntry].
+extension ListenBrainzListenEntryPatterns on ListenBrainzListenEntry {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ListenBrainzListenEntry value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ListenBrainzListenEntry value)  $default,){
+final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ListenBrainzListenEntry value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String artistName,  String trackName,  int listenedAt,  String? releaseName,  int? durationSeconds)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry() when $default != null:
+return $default(_that.artistName,_that.trackName,_that.listenedAt,_that.releaseName,_that.durationSeconds);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String artistName,  String trackName,  int listenedAt,  String? releaseName,  int? durationSeconds)  $default,) {final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry():
+return $default(_that.artistName,_that.trackName,_that.listenedAt,_that.releaseName,_that.durationSeconds);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String artistName,  String trackName,  int listenedAt,  String? releaseName,  int? durationSeconds)?  $default,) {final _that = this;
+switch (_that) {
+case _ListenBrainzListenEntry() when $default != null:
+return $default(_that.artistName,_that.trackName,_that.listenedAt,_that.releaseName,_that.durationSeconds);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ListenBrainzListenEntry implements ListenBrainzListenEntry {
+  const _ListenBrainzListenEntry({required this.artistName, required this.trackName, required this.listenedAt, this.releaseName, this.durationSeconds});
+  factory _ListenBrainzListenEntry.fromJson(Map<String, dynamic> json) => _$ListenBrainzListenEntryFromJson(json);
+
+@override final  String artistName;
+@override final  String trackName;
+@override final  int listenedAt;
+@override final  String? releaseName;
+@override final  int? durationSeconds;
+
+/// Create a copy of ListenBrainzListenEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ListenBrainzListenEntryCopyWith<_ListenBrainzListenEntry> get copyWith => __$ListenBrainzListenEntryCopyWithImpl<_ListenBrainzListenEntry>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ListenBrainzListenEntryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ListenBrainzListenEntry&&(identical(other.artistName, artistName) || other.artistName == artistName)&&(identical(other.trackName, trackName) || other.trackName == trackName)&&(identical(other.listenedAt, listenedAt) || other.listenedAt == listenedAt)&&(identical(other.releaseName, releaseName) || other.releaseName == releaseName)&&(identical(other.durationSeconds, durationSeconds) || other.durationSeconds == durationSeconds));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,artistName,trackName,listenedAt,releaseName,durationSeconds);
+
+@override
+String toString() {
+  return 'ListenBrainzListenEntry(artistName: $artistName, trackName: $trackName, listenedAt: $listenedAt, releaseName: $releaseName, durationSeconds: $durationSeconds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ListenBrainzListenEntryCopyWith<$Res> implements $ListenBrainzListenEntryCopyWith<$Res> {
+  factory _$ListenBrainzListenEntryCopyWith(_ListenBrainzListenEntry value, $Res Function(_ListenBrainzListenEntry) _then) = __$ListenBrainzListenEntryCopyWithImpl;
+@override @useResult
+$Res call({
+ String artistName, String trackName, int listenedAt, String? releaseName, int? durationSeconds
+});
+
+
+
+
+}
+/// @nodoc
+class __$ListenBrainzListenEntryCopyWithImpl<$Res>
+    implements _$ListenBrainzListenEntryCopyWith<$Res> {
+  __$ListenBrainzListenEntryCopyWithImpl(this._self, this._then);
+
+  final _ListenBrainzListenEntry _self;
+  final $Res Function(_ListenBrainzListenEntry) _then;
+
+/// Create a copy of ListenBrainzListenEntry
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? artistName = null,Object? trackName = null,Object? listenedAt = null,Object? releaseName = freezed,Object? durationSeconds = freezed,}) {
+  return _then(_ListenBrainzListenEntry(
+artistName: null == artistName ? _self.artistName : artistName // ignore: cast_nullable_to_non_nullable
+as String,trackName: null == trackName ? _self.trackName : trackName // ignore: cast_nullable_to_non_nullable
+as String,listenedAt: null == listenedAt ? _self.listenedAt : listenedAt // ignore: cast_nullable_to_non_nullable
+as int,releaseName: freezed == releaseName ? _self.releaseName : releaseName // ignore: cast_nullable_to_non_nullable
+as String?,durationSeconds: freezed == durationSeconds ? _self.durationSeconds : durationSeconds // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/services/listenbrainz/listenbrainz_models.g.dart
+++ b/lib/services/listenbrainz/listenbrainz_models.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'listenbrainz_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ListenBrainzSession _$ListenBrainzSessionFromJson(Map<String, dynamic> json) =>
+    _ListenBrainzSession(
+      token: json['token'] as String,
+      username: json['username'] as String,
+    );
+
+Map<String, dynamic> _$ListenBrainzSessionToJson(
+  _ListenBrainzSession instance,
+) => <String, dynamic>{'token': instance.token, 'username': instance.username};
+
+_ListenBrainzListenEntry _$ListenBrainzListenEntryFromJson(
+  Map<String, dynamic> json,
+) => _ListenBrainzListenEntry(
+  artistName: json['artistName'] as String,
+  trackName: json['trackName'] as String,
+  listenedAt: (json['listenedAt'] as num).toInt(),
+  releaseName: json['releaseName'] as String?,
+  durationSeconds: (json['durationSeconds'] as num?)?.toInt(),
+);
+
+Map<String, dynamic> _$ListenBrainzListenEntryToJson(
+  _ListenBrainzListenEntry instance,
+) => <String, dynamic>{
+  'artistName': instance.artistName,
+  'trackName': instance.trackName,
+  'listenedAt': instance.listenedAt,
+  'releaseName': instance.releaseName,
+  'durationSeconds': instance.durationSeconds,
+};

--- a/lib/services/listenbrainz/listenbrainz_scrobble_queue.dart
+++ b/lib/services/listenbrainz/listenbrainz_scrobble_queue.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_api_client.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_models.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_scrobble_service.dart';
+
+/// Offline-safe ListenBrainz listen queue persisted in SharedPreferences.
+class ListenBrainzScrobbleQueue {
+  ListenBrainzScrobbleQueue({ListenBrainzScrobbleService? service})
+    : _service = service ?? ListenBrainzScrobbleService();
+
+  final ListenBrainzScrobbleService _service;
+  static const _kQueueKey = 'listenbrainz_scrobble_queue_v1';
+  static const _kMaxQueueSize = 1000;
+
+  Future<void> enqueue(ListenBrainzListenEntry entry) async {
+    final queue = await _load();
+    queue.add(entry.toJson());
+    // Drop oldest entries if queue exceeds max size
+    if (queue.length > _kMaxQueueSize) {
+      final dropped = queue.length - _kMaxQueueSize;
+      queue.removeRange(0, dropped);
+      devLog('[ListenBrainz] queue overflow: dropped $dropped oldest entries');
+    }
+    devLog(
+      '[ListenBrainz] queue enqueue artist="${entry.artistName}" track="${entry.trackName}" pending=${queue.length}',
+    );
+    await _save(queue);
+  }
+
+  /// Attempts to flush all queued listens.
+  /// Keeps queue intact on failure for future retries.
+  Future<void> flush() async {
+    final raw = await _load();
+    if (raw.isEmpty) {
+      devLog('[ListenBrainz] queue flush skipped: empty');
+      return;
+    }
+
+    devLog('[ListenBrainz] queue flush start pending=${raw.length}');
+
+    final entries = raw
+        .map(
+          (entry) => ListenBrainzListenEntry.fromJson(
+            Map<String, dynamic>.from(entry as Map),
+          ),
+        )
+        .toList();
+
+    try {
+      await _service.scrobbleBatch(entries);
+      await _clear();
+      devLog('[ListenBrainz] queue flush success; queue cleared');
+    } on ListenBrainzNoTokenException {
+      // No active token — keep queue intact for later retry after login
+      devLog('[ListenBrainz] queue flush skipped: no token; queue retained');
+      return;
+    } on ListenBrainzApiException catch (e) {
+      if (e.statusCode == 401) {
+        // Invalid token — keep queue; user must re-auth before retry
+        devLog(
+          '[ListenBrainz] queue flush failed: token invalid (401); queue retained until re-auth',
+        );
+        return;
+      }
+      devLog('[ListenBrainz] queue flush failed; queue retained');
+      rethrow;
+    } catch (_) {
+      devLog('[ListenBrainz] queue flush failed; queue retained');
+      rethrow;
+    }
+  }
+
+  Future<int> get pendingCount async {
+    return (await _load()).length;
+  }
+
+  Future<List<dynamic>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kQueueKey);
+    if (raw == null) {
+      return [];
+    }
+    try {
+      return jsonDecode(raw) as List<dynamic>;
+    } catch (e) {
+      // Malformed or incompatible JSON; clear stored queue and start fresh
+      devLog('[ListenBrainz] queue load failed; clearing corrupt data: $e');
+      await prefs.remove(_kQueueKey);
+      return [];
+    }
+  }
+
+  Future<void> _save(List<dynamic> queue) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kQueueKey, jsonEncode(queue));
+  }
+
+  Future<void> _clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_kQueueKey);
+  }
+}

--- a/lib/services/listenbrainz/listenbrainz_scrobble_service.dart
+++ b/lib/services/listenbrainz/listenbrainz_scrobble_service.dart
@@ -1,0 +1,126 @@
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/utils/dev_log.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_api_client.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_auth_service.dart';
+import 'package:flick/services/listenbrainz/listenbrainz_models.dart';
+
+/// Handles "playing now" and listen submissions to ListenBrainz.
+class ListenBrainzScrobbleService {
+  ListenBrainzScrobbleService({
+    ListenBrainzApiClient? client,
+    ListenBrainzAuthService? auth,
+  }) : _client = client ?? ListenBrainzApiClient(),
+       _auth = auth ?? ListenBrainzAuthService();
+
+  final ListenBrainzApiClient _client;
+  final ListenBrainzAuthService _auth;
+
+  /// Returns true if the track meets ListenBrainz listen requirements:
+  /// listened to at least half the track or 4 minutes, whichever is lower.
+  bool isEligibleToScrobble({
+    required int trackDurationSeconds,
+    required int listenedSeconds,
+  }) {
+    if (trackDurationSeconds <= 0) return false;
+
+    final threshold = (trackDurationSeconds / 2).floor();
+    final minThreshold = threshold < 240 ? threshold : 240;
+    return listenedSeconds >= minThreshold;
+  }
+
+  /// Call at playback start to update ListenBrainz "playing_now".
+  Future<void> updateNowPlaying(ListenBrainzListenEntry entry) async {
+    final session = await _auth.getSession();
+    if (session == null) {
+      devLog('[ListenBrainz] playing-now skipped: no token');
+      return;
+    }
+
+    try {
+      devLog(
+        '[ListenBrainz] playing-now send artist="${entry.artistName}" track="${entry.trackName}"',
+      );
+      await _client.post(
+        '/1/submit-listens',
+        body: {
+          'listen_type': 'playing_now',
+          'payload': [_entryToPayload(entry, includeListenedAt: false)],
+        },
+      );
+      devLog('[ListenBrainz] playing-now success');
+    } catch (_) {
+      // Playing now is non-critical; failures are intentionally ignored.
+      devLog('[ListenBrainz] playing-now failed');
+    }
+  }
+
+  Future<void> scrobble(ListenBrainzListenEntry entry) async {
+    await scrobbleBatch([entry]);
+  }
+
+  /// Batch submit listens. Uses `import` listen_type for batches and `single`
+  /// for a single entry, matching ListenBrainz conventions.
+  Future<void> scrobbleBatch(List<ListenBrainzListenEntry> entries) async {
+    if (entries.isEmpty) {
+      devLog('[ListenBrainz] scrobble skipped: empty batch');
+      return;
+    }
+
+    final session = await _auth.getSession();
+    if (session == null) {
+      devLog('[ListenBrainz] scrobble skipped: no token');
+      throw ListenBrainzNoTokenException();
+    }
+
+    const maxBatch = 1000;
+    final isSingle = entries.length == 1;
+
+    for (var i = 0; i < entries.length; i += maxBatch) {
+      final batch = entries.skip(i).take(maxBatch).toList();
+      devLog('[ListenBrainz] scrobble send batchSize=${batch.length}');
+
+      await _client.post(
+        '/1/submit-listens',
+        body: {
+          'listen_type': isSingle ? 'single' : 'import',
+          'payload':
+              batch
+                  .map((e) => _entryToPayload(e, includeListenedAt: true))
+                  .toList(),
+        },
+      );
+      devLog('[ListenBrainz] scrobble batch success');
+    }
+  }
+
+  Map<String, dynamic> _entryToPayload(
+    ListenBrainzListenEntry entry, {
+    required bool includeListenedAt,
+  }) {
+    final additionalInfo = <String, dynamic>{
+      'media_player': 'Flick',
+      'submission_client': 'Flick',
+      'submission_client_version': kAppVersion,
+    };
+
+    if (entry.durationSeconds != null && entry.durationSeconds! > 0) {
+      additionalInfo['duration_ms'] = entry.durationSeconds! * 1000;
+    }
+
+    final payload = <String, dynamic>{
+      'track_metadata': <String, dynamic>{
+        'artist_name': entry.artistName,
+        'track_name': entry.trackName,
+        if (entry.releaseName != null && entry.releaseName!.isNotEmpty)
+          'release_name': entry.releaseName,
+        'additional_info': additionalInfo,
+      },
+    };
+
+    if (includeListenedAt) {
+      payload['listened_at'] = entry.listenedAt;
+    }
+
+    return payload;
+  }
+}

--- a/lib/services/mediastore_observer_service.dart
+++ b/lib/services/mediastore_observer_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'music_folder_service.dart';
 import 'library_scanner_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class MediaStoreObserverService {
   final MusicFolderService _musicFolderService;
@@ -23,11 +24,11 @@ class MediaStoreObserverService {
       _subscription = _musicFolderService.mediaStoreChanges.listen(
         _onChange,
         onError: (e) {
-          debugPrint('MediaStoreObserver error: $e');
+          devLog('MediaStoreObserver error: $e');
         },
       );
     } catch (e) {
-      debugPrint('MediaStoreObserver failed to start: $e');
+      devLog('MediaStoreObserver failed to start: $e');
     }
   }
 
@@ -66,9 +67,9 @@ class MediaStoreObserverService {
 
     try {
       await for (final _ in _scannerService.scanAllFolders()) {}
-      debugPrint('MediaStoreObserver: auto-rescan complete');
+      devLog('MediaStoreObserver: auto-rescan complete');
     } catch (e) {
-      debugPrint('MediaStoreObserver rescan failed: $e');
+      devLog('MediaStoreObserver rescan failed: $e');
     } finally {
       _isProcessing = false;
       if (_pendingRescan) {

--- a/lib/services/music_folder_service.dart
+++ b/lib/services/music_folder_service.dart
@@ -6,6 +6,7 @@ import 'package:flick/core/utils/uri_display_utils.dart';
 import 'permission_service.dart';
 import '../data/repositories/folder_repository.dart';
 import '../data/entities/folder_entity.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 String normalizeFolderIdentifier(String uri) {
   final parsed = Uri.tryParse(uri);
@@ -557,7 +558,7 @@ class MusicFolderService {
         'filePath': filePath,
       }) ?? false;
     } catch (e) {
-      debugPrint('deleteDocument failed: $e');
+      devLog('deleteDocument failed: $e');
       return false;
     }
   }
@@ -568,7 +569,7 @@ class MusicFolderService {
         'filePath': filePath,
       }) ?? false;
     } catch (e) {
-      debugPrint('removeFromMediaStore failed: $e');
+      devLog('removeFromMediaStore failed: $e');
       return false;
     }
   }

--- a/lib/services/music_folder_service.dart
+++ b/lib/services/music_folder_service.dart
@@ -561,4 +561,15 @@ class MusicFolderService {
       return false;
     }
   }
+
+  static Future<bool> removeFromMediaStore(String filePath) async {
+    try {
+      return await _channel.invokeMethod<bool>('removeFromMediaStore', {
+        'filePath': filePath,
+      }) ?? false;
+    } catch (e) {
+      debugPrint('removeFromMediaStore failed: $e');
+      return false;
+    }
+  }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Flutter service to communicate with native Android notification service.
 /// Handles media playback notifications with controls.
@@ -88,7 +89,7 @@ class NotificationService {
       await _channel.invokeMethod('showNotification', args);
       _isNotificationVisible = true;
     } catch (e) {
-      debugPrint('Failed to show notification: $e');
+      devLog('Failed to show notification: $e');
     }
   }
 
@@ -106,7 +107,7 @@ class NotificationService {
       }
       await _channel.invokeMethod('updateNotification', args);
     } catch (e) {
-      debugPrint('Failed to update notification state: $e');
+      devLog('Failed to update notification state: $e');
     }
   }
 
@@ -137,7 +138,7 @@ class NotificationService {
       await _channel.invokeMethod('updateNotification', args);
       _isNotificationVisible = true;
     } catch (e) {
-      debugPrint('Failed to update notification: $e');
+      devLog('Failed to update notification: $e');
     }
   }
 
@@ -147,7 +148,7 @@ class NotificationService {
       await _channel.invokeMethod('hideNotification');
       _isNotificationVisible = false;
     } catch (e) {
-      debugPrint('Failed to hide notification: $e');
+      devLog('Failed to hide notification: $e');
     }
   }
 }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -36,6 +36,7 @@ import 'package:flick/services/album_color_mode_preference_service.dart';
 import 'package:flick/models/album_color_mode.dart';
 import 'package:flick/services/uac2_service.dart';
 import 'package:flick/services/alac_converter_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 enum HwVolumeCapability { unknown, supported, unsupported }
 
@@ -935,9 +936,7 @@ class PlayerService {
   }
 
   void _debugLog(String message) {
-    if (Uac2PreferencesService.isDeveloperModeEnabledSync) {
-      debugPrint(message);
-    }
+    devLog(message);
   }
 
   /// Initialize the audio engine.
@@ -1006,7 +1005,7 @@ class PlayerService {
   }
 
   Future<void> _initializeAudio() async {
-    debugPrint('[Engine] Initializing audio manager');
+    _debugLog('[Engine] Initializing audio manager');
 
     try {
       await Future.wait<void>([
@@ -1061,7 +1060,7 @@ class PlayerService {
       final session = await AudioSession.instance;
       await session.setActive(false);
     } catch (e) {
-      debugPrint('[AudioFocus] Failed to deactivate Android audio session: $e');
+      _debugLog('[AudioFocus] Failed to deactivate Android audio session: $e');
     }
   }
 
@@ -1071,9 +1070,9 @@ class PlayerService {
     try {
       final session = await AudioSession.instance;
       final granted = await session.setActive(true);
-      debugPrint('[AudioFocus] Rust engine focus request granted=$granted');
+      _debugLog('[AudioFocus] Rust engine focus request granted=$granted');
     } catch (e) {
-      debugPrint(
+      _debugLog(
         '[AudioFocus] Failed to activate audio session for Rust engine: $e',
       );
     }
@@ -1086,7 +1085,7 @@ class PlayerService {
       return;
     }
 
-    debugPrint('[Engine] Releasing Android-managed audio resources ($reason)');
+    _debugLog('[Engine] Releasing Android-managed audio resources ($reason)');
     await _disposeAndroidEngine();
     await _deactivateAndroidAudioSession();
   }
@@ -1113,12 +1112,12 @@ class PlayerService {
       });
       _audioSessionConfigured = true;
     } catch (e) {
-      debugPrint('[AudioFocus] Failed to configure Android audio session: $e');
+      _debugLog('[AudioFocus] Failed to configure Android audio session: $e');
     }
   }
 
   void _onAudioInterruptionEvent(AudioInterruptionEvent event) {
-    debugPrint(
+    _debugLog(
       '[AudioFocus] Interruption event: begin=${event.begin}, '
       'type=${event.type}, wasPlaying=$_wasPlayingBeforeAudioInterruption, '
       'playing=${isPlayingNotifier.value}',
@@ -1159,7 +1158,7 @@ class PlayerService {
     try {
       await _resumeInternal();
     } catch (e, stackTrace) {
-      debugPrint('[AudioFocus] Auto-resume after interruption failed: $e');
+      _debugLog('[AudioFocus] Auto-resume after interruption failed: $e');
       debugPrintStack(stackTrace: stackTrace);
     }
   }
@@ -1189,7 +1188,7 @@ class PlayerService {
         final session = await AudioSession.instance;
         await session.setActive(true);
       } catch (e) {
-        debugPrint('[AudioFocus] Failed to activate Android audio session: $e');
+        _debugLog('[AudioFocus] Failed to activate Android audio session: $e');
       }
     }
 
@@ -1224,7 +1223,7 @@ class PlayerService {
       return true;
     }
     if (_rustBackendAvailable && !_rustAudioService.isInitialized) {
-      debugPrint(
+      _debugLog(
         '[Engine] Rust backend flag was stale; reinitializing Rust audio manager',
       );
       _rustBackendAvailable = false;
@@ -1241,7 +1240,7 @@ class PlayerService {
       return _rustBackendAvailable;
     } catch (e) {
       _rustBackendAvailable = false;
-      debugPrint('Rust audio backend unavailable: $e');
+      _debugLog('Rust audio backend unavailable: $e');
       return false;
     } finally {
       completer.complete(_rustBackendAvailable);
@@ -1912,7 +1911,7 @@ class PlayerService {
 
     final newSong = _playlist[newIndex];
     if (fromListener && _shouldIgnoreAutoSyncedSong(newSong)) {
-      debugPrint(
+      _debugLog(
         'Ignoring transient auto-sync to ${newSong.title} during explicit play handoff',
       );
       return;
@@ -1929,7 +1928,7 @@ class PlayerService {
       _clearAutoSyncGuard();
     }
     if (newSong != currentSongNotifier.value) {
-      debugPrint(
+      _debugLog(
         'Track transition: ${currentSongNotifier.value?.title} -> ${newSong.title}',
       );
     }
@@ -2036,7 +2035,7 @@ class PlayerService {
       unawaited(_onSongFinished(endedPath: endedPath));
     };
     _rustAudioService.onError = (message) {
-      debugPrint('[PlayerService] Rust backend error: $message');
+      _debugLog('[PlayerService] Rust backend error: $message');
       unawaited(_refreshAudioOutputDiagnostics(reason: 'Rust backend error'));
     };
   }
@@ -2203,7 +2202,7 @@ class PlayerService {
       try {
         isFav = await _favoritesService.isFavorite(song.id);
       } catch (e) {
-        debugPrint('Failed to load favorite state: $e');
+        _debugLog('Failed to load favorite state: $e');
       }
     }
 
@@ -2229,7 +2228,7 @@ class PlayerService {
         }
       }
     } catch (e) {
-      debugPrint('Failed to extract notification color: $e');
+      _debugLog('Failed to extract notification color: $e');
     }
 
     await _notificationService.updateNotification(
@@ -2252,7 +2251,7 @@ class PlayerService {
   }
 
   Future<void> _onSongFinishedInternal({String? endedPath}) async {
-    debugPrint(
+    _debugLog(
       '_onSongFinished: loopMode=${loopModeNotifier.value}, currentIndex=$_currentIndex, playlistLength=${_playlist.length}, usingRustBackend=$_usingRustBackend, endedPath=$endedPath',
     );
 
@@ -2265,12 +2264,12 @@ class PlayerService {
       usingRustBackend: _usingRustBackend,
       loopMode: loopModeNotifier.value,
     )) {
-      debugPrint('_onSongFinished: skipping manual completion handling');
+      _debugLog('_onSongFinished: skipping manual completion handling');
       return;
     }
 
     if (loopModeNotifier.value == LoopMode.stopAfterCurrent) {
-      debugPrint('_onSongFinished: stopAfterCurrent, pausing');
+      _debugLog('_onSongFinished: stopAfterCurrent, pausing');
       await _pauseInternal();
       await seek(Duration.zero);
       return;
@@ -2279,11 +2278,11 @@ class PlayerService {
     if (loopModeNotifier.value == LoopMode.one) {
       final songToReplay = currentSongNotifier.value ?? _songAtCurrentIndex();
       if (songToReplay != null) {
-        debugPrint('_onSongFinished: LoopMode.one, replaying current song');
+        _debugLog('_onSongFinished: LoopMode.one, replaying current song');
         await _playInternal(songToReplay);
       }
     } else {
-      debugPrint('_onSongFinished: Calling next()');
+      _debugLog('_onSongFinished: Calling next()');
       await _nextInternal();
     }
   }
@@ -2346,7 +2345,7 @@ class PlayerService {
     try {
       await _playbackManager.stop();
     } catch (e) {
-      debugPrint('Stop failed: $e');
+      _debugLog('Stop failed: $e');
     }
     await _refreshAudioOutputDiagnostics(reason: 'playback stopped');
     cancelSleepTimer();
@@ -2490,7 +2489,7 @@ class PlayerService {
         return stagedPath;
       }
     } catch (e) {
-      debugPrint('Failed to stage content URI for playback: $e');
+      _debugLog('Failed to stage content URI for playback: $e');
     }
     return null;
   }
@@ -2573,7 +2572,7 @@ class PlayerService {
       return convertedPath;
     } catch (e) {
       _unsupportedWavConversionSources.add(sourceKey);
-      debugPrint('Failed to convert playback path to WAV: $e');
+      _debugLog('Failed to convert playback path to WAV: $e');
       return null;
     }
   }
@@ -2636,7 +2635,7 @@ class PlayerService {
   ) async {
     final inFlight = _rustEnginePreparationInFlight;
     if (inFlight != null) {
-      debugPrint(
+      _debugLog(
         '[Engine] Waiting for in-flight Rust engine preparation to complete',
       );
       await inFlight;
@@ -2663,13 +2662,13 @@ class PlayerService {
     if (requiresUsbDac) {
       final deviceInfo = await AndroidAudioDeviceService.instance.refresh();
       if (!deviceInfo.hasUsbDac) {
-        debugPrint('[Engine] USB init blocked: no USB DAC detected');
+        _debugLog('[Engine] USB init blocked: no USB DAC detected');
         throw StateError('Rust USB engine requires a USB DAC');
       }
     }
 
     if (!_rustAudioService.isInitialized) {
-      debugPrint(
+      _debugLog(
         '[Engine] Initializing Rust engine for ${playbackMode.logLabel}',
       );
     }
@@ -2693,12 +2692,12 @@ class PlayerService {
         playbackMode,
       );
       if (playbackMode == AudioEngineType.usbDacExperimental) {
-        debugPrint(
+        _debugLog(
           '[Engine] Ensuring USB DAC is registered before engine preparation',
         );
         final dacRegistered = await _ensureUsbDacRegistered();
         if (!dacRegistered) {
-          debugPrint(
+          _debugLog(
             '[Engine] Failed to register USB DAC before engine preparation',
           );
           throw StateError('USB DAC registration failed');
@@ -2772,7 +2771,7 @@ class PlayerService {
       return null;
     }
 
-    debugPrint(
+    _debugLog(
       '[Engine] DAP managed playback pinned to $preferredSampleRate Hz '
       '(${formatPreference.name}) while Bit-perfect (DAP Internal) is disabled',
     );
@@ -2813,11 +2812,11 @@ class PlayerService {
           directUsbState?['playback_format_sample_rate'] != null;
 
       if (alreadyRegistered && hasPlaybackFormat) {
-        debugPrint('[Engine] USB DAC already registered with playback format');
+        _debugLog('[Engine] USB DAC already registered with playback format');
         return true;
       }
 
-      debugPrint(
+      _debugLog(
         '[Engine] Preparing USB DAC for playback (registered=$alreadyRegistered, hasFormat=$hasPlaybackFormat)',
       );
 
@@ -2833,7 +2832,7 @@ class PlayerService {
       );
 
       if (!prepared) {
-        debugPrint('[Engine] Failed to prepare USB DAC for playback');
+        _debugLog('[Engine] Failed to prepare USB DAC for playback');
         return false;
       }
 
@@ -2848,18 +2847,18 @@ class PlayerService {
           verifyDirectUsbState?['playback_format_sample_rate'] != null;
 
       if (nowRegistered && nowHasFormat) {
-        debugPrint(
+        _debugLog(
           '[Engine] USB DAC successfully prepared: registered=$nowRegistered, hasFormat=$nowHasFormat, rate=${verifyDirectUsbState?['playback_format_sample_rate']}',
         );
       } else {
-        debugPrint(
+        _debugLog(
           '[Engine] USB DAC preparation incomplete: registered=$nowRegistered, hasFormat=$nowHasFormat',
         );
       }
 
       return nowRegistered && nowHasFormat;
     } catch (e) {
-      debugPrint('[Engine] Error ensuring USB DAC registration: $e');
+      _debugLog('[Engine] Error ensuring USB DAC registration: $e');
       return false;
     }
   }
@@ -2914,7 +2913,7 @@ class PlayerService {
       return false;
     }
     if (await _uac2Service.isBitPerfectEnabled()) {
-      debugPrint(
+      _debugLog(
         '[Engine] Bit-perfect (USB DAC) requires an exact verified DAC rate; '
         'skipping fallback-rate direct retry from '
         '${currentFormat.sampleRate} Hz',
@@ -2932,7 +2931,7 @@ class PlayerService {
       return false;
     }
 
-    debugPrint(
+    _debugLog(
       '[Engine] Direct USB clock setup failed at ${currentFormat.sampleRate} Hz; '
       'retrying direct USB at ${fallbackFormat.sampleRate} Hz',
     );
@@ -2955,7 +2954,7 @@ class PlayerService {
     final player = _justAudioPlayer;
     if (player == null) return;
 
-    debugPrint('[Engine] Disposing Android engine');
+    _debugLog('[Engine] Disposing Android engine');
 
     try {
       await player.stop();
@@ -2970,7 +2969,7 @@ class PlayerService {
   Future<void> _disposeUsbEngine() async {
     if (!_rustAudioService.isInitialized) return;
 
-    debugPrint('[Engine] Disposing Rust engine');
+    _debugLog('[Engine] Disposing Rust engine');
     if (_rustListenersAttached) {
       if (_rustStateListener != null) {
         _rustAudioService.stateNotifier.removeListener(_rustStateListener!);
@@ -3024,13 +3023,13 @@ class PlayerService {
     // This prevents USB "Resource busy" from overlapping sessions.
     if (from != to || from == null) {
       if (_rustEngine != null) {
-        debugPrint(
+        _debugLog(
           '[Engine] Full dispose of Rust engine before ${to.logLabel}',
         );
         await _disposeUsbEngine();
       }
       if (_justAudioPlayer != null) {
-        debugPrint(
+        _debugLog(
           '[Engine] Full dispose of Android engine before ${to.logLabel}',
         );
         await _disposeAndroidEngine();
@@ -3045,7 +3044,7 @@ class PlayerService {
 
     final hasDetachedAndroidPrewarm = _justAudioPlayer != null;
     if (hasDetachedAndroidPrewarm) {
-      debugPrint(
+      _debugLog(
         '[Engine] Disposing detached Android prewarm before ${to.logLabel}',
       );
       await _disposeAndroidEngine();
@@ -3072,7 +3071,7 @@ class PlayerService {
       _usingRustBackend = false;
     }
 
-    debugPrint(
+    _debugLog(
       '[Engine] Switch complete: ${from?.logLabel ?? 'none'} -> '
       '${to.logLabel} ($reason)',
     );
@@ -3137,7 +3136,7 @@ class PlayerService {
       return desiredEngine;
     }
 
-    debugPrint(
+    _debugLog(
       '[Engine] USB engine requested without a USB DAC; '
       'falling back to Android ($reason)',
     );
@@ -3231,7 +3230,7 @@ class PlayerService {
             _sameUac2Format(currentUsbFormat, targetUsbOutputFormat);
 
         if (formatMatches) {
-          debugPrint(
+          _debugLog(
             '[Engine] USB engine already active with matching format '
             '(${targetUsbOutputFormat.sampleRate}Hz/'
             '${targetUsbOutputFormat.bitDepth}-bit/'
@@ -3267,7 +3266,7 @@ class PlayerService {
             alreadyInUsbMode &&
             !_sameUac2Format(currentUsbFormat, preparedUsbFormat);
         if (needsDirectUsbPrewarm && _rustAudioService.isInitialized) {
-          debugPrint(
+          _debugLog(
             '[Engine] Prewarming active USB engine for '
             '${preparedUsbFormat.sampleRate}Hz/${preparedUsbFormat.bitDepth}-bit/'
             '${preparedUsbFormat.channels}ch before playback',
@@ -3291,7 +3290,7 @@ class PlayerService {
     List<Song>? playlist,
     PlaybackContext? context,
   }) {
-    debugPrint('[UI] tap(${song.id})');
+    _debugLog('[UI] tap(${song.id})');
     if (context != null) setPlaybackContext(context);
     return _enqueuePlaybackRequest(
       () => _playInternal(song, playlist: playlist),
@@ -3299,23 +3298,23 @@ class PlayerService {
   }
 
   Future<void> _enqueuePlaybackRequest(Future<void> Function() action) {
-    debugPrint('[PlayerService] _enqueuePlaybackRequest called');
+    _debugLog('[PlayerService] _enqueuePlaybackRequest called');
     final operation = _playRequestQueue
         .then<void>((_) async {
-          debugPrint(
+          _debugLog(
             '[PlayerService] _enqueuePlaybackRequest: previous operation complete, executing action',
           );
           try {
             await action();
           } catch (e, stack) {
-            debugPrint(
+            _debugLog(
               '[PlayerService] _enqueuePlaybackRequest action error: $e\n$stack',
             );
             rethrow;
           }
         })
         .catchError((e) {
-          debugPrint('[PlayerService] _enqueuePlaybackRequest queue error: $e');
+          _debugLog('[PlayerService] _enqueuePlaybackRequest queue error: $e');
         });
     _playRequestQueue = operation;
     return operation;
@@ -3324,7 +3323,7 @@ class PlayerService {
   Future<void> _playInternal(Song song, {List<Song>? playlist}) async {
     await initAudio();
     try {
-      debugPrint(
+      _debugLog(
         '[Playback] play() called for ${song.title} '
         '(selected mode: ${_sessionManager.selectedMode.logLabel})',
       );
@@ -3380,7 +3379,7 @@ class PlayerService {
           song: song,
           reason: 'playback requested',
         );
-        debugPrint(
+        _debugLog(
           '[Engine] Playback route resolved to ${activeEngine.logLabel}',
         );
         await _runWithSuppressedSequenceStateUpdates(() async {
@@ -3405,7 +3404,7 @@ class PlayerService {
       if (recovered) {
         return;
       }
-      debugPrint(
+      _debugLog(
         '[Playback] play() failed for ${song.title} '
         'on ${currentEngineType.logLabel}: $e',
       );
@@ -3450,7 +3449,7 @@ class PlayerService {
         wasPlaying: isPlayingNotifier.value,
       );
     } catch (e) {
-      debugPrint('Failed to save last played position: $e');
+      _debugLog('Failed to save last played position: $e');
     }
   }
 
@@ -3512,7 +3511,7 @@ class PlayerService {
       );
 
       if (restoredSong.filePath != null) {
-        debugPrint(
+        _debugLog(
           '[Playback] Restored ${restoredSong.title} at '
           '${lastPlayed.position.inMilliseconds}ms; waiting for explicit playback',
         );
@@ -3521,12 +3520,12 @@ class PlayerService {
   }
 
   Future<void> pause() {
-    debugPrint('[PlayerService] pause() called');
+    _debugLog('[PlayerService] pause() called');
     return _enqueuePlaybackRequest(_pauseInternal);
   }
 
   Future<void> _pauseInternal() async {
-    debugPrint(
+    _debugLog(
       '[Playback] pause() called, hasAttachedEngine=${_playbackManager.hasAttachedEngine}',
     );
     if (isPlayingNotifier.value) {
@@ -3536,7 +3535,7 @@ class PlayerService {
     // If no engine has been attached yet (e.g. pausing a restored-but-not-started
     // track), there is nothing to pause — the optimistic update above is enough.
     if (!_playbackManager.hasAttachedEngine) {
-      debugPrint(
+      _debugLog(
         '[Playback] pause(): no engine attached, returning after optimistic update',
       );
       return;
@@ -3544,7 +3543,7 @@ class PlayerService {
     try {
       await _playbackManager.pause();
     } catch (e) {
-      debugPrint('Pause failed: $e');
+      _debugLog('Pause failed: $e');
     }
     await _refreshAudioOutputDiagnostics(
       reason: 'playback paused',
@@ -3564,7 +3563,7 @@ class PlayerService {
       return;
     }
 
-    debugPrint('[Playback] resume() called');
+    _debugLog('[Playback] resume() called');
     // Use the cached route selection maintained by the session manager's device
     // listener rather than doing another blocking device probe on resume.
     final desiredEngine = _sessionManager.selectedMode;
@@ -3573,7 +3572,7 @@ class PlayerService {
       song: song,
       reason: 'resume requested',
     );
-    debugPrint('[Engine] Resume route resolved to ${activeEngine.logLabel}');
+    _debugLog('[Engine] Resume route resolved to ${activeEngine.logLabel}');
 
     final latestState = _playbackManager.latestState;
     final canResumeDirectly =
@@ -3657,7 +3656,7 @@ class PlayerService {
       return false;
     }
 
-    debugPrint(
+    _debugLog(
       '[Engine] Direct USB startup refused: $message. Falling back to NORMAL_ANDROID',
     );
     await _uac2Service.markAndroidDirectUsbFallback(message);
@@ -3698,11 +3697,11 @@ class PlayerService {
   }
 
   Future<void> togglePlayPause() {
-    debugPrint(
+    _debugLog(
       '[PlayerService] togglePlayPause called, isPlaying=${isPlayingNotifier.value}',
     );
     return _enqueuePlaybackRequest(() async {
-      debugPrint(
+      _debugLog(
         '[PlayerService] togglePlayPause executing, isPlaying=${isPlayingNotifier.value}',
       );
       try {
@@ -3720,7 +3719,7 @@ class PlayerService {
         if (recovered) {
           return;
         }
-        debugPrint('[PlayerService] togglePlayPause error: $e\n$stack');
+        _debugLog('[PlayerService] togglePlayPause error: $e\n$stack');
       }
     });
   }
@@ -3729,28 +3728,28 @@ class PlayerService {
     try {
       await _playbackManager.seek(position);
     } catch (e) {
-      debugPrint('Seek failed: $e');
+      _debugLog('Seek failed: $e');
     }
     unawaited(_updateNotificationState());
   }
 
   Future<void> next() {
-    debugPrint('[PlayerService] next() called');
+    _debugLog('[PlayerService] next() called');
     return _enqueuePlaybackRequest(_nextInternal);
   }
 
   Future<void> _nextInternal() async {
-    debugPrint(
+    _debugLog(
       '[PlayerService] _nextInternal() called, playlist.length=${_playlist.length}, currentIndex=$_currentIndex',
     );
     if (_playlist.isEmpty) {
-      debugPrint(
+      _debugLog(
         '[PlayerService] _nextInternal: playlist is empty, returning early',
       );
       return;
     }
 
-    debugPrint(
+    _debugLog(
       'next(): currentIndex=$_currentIndex, playlistLength=${_playlist.length}, loopMode=${loopModeNotifier.value}',
     );
 
@@ -3776,7 +3775,7 @@ class PlayerService {
     final shuffle = shuffleModeNotifier.value;
     if (shuffle == ShuffleMode.songsAndCategories ||
         shuffle == ShuffleMode.categories) {
-      debugPrint(
+      _debugLog(
         'next(): category shuffle active, advancing to random category',
       );
       await _advanceToRandomCategory();
@@ -3784,36 +3783,36 @@ class PlayerService {
     }
 
     if (loopModeNotifier.value == LoopMode.all) {
-      debugPrint('next(): LoopMode.all, wrapping to index 0');
+      _debugLog('next(): LoopMode.all, wrapping to index 0');
       _setCurrentIndex(0);
       await _playSongAtCurrentIndex();
       return;
     }
 
     if (loopModeNotifier.value.isAdvanceMode) {
-      debugPrint(
+      _debugLog(
         'next(): ${loopModeNotifier.value}, advancing to next category',
       );
       await _advanceForMode(loopModeNotifier.value);
       return;
     }
 
-    debugPrint('next(): End of playlist, pausing');
+    _debugLog('next(): End of playlist, pausing');
     await _pauseInternal();
     await seek(Duration.zero);
   }
 
   Future<void> previous() {
-    debugPrint('[PlayerService] previous() called');
+    _debugLog('[PlayerService] previous() called');
     return _enqueuePlaybackRequest(_previousInternal);
   }
 
   Future<void> _previousInternal() async {
-    debugPrint(
+    _debugLog(
       '[PlayerService] _previousInternal() called, playlist.length=${_playlist.length}, currentIndex=$_currentIndex',
     );
     if (_playlist.isEmpty) {
-      debugPrint(
+      _debugLog(
         '[PlayerService] _previousInternal: playlist is empty, returning early',
       );
       return;
@@ -3864,7 +3863,7 @@ class PlayerService {
         await player.play();
       }
     } catch (e) {
-      debugPrint('Error rebuilding playlist: $e');
+      _debugLog('Error rebuilding playlist: $e');
     } finally {
       _isRebuildingPlaylist = false;
     }
@@ -4037,11 +4036,11 @@ class PlayerService {
     // Volume must go through DAC hardware exclusively.
     if (isCurrentTrackDoP && _isDirectUsbPath) {
       if (_shouldAttemptHardwareVolume()) {
-        debugPrint('[VolFlow] DoP HW path: uac2 setVolume($clampedVolume)');
+        _debugLog('[VolFlow] DoP HW path: uac2 setVolume($clampedVolume)');
         final hwOk = await _uac2Service.setVolume(clampedVolume);
         _onHwVolumeResult(hwOk);
       } else {
-        debugPrint(
+        _debugLog(
           '[VolFlow] DoP: no hardware volume available — volume unchanged',
         );
       }
@@ -4065,14 +4064,14 @@ class PlayerService {
     switch (tier) {
       case VolumeTier.hardware:
         if (_shouldAttemptHardwareVolume()) {
-          debugPrint('[VolFlow] HW path: uac2 setVolume($clampedVolume)');
+          _debugLog('[VolFlow] HW path: uac2 setVolume($clampedVolume)');
           final hwOk = await _uac2Service.setVolume(clampedVolume);
           _onHwVolumeResult(hwOk);
         }
         break;
       case VolumeTier.software:
         if (_usingRustBackend) {
-          debugPrint('[VolFlow] SW path: engine setVolume($clampedVolume)');
+          _debugLog('[VolFlow] SW path: engine setVolume($clampedVolume)');
           await _rustAudioService.setVolume(clampedVolume);
         }
         break;
@@ -4091,7 +4090,7 @@ class PlayerService {
   /// This restarts the active DSD track's decoder in PCM decimation mode,
   /// where the normal audio-callback gain-loop handles volume cleanly.
   Future<void> _switchDoPForVolumeTrack(double volume) async {
-    debugPrint('[VolFlow] DoP → PCM auto-switch for volume=$volume');
+    _debugLog('[VolFlow] DoP → PCM auto-switch for volume=$volume');
 
     // Persist the mode change so new DSD tracks also use PCM.
     await Uac2PreferencesService().setDsdOutputMode(DsdOutputMode.forcePcm);
@@ -4110,7 +4109,7 @@ class PlayerService {
 
     // Volume now works via normal callback gain.
     await _rustAudioService.setVolume(volume);
-    debugPrint('[VolFlow] DoP → PCM switch complete');
+    _debugLog('[VolFlow] DoP → PCM switch complete');
   }
 
   Future<int> addToQueue(Song song) async {
@@ -4300,7 +4299,7 @@ class PlayerService {
   Future<void> setPlaybackSpeed(double speed) async {
     final clampedSpeed = speed.clamp(0.5, 2.0).toDouble();
     if (isBitPerfectProcessingLocked) {
-      debugPrint(
+      _debugLog(
         '[Playback] Ignoring playback-speed change while Bit-perfect (USB DAC) is enabled',
       );
       if (_usingRustBackend) {
@@ -4469,7 +4468,7 @@ class PlayerService {
     if (_activeTier != VolumeTier.hardware) return;
     final healthy = await _uac2Service.verifyHardwareVolumeHealth();
     if (healthy == false) {
-      debugPrint(
+      _debugLog(
         '[VolFlow] HW volume health check failed — falling back to software tier',
       );
       _onHwVolumeResult(false);
@@ -4576,7 +4575,7 @@ class PlayerService {
         await file.delete();
       }
     } catch (e) {
-      debugPrint('Failed to delete temporary playback file: $e');
+      _debugLog('Failed to delete temporary playback file: $e');
     }
   }
 
@@ -4623,14 +4622,14 @@ class PlayerService {
       }
 
       if (nextSongs == null || nextSongs.isEmpty) {
-        debugPrint('_advanceForMode($mode): no next category found, pausing');
+        _debugLog('_advanceForMode($mode): no next category found, pausing');
         await _pauseInternal();
         await seek(Duration.zero);
         return;
       }
       await _playInternal(nextSongs.first, playlist: nextSongs);
     } catch (e) {
-      debugPrint('_advanceForMode($mode): error: $e');
+      _debugLog('_advanceForMode($mode): error: $e');
       await _pauseInternal();
       await seek(Duration.zero);
     }
@@ -4780,7 +4779,7 @@ class PlayerService {
           : songs;
       await _playInternal(ordered.first, playlist: ordered);
     } catch (e) {
-      debugPrint('_advanceToRandomCategory error: $e');
+      _debugLog('_advanceToRandomCategory error: $e');
       await _pauseInternal();
       await seek(Duration.zero);
     }

--- a/lib/services/playlist_service.dart
+++ b/lib/services/playlist_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/models/playlist.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class PlaylistImportResult {
   final Playlist playlist;
@@ -241,7 +242,7 @@ class PlaylistService {
       final uri = await _storageChannel.invokeMethod<String>('openDocument', {
         'mimeTypes': _playlistMimeTypes,
       });
-      debugPrint('[PlaylistService] Selected URI: $uri');
+      devLog('[PlaylistService] Selected URI: $uri');
       if (uri == null || uri.trim().isEmpty) return null;
 
       final parsedUri = Uri.tryParse(uri);
@@ -253,7 +254,7 @@ class PlaylistService {
         'readTextDocument',
         {'uri': uri},
       );
-      debugPrint('[PlaylistService] Content length: ${content?.length ?? 0}');
+      devLog('[PlaylistService] Content length: ${content?.length ?? 0}');
       if (content == null || content.trim().isEmpty) {
         throw const FormatException('Selected playlist file is empty');
       }
@@ -262,15 +263,15 @@ class PlaylistService {
         'getDocumentDisplayName',
         {'uri': uri},
       );
-      debugPrint('[PlaylistService] Display name: $displayName');
+      devLog('[PlaylistService] Display name: $displayName');
 
       return _upsertPlaylistFromSource(
         PlaylistSourceFile(sourcePath: uri, displayName: displayName),
         content: content,
       );
     } catch (e, st) {
-      debugPrint('[PlaylistService] Import error: $e');
-      debugPrint('[PlaylistService] Import stack: $st');
+      devLog('[PlaylistService] Import error: $e');
+      devLog('[PlaylistService] Import stack: $st');
       rethrow;
     } finally {
       _importInProgress = false;
@@ -303,10 +304,10 @@ class PlaylistService {
           results.add(imported);
         }
       } catch (e, st) {
-        debugPrint(
+        devLog(
           '[PlaylistService] Failed to sync playlist source "${source.sourcePath}": $e',
         );
-        debugPrint('[PlaylistService] Playlist sync stack: $st');
+        devLog('[PlaylistService] Playlist sync stack: $st');
       }
     }
 
@@ -333,13 +334,13 @@ class PlaylistService {
       baseName,
       excludeId: existing?.id,
     );
-    debugPrint('[PlaylistService] Playlist name: $playlistName');
+    devLog('[PlaylistService] Playlist name: $playlistName');
 
     final entries = _parseM3uEntries(content);
-    debugPrint('[PlaylistService] Parsed ${entries.length} entries');
+    devLog('[PlaylistService] Parsed ${entries.length} entries');
     final lookup = songLookup ?? await _buildSongLookup();
     final resolved = _resolveSongIdsWithLookup(entries, lookup);
-    debugPrint(
+    devLog(
       '[PlaylistService] Resolved ${resolved.ids.length} songs, ${resolved.unmatchedEntries.length} unmatched',
     );
 
@@ -551,10 +552,10 @@ class PlaylistService {
           byFileName.putIfAbsent(fileName, () => []).add(song);
         }
       } catch (e, st) {
-        debugPrint(
+        devLog(
           '[PlaylistService] Skipping song during import matching: path="$filePath", error=$e',
         );
-        debugPrint('[PlaylistService] Song matching stack: $st');
+        devLog('[PlaylistService] Song matching stack: $st');
       }
     }
 
@@ -602,10 +603,10 @@ class PlaylistService {
           ids.add(match.id);
         }
       } catch (e, st) {
-        debugPrint(
+        devLog(
           '[PlaylistService] Failed to resolve playlist entry: "${entry.pathOrUri}", error=$e',
         );
-        debugPrint('[PlaylistService] Entry matching stack: $st');
+        devLog('[PlaylistService] Entry matching stack: $st');
         unmatched.add(entry.pathOrUri);
       }
     }
@@ -787,7 +788,7 @@ class PlaylistService {
       }
       return uri;
     } on FormatException catch (e) {
-      debugPrint('[PlaylistService] URI parse error for "$value": $e');
+      devLog('[PlaylistService] URI parse error for "$value": $e');
       return null;
     }
   }
@@ -796,7 +797,7 @@ class PlaylistService {
     try {
       return Uri.decodeFull(value);
     } on FormatException catch (e) {
-      debugPrint('[PlaylistService] URI decode error for "$value": $e');
+      devLog('[PlaylistService] URI decode error for "$value": $e');
       return value;
     }
   }

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
 import 'package:flick/services/uac2_preferences_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Playback state enum matching the Rust engine states.
 enum RustPlaybackState {
@@ -67,7 +68,7 @@ class RustAudioService {
 
     // Check if native audio is available on this platform
     if (!rust_audio.audioIsNativeAvailable()) {
-      debugPrint(
+      devLog(
         'Native audio engine not available (expected on mobile platforms)',
       );
       return false;
@@ -77,13 +78,13 @@ class RustAudioService {
       rust_audio.audioInit();
       rust_audio.audioSetHighResMode(enabled: _highResModeEnabled);
       _initialized = true;
-      debugPrint('Rust audio engine manager initialized');
+      devLog('Rust audio engine manager initialized');
 
       // Start event polling
       _startEventPolling();
       return true;
     } catch (e) {
-      debugPrint('Failed to initialize Rust audio engine: $e');
+      devLog('Failed to initialize Rust audio engine: $e');
       return false;
     }
   }
@@ -112,7 +113,7 @@ class RustAudioService {
         preferredSampleRate: preferredSampleRate,
       );
     } catch (e) {
-      debugPrint('Error detecting DAC availability: $e');
+      devLog('Error detecting DAC availability: $e');
       return false;
     }
   }
@@ -124,7 +125,7 @@ class RustAudioService {
     try {
       rust_audio.audioSetCapabilityInfo(info: info);
     } catch (e) {
-      debugPrint('Error updating audio capability info: $e');
+      devLog('Error updating audio capability info: $e');
     }
   }
 
@@ -146,7 +147,7 @@ class RustAudioService {
         preferredSampleRate: preferredSampleRate,
       );
     } catch (e) {
-      debugPrint('Error reading audio capability info: $e');
+      devLog('Error reading audio capability info: $e');
       return const rust_audio.AudioCapabilityInfo(
         capabilities: [rust_audio.AudioCapabilityType.standard],
         routeType: 'unknown',
@@ -182,7 +183,7 @@ class RustAudioService {
         preferredSampleRate: preferredSampleRate,
       );
     } catch (e) {
-      debugPrint('Error preparing Rust audio engine: $e');
+      devLog('Error preparing Rust audio engine: $e');
       rethrow;
     }
   }
@@ -201,7 +202,7 @@ class RustAudioService {
     try {
       return rust_audio.audioGetCurrentPath();
     } catch (e) {
-      debugPrint('Error getting current path: $e');
+      devLog('Error getting current path: $e');
       return _currentPath; // Fallback to cached value
     }
   }
@@ -517,7 +518,7 @@ class RustAudioService {
           onCrossfadeStarted?.call(fromPath, toPath);
         },
         error: (message) {
-          debugPrint('Rust audio error: $message');
+          devLog('Rust audio error: $message');
           onError?.call(message);
         },
         nextTrackReady: (path) {

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flick/services/uac2_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 enum Uac2FormatPreference { highestQuality, compatibility, custom }
 
@@ -51,7 +52,7 @@ class Uac2PreferencesService {
       });
       await prefs.setString(_keySelectedDevice, deviceJson);
     } catch (e) {
-      debugPrint('Failed to save selected device: $e');
+      devLog('Failed to save selected device: $e');
     }
   }
 
@@ -71,7 +72,7 @@ class Uac2PreferencesService {
         deviceName: map['deviceName'] as String?,
       );
     } catch (e) {
-      debugPrint('Failed to load selected device: $e');
+      devLog('Failed to load selected device: $e');
       return null;
     }
   }
@@ -81,7 +82,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_keySelectedDevice);
     } catch (e) {
-      debugPrint('Failed to clear selected device: $e');
+      devLog('Failed to clear selected device: $e');
     }
   }
 
@@ -91,7 +92,7 @@ class Uac2PreferencesService {
       final formatJson = jsonEncode(format.toJson());
       await prefs.setString(_keyPreferredFormat, formatJson);
     } catch (e) {
-      debugPrint('Failed to save preferred format: $e');
+      devLog('Failed to save preferred format: $e');
     }
   }
 
@@ -104,7 +105,7 @@ class Uac2PreferencesService {
       final map = jsonDecode(formatJson) as Map<String, dynamic>;
       return Uac2AudioFormat.fromJson(map);
     } catch (e) {
-      debugPrint('Failed to load preferred format: $e');
+      devLog('Failed to load preferred format: $e');
       return null;
     }
   }
@@ -114,7 +115,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_keyHiFiModeEnabled, enabled);
     } catch (e) {
-      debugPrint('Failed to save HiFi mode setting: $e');
+      devLog('Failed to save HiFi mode setting: $e');
     }
   }
 
@@ -123,7 +124,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getBool(_keyHiFiModeEnabled) ?? false;
     } catch (e) {
-      debugPrint('Failed to load HiFi mode setting: $e');
+      devLog('Failed to load HiFi mode setting: $e');
       return false;
     }
   }
@@ -134,7 +135,7 @@ class Uac2PreferencesService {
       await prefs.setBool(_keyBitPerfectEnabled, enabled);
       await prefs.setBool(_keyExclusiveDacModeEnabled, enabled);
     } catch (e) {
-      debugPrint('Failed to save bit-perfect mode setting: $e');
+      devLog('Failed to save bit-perfect mode setting: $e');
     }
   }
 
@@ -143,7 +144,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getBool(_keyBitPerfectEnabled) ?? false;
     } catch (e) {
-      debugPrint('Failed to load bit-perfect mode setting: $e');
+      devLog('Failed to load bit-perfect mode setting: $e');
       return false;
     }
   }
@@ -153,7 +154,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_keyDapBitPerfectEnabled, enabled);
     } catch (e) {
-      debugPrint('Failed to save Bit-perfect (DAP Internal) setting: $e');
+      devLog('Failed to save Bit-perfect (DAP Internal) setting: $e');
     }
   }
 
@@ -162,7 +163,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getBool(_keyDapBitPerfectEnabled) ?? true;
     } catch (e) {
-      debugPrint('Failed to load Bit-perfect (DAP Internal) setting: $e');
+      devLog('Failed to load Bit-perfect (DAP Internal) setting: $e');
       return true;
     }
   }
@@ -173,7 +174,7 @@ class Uac2PreferencesService {
       await prefs.setBool(_key432HzTuningEnabled, enabled);
       tuning432HzNotifier.value = enabled;
     } catch (e) {
-      debugPrint('Failed to save 432 Hz tuning setting: $e');
+      devLog('Failed to save 432 Hz tuning setting: $e');
     }
   }
 
@@ -186,7 +187,7 @@ class Uac2PreferencesService {
       }
       return enabled;
     } catch (e) {
-      debugPrint('Failed to load 432 Hz tuning setting: $e');
+      devLog('Failed to load 432 Hz tuning setting: $e');
       return tuning432HzNotifier.value;
     }
   }
@@ -213,7 +214,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_keyAudioEnginePreference, preference.name);
     } catch (e) {
-      debugPrint('Failed to save audio engine preference: $e');
+      devLog('Failed to save audio engine preference: $e');
     }
   }
 
@@ -228,7 +229,7 @@ class Uac2PreferencesService {
         orElse: () => AudioEnginePreference.exoPlayer,
       );
     } catch (e) {
-      debugPrint('Failed to load audio engine preference: $e');
+      devLog('Failed to load audio engine preference: $e');
       return AudioEnginePreference.exoPlayer;
     }
   }
@@ -238,6 +239,7 @@ class Uac2PreferencesService {
     if (developerModeNotifier.value != enabled) {
       developerModeNotifier.value = enabled;
     }
+    await Uac2Service.instance.syncDeveloperModeToNative();
   }
 
   Future<void> initializeKillIsochronousUsbOnQuitCache() async {
@@ -252,8 +254,9 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_keyDeveloperModeEnabled, enabled);
       developerModeNotifier.value = enabled;
+      await Uac2Service.instance.syncDeveloperModeToNative();
     } catch (e) {
-      debugPrint('Failed to save developer mode setting: $e');
+      devLog('Failed to save developer mode setting: $e');
     }
   }
 
@@ -266,7 +269,7 @@ class Uac2PreferencesService {
       }
       return enabled;
     } catch (e) {
-      debugPrint('Failed to load developer mode setting: $e');
+      devLog('Failed to load developer mode setting: $e');
       return developerModeNotifier.value;
     }
   }
@@ -276,7 +279,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_keyAudioFormatEnabled, enabled);
     } catch (e) {
-      debugPrint('Failed to save audio format setting: $e');
+      devLog('Failed to save audio format setting: $e');
     }
   }
 
@@ -285,7 +288,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getBool(_keyAudioFormatEnabled) ?? true;
     } catch (e) {
-      debugPrint('Failed to load audio format setting: $e');
+      devLog('Failed to load audio format setting: $e');
       return true;
     }
   }
@@ -295,7 +298,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_keyFormatPreference, preference.name);
     } catch (e) {
-      debugPrint('Failed to save format preference: $e');
+      devLog('Failed to save format preference: $e');
     }
   }
 
@@ -304,7 +307,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setDouble(_keyUsbSoftwareVolume, volume.clamp(0.0, 1.0));
     } catch (e) {
-      debugPrint('Failed to save USB software volume: $e');
+      devLog('Failed to save USB software volume: $e');
     }
   }
 
@@ -313,7 +316,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getDouble(_keyUsbSoftwareVolume) ?? 1.0;
     } catch (e) {
-      debugPrint('Failed to load USB software volume: $e');
+      devLog('Failed to load USB software volume: $e');
       return 1.0;
     }
   }
@@ -323,7 +326,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.containsKey(_keyUsbSoftwareVolume);
     } catch (e) {
-      debugPrint('Failed to check USB software volume key: $e');
+      devLog('Failed to check USB software volume key: $e');
       return false;
     }
   }
@@ -334,7 +337,7 @@ class Uac2PreferencesService {
       await prefs.setBool(_keyKillIsochronousUsbOnQuit, enabled);
       killIsochronousUsbOnQuitNotifier.value = enabled;
     } catch (e) {
-      debugPrint('Failed to save kill Isochronous USB on quit setting: $e');
+      devLog('Failed to save kill Isochronous USB on quit setting: $e');
     }
   }
 
@@ -347,7 +350,7 @@ class Uac2PreferencesService {
       }
       return enabled;
     } catch (e) {
-      debugPrint('Failed to load kill Isochronous USB on quit setting: $e');
+      devLog('Failed to load kill Isochronous USB on quit setting: $e');
       return killIsochronousUsbOnQuitNotifier.value;
     }
   }
@@ -357,7 +360,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_keyGaplessPlaybackEnabled, enabled);
     } catch (e) {
-      debugPrint('Failed to save gapless playback setting: $e');
+      devLog('Failed to save gapless playback setting: $e');
     }
   }
 
@@ -366,7 +369,7 @@ class Uac2PreferencesService {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getBool(_keyGaplessPlaybackEnabled) ?? true;
     } catch (e) {
-      debugPrint('Failed to load gapless playback setting: $e');
+      devLog('Failed to load gapless playback setting: $e');
       return true;
     }
   }
@@ -382,7 +385,7 @@ class Uac2PreferencesService {
         orElse: () => Uac2FormatPreference.highestQuality,
       );
     } catch (e) {
-      debugPrint('Failed to load format preference: $e');
+      devLog('Failed to load format preference: $e');
       return Uac2FormatPreference.highestQuality;
     }
   }
@@ -393,7 +396,7 @@ class Uac2PreferencesService {
       await prefs.setString(_keyDsdOutputMode, mode.name);
       dsdOutputModeNotifier.value = mode;
     } catch (e) {
-      debugPrint('Failed to save DSD output mode: $e');
+      devLog('Failed to save DSD output mode: $e');
     }
   }
 
@@ -410,7 +413,7 @@ class Uac2PreferencesService {
       dsdOutputModeNotifier.value = mode;
       return mode;
     } catch (e) {
-      debugPrint('Failed to load DSD output mode: $e');
+      devLog('Failed to load DSD output mode: $e');
       return DsdOutputMode.auto;
     }
   }
@@ -421,7 +424,7 @@ class Uac2PreferencesService {
       await prefs.setBool(_keyAutoSwitchDsdForVolume, value);
       autoSwitchDsdForVolumeNotifier.value = value;
     } catch (e) {
-      debugPrint('Failed to save auto-switch DSD for volume: $e');
+      devLog('Failed to save auto-switch DSD for volume: $e');
     }
   }
 
@@ -432,7 +435,7 @@ class Uac2PreferencesService {
       autoSwitchDsdForVolumeNotifier.value = value;
       return value;
     } catch (e) {
-      debugPrint('Failed to load auto-switch DSD for volume: $e');
+      devLog('Failed to load auto-switch DSD for volume: $e');
       return false;
     }
   }
@@ -461,7 +464,7 @@ class Uac2PreferencesService {
       killIsochronousUsbOnQuitNotifier.value = true;
       tuning432HzNotifier.value = false;
     } catch (e) {
-      debugPrint('Failed to clear preferences: $e');
+      devLog('Failed to clear preferences: $e');
     }
   }
 }

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -10,6 +10,7 @@ import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
 import 'package:flick/src/rust/api/uac2_api.dart' as rust_uac2;
 import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/services/uac2_exception.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 const Object _unset = Object();
 
@@ -165,7 +166,19 @@ class Uac2Service {
         'enabled': enabled,
       });
     } catch (e) {
-      debugPrint('Uac2Service.syncKillIsochronousUsbOnQuitToNative failed: $e');
+      devLog('Uac2Service.syncKillIsochronousUsbOnQuitToNative failed: $e');
+    }
+  }
+
+  Future<void> syncDeveloperModeToNative() async {
+    if (!Platform.isAndroid) return;
+    final enabled = Uac2PreferencesService.isDeveloperModeEnabledSync;
+    try {
+      await _channel.invokeMethod<bool>('setDeveloperMode', {
+        'enabled': enabled,
+      });
+    } catch (e) {
+      devLog('Uac2Service.syncDeveloperModeToNative failed: $e');
     }
   }
   Uac2DeviceStatus? _currentDeviceStatus;
@@ -308,7 +321,7 @@ class Uac2Service {
         requireActivatableDeviceName: false,
       );
       if (currentPlaybackDevice != null) {
-        debugPrint(
+        devLog(
           'Uac2Service.listDevices (Android): reusing frozen direct USB device '
           '${_describeAndroidDevice(currentPlaybackDevice)}',
         );
@@ -320,7 +333,7 @@ class Uac2Service {
     try {
       return rust_uac2.uac2ListDevices();
     } catch (e) {
-      debugPrint('Uac2Service.listDevices failed: $e');
+      devLog('Uac2Service.listDevices failed: $e');
       throw Uac2Exception.fromMessage(e.toString());
     }
   }
@@ -329,7 +342,7 @@ class Uac2Service {
     try {
       final raw = await _channel.invokeMethod<List<dynamic>>('listDevices');
       if (raw == null) {
-        debugPrint(
+        devLog(
           'Uac2Service.listDevices (Android): no UsbManager devices returned',
         );
         return [];
@@ -346,13 +359,13 @@ class Uac2Service {
           deviceName: deviceName,
         );
       }).toList();
-      debugPrint(
+      devLog(
         'Uac2Service.listDevices (Android): ${devices.length} candidate(s): '
         '${devices.map((device) => '${device.productName}@${device.deviceName}').join(', ')}',
       );
       return devices;
     } catch (e) {
-      debugPrint('Uac2Service.listDevices (Android) failed: $e');
+      devLog('Uac2Service.listDevices (Android) failed: $e');
       return [];
     }
   }
@@ -365,7 +378,7 @@ class Uac2Service {
       });
       return result ?? false;
     } catch (e) {
-      debugPrint('Uac2Service.hasPermission failed: $e');
+      devLog('Uac2Service.hasPermission failed: $e');
       return false;
     }
   }
@@ -378,7 +391,7 @@ class Uac2Service {
       });
       return result ?? false;
     } catch (e) {
-      debugPrint('Uac2Service.requestPermission failed: $e');
+      devLog('Uac2Service.requestPermission failed: $e');
       return false;
     }
   }
@@ -437,7 +450,7 @@ class Uac2Service {
         deviceType: 'DAC',
       );
     } catch (e) {
-      debugPrint('Uac2Service.getDeviceCapabilities failed: $e');
+      devLog('Uac2Service.getDeviceCapabilities failed: $e');
       return null;
     }
   }
@@ -535,7 +548,7 @@ class Uac2Service {
       );
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.selectDevice failed: $e');
+      devLog('Uac2Service.selectDevice failed: $e');
       _updateStatus(
         Uac2DeviceStatus(
           device: device,
@@ -559,7 +572,7 @@ class Uac2Service {
     final resolvedDevice = await _resolvePreferredAndroidActivationDevice(null);
     if (resolvedDevice == null ||
         !(resolvedDevice.deviceName?.isNotEmpty ?? false)) {
-      debugPrint(
+      devLog(
         'Uac2Service.prepareAndroidExperimentalUsbPlayback: no activatable '
         'USB DAC was resolved',
       );
@@ -578,7 +591,7 @@ class Uac2Service {
       disallowedSampleRates: disallowedSampleRates,
     );
     if (selectedFormat == null) {
-      debugPrint(
+      devLog(
         'Uac2Service.prepareAndroidExperimentalUsbPlayback: no compatible '
         'direct USB output format could be selected for requested '
         '${format.sampleRate}Hz/${format.bitDepth}-bit/${format.channels}ch',
@@ -590,7 +603,7 @@ class Uac2Service {
         selectedFormat.bitDepth != format.bitDepth ||
         selectedFormat.channels != format.channels;
     if (usingFallbackFormat) {
-      debugPrint(
+      devLog(
         'Uac2Service.prepareAndroidExperimentalUsbPlayback: using fallback '
         'direct USB output ${selectedFormat.sampleRate}Hz/'
         '${selectedFormat.bitDepth}-bit/${selectedFormat.channels}ch for '
@@ -611,7 +624,7 @@ class Uac2Service {
       if (!sampleRateSupported ||
           !bitDepthSupported ||
           !channelCountSupported) {
-        debugPrint(
+        devLog(
           'Uac2Service.prepareAndroidExperimentalUsbPlayback: requested '
           '${selectedFormat.sampleRate}Hz/${selectedFormat.bitDepth}-bit/'
           '${selectedFormat.channels}ch '
@@ -631,7 +644,7 @@ class Uac2Service {
             'isNativeDsd': selectedFormat.isNativeDsd,
           });
       if (applied != true) {
-        debugPrint(
+        devLog(
           'Uac2Service.setDirectUsbPlaybackFormat returned false for '
           '${selectedFormat.sampleRate}Hz/${selectedFormat.bitDepth}-bit/'
           '${selectedFormat.channels}ch',
@@ -639,7 +652,7 @@ class Uac2Service {
         return false;
       }
     } catch (e) {
-      debugPrint('Uac2Service.setDirectUsbPlaybackFormat failed: $e');
+      devLog('Uac2Service.setDirectUsbPlaybackFormat failed: $e');
       return false;
     }
 
@@ -782,7 +795,7 @@ class Uac2Service {
               'isNativeDsd': format.isNativeDsd,
             });
         if (applied != true) {
-          debugPrint(
+          devLog(
             'Uac2Service.resetAndroidDirectUsbPath format apply returned '
             'false for ${format.sampleRate}Hz/${format.bitDepth}-bit/'
             '${format.channels}ch',
@@ -790,7 +803,7 @@ class Uac2Service {
           return false;
         }
       } catch (e) {
-        debugPrint(
+        devLog(
           'Uac2Service.resetAndroidDirectUsbPath format apply failed: $e',
         );
         return false;
@@ -816,12 +829,12 @@ class Uac2Service {
     try {
       await _channel.invokeMethod<bool>('clearDirectUsbPlaybackFormat');
     } catch (e) {
-      debugPrint('Uac2Service.clearDirectUsbPlaybackFormat failed: $e');
+      devLog('Uac2Service.clearDirectUsbPlaybackFormat failed: $e');
     }
     try {
       await _channel.invokeMethod<bool>('deactivateDirectUsb');
     } catch (e) {
-      debugPrint('Uac2Service.deactivateDirectUsb failed: $e');
+      devLog('Uac2Service.deactivateDirectUsb failed: $e');
     }
 
     await _refreshAndroidRouteStatus(
@@ -842,7 +855,7 @@ Future<void> markAndroidDirectUsbFallback(String reason) async {
         'reason': reason,
       });
     } catch (e) {
-      debugPrint('Uac2Service.markAndroidDirectUsbFallback failed: $e');
+      devLog('Uac2Service.markAndroidDirectUsbFallback failed: $e');
     }
   }
 
@@ -851,7 +864,7 @@ Future<void> markAndroidDirectUsbFallback(String reason) async {
     try {
       await _channel.invokeMethod<bool>('startPriorityAnchor');
     } catch (e) {
-      debugPrint('Uac2Service.startPriorityAnchor failed: $e');
+      devLog('Uac2Service.startPriorityAnchor failed: $e');
     }
   }
 
@@ -860,7 +873,7 @@ Future<void> stopPriorityAnchor() async {
     try {
       await _channel.invokeMethod<bool>('stopPriorityAnchor');
     } catch (e) {
-      debugPrint('Uac2Service.stopPriorityAnchor failed: $e');
+      devLog('Uac2Service.stopPriorityAnchor failed: $e');
     }
   }
 
@@ -893,7 +906,7 @@ Future<void> stopPriorityAnchor() async {
       );
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.startStreaming failed: $e');
+      devLog('Uac2Service.startStreaming failed: $e');
       _updateStatus(
         _currentDeviceStatus!.copyWith(
           state: Uac2State.error,
@@ -932,7 +945,7 @@ Future<void> stopPriorityAnchor() async {
       );
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.stopStreaming failed: $e');
+      devLog('Uac2Service.stopStreaming failed: $e');
       return false;
     }
   }
@@ -946,14 +959,14 @@ Future<void> stopPriorityAnchor() async {
       }
       await _preferencesService.clearSelectedDevice();
     } catch (e) {
-      debugPrint('Uac2Service.disconnect failed: $e');
+      devLog('Uac2Service.disconnect failed: $e');
     } finally {
       if (Platform.isAndroid) {
         await _setAndroidDirectUsbPlaybackActive(false);
         try {
           await _channel.invokeMethod<bool>('deactivateDirectUsb');
         } catch (e) {
-          debugPrint('Uac2Service.deactivateDirectUsb failed: $e');
+          devLog('Uac2Service.deactivateDirectUsb failed: $e');
         }
         await _refreshAndroidRouteStatus(
           formatOverride: _lastKnownFormat,
@@ -991,7 +1004,7 @@ Future<void> stopPriorityAnchor() async {
       _updateStatus(_currentDeviceStatus!.copyWith(volume: volume));
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.setVolume failed: $e');
+      devLog('Uac2Service.setVolume failed: $e');
       return false;
     }
   }
@@ -1009,7 +1022,7 @@ Future<void> stopPriorityAnchor() async {
       if (result == 0) return false;
       return null; // -1 or any other value
     } catch (e) {
-      debugPrint('Uac2Service.verifyHardwareVolumeHealth failed: $e');
+      devLog('Uac2Service.verifyHardwareVolumeHealth failed: $e');
       return null;
     }
   }
@@ -1028,7 +1041,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetVolume();
     } catch (e) {
-      debugPrint('Uac2Service.getVolume failed: $e');
+      devLog('Uac2Service.getVolume failed: $e');
       return null;
     }
   }
@@ -1056,7 +1069,7 @@ Future<void> stopPriorityAnchor() async {
       _updateStatus(_currentDeviceStatus!.copyWith(muted: muted));
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.setMute failed: $e');
+      devLog('Uac2Service.setMute failed: $e');
       return false;
     }
   }
@@ -1075,7 +1088,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetMute();
     } catch (e) {
-      debugPrint('Uac2Service.getMute failed: $e');
+      devLog('Uac2Service.getMute failed: $e');
       return null;
     }
   }
@@ -1090,7 +1103,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetVolumeRange();
     } catch (e) {
-      debugPrint('Uac2Service.getVolumeRange failed: $e');
+      devLog('Uac2Service.getVolumeRange failed: $e');
       return null;
     }
   }
@@ -1106,7 +1119,7 @@ Future<void> stopPriorityAnchor() async {
       await rust_uac2.uac2SetSamplingFrequency(frequency: frequency);
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.setSamplingFrequency failed: $e');
+      devLog('Uac2Service.setSamplingFrequency failed: $e');
       return false;
     }
   }
@@ -1121,7 +1134,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetSamplingFrequency();
     } catch (e) {
-      debugPrint('Uac2Service.getSamplingFrequency failed: $e');
+      devLog('Uac2Service.getSamplingFrequency failed: $e');
       return null;
     }
   }
@@ -1134,7 +1147,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetConnectionState();
     } catch (e) {
-      debugPrint('Uac2Service.getConnectionState failed: $e');
+      devLog('Uac2Service.getConnectionState failed: $e');
       return null;
     }
   }
@@ -1148,7 +1161,7 @@ Future<void> stopPriorityAnchor() async {
       await rust_uac2.uac2SetAutoReconnect(enabled: enabled);
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.setAutoReconnect failed: $e');
+      devLog('Uac2Service.setAutoReconnect failed: $e');
       return false;
     }
   }
@@ -1161,7 +1174,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return false;
       return rust_uac2.uac2AttemptReconnect();
     } catch (e) {
-      debugPrint('Uac2Service.attemptReconnect failed: $e');
+      devLog('Uac2Service.attemptReconnect failed: $e');
       return false;
     }
   }
@@ -1174,7 +1187,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return null;
       return rust_uac2.uac2GetFallbackInfo();
     } catch (e) {
-      debugPrint('Uac2Service.getFallbackInfo failed: $e');
+      devLog('Uac2Service.getFallbackInfo failed: $e');
       return null;
     }
   }
@@ -1187,7 +1200,7 @@ Future<void> stopPriorityAnchor() async {
       if (!rust_uac2.uac2IsAvailable()) return false;
       return rust_uac2.uac2ActivateFallback();
     } catch (e) {
-      debugPrint('Uac2Service.activateFallback failed: $e');
+      devLog('Uac2Service.activateFallback failed: $e');
       return false;
     }
   }
@@ -1201,7 +1214,7 @@ Future<void> stopPriorityAnchor() async {
       await rust_uac2.uac2DeactivateFallback();
       return true;
     } catch (e) {
-      debugPrint('Uac2Service.deactivateFallback failed: $e');
+      devLog('Uac2Service.deactivateFallback failed: $e');
       return false;
     }
   }
@@ -1482,7 +1495,7 @@ Future<void> stopPriorityAnchor() async {
         maxSampleRate: (map['maxSupportedSampleRate'] as num?)?.toInt(),
       );
     } catch (e) {
-      debugPrint('Uac2Service.getAndroidAudioCapabilityInfo failed: $e');
+      devLog('Uac2Service.getAndroidAudioCapabilityInfo failed: $e');
       return const rust_audio.AudioCapabilityInfo(
         capabilities: [rust_audio.AudioCapabilityType.standard],
         routeType: 'unknown',
@@ -1535,14 +1548,14 @@ Future<void> stopPriorityAnchor() async {
             );
           }
         } catch (e) {
-          debugPrint(
+          devLog(
             'Uac2Service.getAndroidPlaybackDebugState JSON failed: $e',
           );
         }
       }
       return map;
     } catch (e) {
-      debugPrint('Uac2Service.getAndroidPlaybackDebugState failed: $e');
+      devLog('Uac2Service.getAndroidPlaybackDebugState failed: $e');
       return null;
     }
   }
@@ -1589,7 +1602,7 @@ Future<void> stopPriorityAnchor() async {
         resolvedPreferred,
         requireActivatableDeviceName: requireActivatableDeviceName,
       )) {
-        debugPrint(
+        devLog(
           'Uac2Service._resolvePreferredAndroidDevice: using explicit '
           'preferred device ${_describeAndroidDevice(resolvedPreferred)}',
         );
@@ -1606,7 +1619,7 @@ Future<void> stopPriorityAnchor() async {
         resolvedCurrentDevice,
         requireActivatableDeviceName: requireActivatableDeviceName,
       )) {
-        debugPrint(
+        devLog(
           'Uac2Service._resolvePreferredAndroidDevice: using current route '
           'device ${_describeAndroidDevice(resolvedCurrentDevice)}',
         );
@@ -1622,7 +1635,7 @@ Future<void> stopPriorityAnchor() async {
       resolvedStoredDevice,
       requireActivatableDeviceName: requireActivatableDeviceName,
     )) {
-      debugPrint(
+      devLog(
         'Uac2Service._resolvePreferredAndroidDevice: using stored device '
         '${_describeAndroidDevice(resolvedStoredDevice)}',
       );
@@ -1636,14 +1649,14 @@ Future<void> stopPriorityAnchor() async {
       discoveredDevice,
       requireActivatableDeviceName: requireActivatableDeviceName,
     )) {
-      debugPrint(
+      devLog(
         'Uac2Service._resolvePreferredAndroidDevice: discovered default '
         'device ${_describeAndroidDevice(discoveredDevice)}',
       );
       return discoveredDevice;
     }
 
-    debugPrint(
+    devLog(
       'Uac2Service._resolvePreferredAndroidDevice: no usable Android USB '
       'device resolved (requireDeviceName=$requireActivatableDeviceName)',
     );
@@ -1766,7 +1779,7 @@ Future<void> stopPriorityAnchor() async {
 
     final devices = await _listDevicesAndroid();
     if (devices.isEmpty) {
-      debugPrint(
+      devLog(
         'Uac2Service._discoverDefaultAndroidUsbDevice: no UsbManager audio devices found',
       );
       return null;
@@ -1780,7 +1793,7 @@ Future<void> stopPriorityAnchor() async {
         if (normalizedRouteLabel.contains(productName) ||
             (manufacturer.isNotEmpty &&
                 normalizedRouteLabel.contains(manufacturer))) {
-          debugPrint(
+          devLog(
             'Uac2Service._discoverDefaultAndroidUsbDevice matched route '
             'label "$routeLabelHint" to ${device.productName}',
           );
@@ -1789,7 +1802,7 @@ Future<void> stopPriorityAnchor() async {
       }
     }
 
-    debugPrint(
+    devLog(
       'Uac2Service._discoverDefaultAndroidUsbDevice falling back to first '
       'UsbManager DAC candidate: ${devices.first.productName}',
     );
@@ -1906,7 +1919,7 @@ Future<void> stopPriorityAnchor() async {
       });
       _lastDirectUsbPlaybackActive = active;
     } catch (e) {
-      debugPrint('Uac2Service.setDirectUsbPlaybackActive failed: $e');
+      devLog('Uac2Service.setDirectUsbPlaybackActive failed: $e');
     }
   }
 
@@ -1989,7 +2002,7 @@ Future<void> stopPriorityAnchor() async {
       if (raw == null) return null;
       return raw.map((key, value) => MapEntry(key.toString(), value));
     } catch (e) {
-      debugPrint('Uac2Service._getAndroidRouteStatus failed: $e');
+      devLog('Uac2Service._getAndroidRouteStatus failed: $e');
       return null;
     }
   }
@@ -2095,7 +2108,7 @@ Future<void> stopPriorityAnchor() async {
       );
       return result ?? true;
     } catch (e) {
-      debugPrint('Uac2Service.setBitPerfectEnabled failed: $e');
+      devLog('Uac2Service.setBitPerfectEnabled failed: $e');
       return false;
     }
   }

--- a/lib/services/visualizer_service.dart
+++ b/lib/services/visualizer_service.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Service that bridges Android's [Visualizer] API to Flutter FFT bar data.
 ///
@@ -46,7 +47,7 @@ class VisualizerService {
         return true;
       }
     } catch (e) {
-      debugPrint('[VisualizerService] attach failed: $e');
+      devLog('[VisualizerService] attach failed: $e');
     }
     _attached = false;
     return false;
@@ -66,7 +67,7 @@ class VisualizerService {
     try {
       await _methodChannel.invokeMethod('detachVisualizer');
     } catch (e) {
-      debugPrint('[VisualizerService] detach failed: $e');
+      devLog('[VisualizerService] detach failed: $e');
     }
   }
 
@@ -75,7 +76,7 @@ class VisualizerService {
     _eventSubscription = _eventChannel.receiveBroadcastStream().listen(
       _onFftData,
       onError: (Object e) {
-        debugPrint('[VisualizerService] event error: $e');
+        devLog('[VisualizerService] event error: $e');
         barHeightsNotifier.value = null;
       },
     );

--- a/lib/services/widget_intent_handler.dart
+++ b/lib/services/widget_intent_handler.dart
@@ -7,6 +7,7 @@ import 'package:home_widget/home_widget.dart';
 
 import '../models/song.dart';
 import '../providers/player_provider.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class WidgetIntentHandler {
   WidgetIntentHandler(this._ref, {VoidCallback? onOpenQueue})
@@ -50,10 +51,10 @@ class WidgetIntentHandler {
       } else if (uri.host == 'queue') {
         _onOpenQueue?.call();
       } else {
-        debugPrint('WidgetIntentHandler: unknown host ${uri.host}');
+        devLog('WidgetIntentHandler: unknown host ${uri.host}');
       }
     } catch (e, st) {
-      debugPrint('WidgetIntentHandler dispatch error: $e\n$st');
+      devLog('WidgetIntentHandler dispatch error: $e\n$st');
     }
   }
 
@@ -77,7 +78,7 @@ class WidgetIntentHandler {
         unawaited(_pushWidgetState());
         break;
       default:
-        debugPrint('WidgetIntentHandler: unknown player action $action');
+        devLog('WidgetIntentHandler: unknown player action $action');
     }
   }
 
@@ -97,7 +98,7 @@ class WidgetIntentHandler {
       }
       await HomeWidget.updateWidget(qualifiedAndroidName: _provider);
     } catch (e) {
-      debugPrint('WidgetIntentHandler: failed to push widget state: $e');
+      devLog('WidgetIntentHandler: failed to push widget state: $e');
     }
   }
 }

--- a/lib/services/widget_sync_service.dart
+++ b/lib/services/widget_sync_service.dart
@@ -8,6 +8,7 @@ import 'package:home_widget/home_widget.dart';
 import '../models/song.dart';
 import '../providers/player_provider.dart';
 import '../services/app_preferences_service.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 class WidgetSyncService {
   WidgetSyncService._();
@@ -102,7 +103,7 @@ class WidgetSyncService {
       _lastPushedSongId = song?.id;
       _lastPushedIsPlaying = state.isPlaying;
     } catch (e, st) {
-      debugPrint('WidgetSyncService push failed: $e\n$st');
+      devLog('WidgetSyncService push failed: $e\n$st');
     }
   }
 
@@ -114,7 +115,7 @@ class WidgetSyncService {
         qualifiedAndroidName: miniPlayerProvider,
       );
     } catch (e, st) {
-      debugPrint('WidgetSyncService pushPaused failed: $e\n$st');
+      devLog('WidgetSyncService pushPaused failed: $e\n$st');
     }
   }
 
@@ -133,7 +134,7 @@ class WidgetSyncService {
         qualifiedAndroidName: miniPlayerProvider,
       );
     } catch (e, st) {
-      debugPrint('WidgetSyncService pushKilled failed: $e\n$st');
+      devLog('WidgetSyncService pushKilled failed: $e\n$st');
     }
   }
 
@@ -172,7 +173,7 @@ class WidgetSyncService {
         qualifiedAndroidName: miniPlayerProvider,
       );
     } catch (e, st) {
-      debugPrint('WidgetSyncService pushCustomization failed: $e\n$st');
+      devLog('WidgetSyncService pushCustomization failed: $e\n$st');
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.18.0-beta.1+14
+version: 0.19.0-beta.1+15
 
 environment:
   sdk: ^3.10.4

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -3,6 +3,8 @@
 //! Decoding happens in a separate thread to avoid blocking the audio callback.
 //! Decoded samples are written to a ring buffer for consumption by the audio thread.
 
+use crate::dev_eprintln;
+
 use crate::audio::opus_decoder;
 use crate::audio::resampler::AudioResampler;
 use crate::audio::source::{AudioSource, SourceInfo, SourceProducer};
@@ -395,7 +397,7 @@ fn decode_thread(
             Ok(decoded) => decoded,
             Err(SymphoniaError::DecodeError(e)) => {
                 // Skip corrupted frames
-                eprintln!("Decode error (skipping frame): {}", e);
+                dev_eprintln!("Decode error (skipping frame): {}", e);
                 continue;
             }
             Err(e) => {
@@ -638,7 +640,7 @@ fn convert_to_interleaved_f32(buffer: &AudioBufferRef, output: &mut Vec<f32>) {
         }
         _ => {
             // Unsupported format - output silence
-            eprintln!("Unsupported audio buffer format");
+            dev_eprintln!("Unsupported audio buffer format");
         }
     }
 }

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -3,6 +3,8 @@
 //! The engine manages the audio output stream, handles commands from Dart,
 //! and coordinates decoding, resampling, and crossfading.
 
+use crate::dev_eprintln;
+
 use crate::audio::commands::{AudioCommand, AudioEvent, PlaybackProgress, PlaybackState};
 use crate::audio::crossfader::Crossfader;
 use crate::audio::decoder::DecoderThread;
@@ -599,7 +601,7 @@ pub fn create_audio_engine(
         .filter(|rate| device_supports_sample_rate(&device, channels as u16, *rate))
         .unwrap_or(sample_rate);
 
-    eprintln!(
+    dev_eprintln!(
         "Audio engine opening output device '{}' at {} Hz (preferred: {:?})",
         device.name().unwrap_or_else(|_| "unknown".to_string()),
         target_sample_rate,
@@ -657,20 +659,20 @@ pub fn create_audio_engine(
                     audio_callback(data, &callback_data_clone, &event_tx_clone);
                 },
                 |err| {
-                    eprintln!("Audio stream error: {}", err);
+                    dev_eprintln!("Audio stream error: {}", err);
                 },
                 None,
             ) {
                 Ok(s) => s,
                 Err(e) => {
-                    eprintln!("Failed to build audio stream: {}", e);
+                    dev_eprintln!("Failed to build audio stream: {}", e);
                     return;
                 }
             };
 
             // Start the stream
             if let Err(e) = stream.play() {
-                eprintln!("Failed to start audio stream: {}", e);
+                dev_eprintln!("Failed to start audio stream: {}", e);
                 return;
             }
 
@@ -1113,7 +1115,7 @@ pub fn create_audio_engine(
 
     #[cfg(feature = "uac2")]
     let channels = {
-        eprintln!(
+        dev_eprintln!(
             "create_audio_engine: requested_rate={} Hz, strategy={:?}, debug_state: registered={}, effective_rate={:?}, requested_rate={:?}, effective_ch={:?}, requested_ch={:?}",
             requested_sample_rate,
             desired_strategy,
@@ -1146,7 +1148,7 @@ pub fn create_audio_engine(
                 ANDROID_DIRECT_CHANNELS
             };
 
-            eprintln!(
+            dev_eprintln!(
                 "create_audio_engine: DAC registered, will attempt USB backend with {} channels (format_matches: effective={}, requested={})",
                 channels, effective_matches, requested_matches
             );
@@ -1501,7 +1503,7 @@ pub fn create_audio_engine(
             };
 
             if let Err(error) = stream.start() {
-                eprintln!("Failed to start Android managed output stream: {}", error);
+                dev_eprintln!("Failed to start Android managed output stream: {}", error);
                 let _ = event_tx.try_send(AudioEvent::Error {
                     message: format!("Failed to start Android managed output stream: {}", error),
                 });
@@ -1520,7 +1522,7 @@ pub fn create_audio_engine(
             );
 
             if let Err(error) = stream.stop() {
-                eprintln!("Failed to stop Android direct output stream: {}", error);
+                dev_eprintln!("Failed to stop Android direct output stream: {}", error);
             }
         });
 
@@ -1568,7 +1570,7 @@ impl AudioOutputCallback for AndroidOutputCallbackF32 {
         audio_stream: &mut dyn AudioOutputStreamSafe,
         error: oboe::Error,
     ) {
-        eprintln!(
+        dev_eprintln!(
             "Android managed output error before close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
             error,
             audio_stream.get_device_id(),
@@ -1583,7 +1585,7 @@ impl AudioOutputCallback for AndroidOutputCallbackF32 {
         audio_stream: &mut dyn AudioOutputStreamSafe,
         error: oboe::Error,
     ) {
-        eprintln!(
+        dev_eprintln!(
             "Android managed output error after close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
             error,
             audio_stream.get_device_id(),
@@ -1601,7 +1603,7 @@ impl AudioOutputCallback for AndroidOutputCallbackF32 {
         let required_samples = audio_data.len() * ANDROID_DIRECT_CHANNELS;
 
         if required_samples > self.scratch.len() {
-            eprintln!(
+            dev_eprintln!(
                 "[oboe] burst {} frames > scratch {} frames — growing scratch",
                 audio_data.len(),
                 self.scratch.len() / ANDROID_DIRECT_CHANNELS,
@@ -1652,7 +1654,7 @@ impl AudioOutputCallback for AndroidOutputCallbackI32 {
         audio_stream: &mut dyn AudioOutputStreamSafe,
         error: oboe::Error,
     ) {
-        eprintln!(
+        dev_eprintln!(
             "Android managed i32 output error before close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
             error,
             audio_stream.get_device_id(),
@@ -1667,7 +1669,7 @@ impl AudioOutputCallback for AndroidOutputCallbackI32 {
         audio_stream: &mut dyn AudioOutputStreamSafe,
         error: oboe::Error,
     ) {
-        eprintln!(
+        dev_eprintln!(
             "Android managed i32 output error after close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
             error,
             audio_stream.get_device_id(),
@@ -1685,7 +1687,7 @@ impl AudioOutputCallback for AndroidOutputCallbackI32 {
         let required_samples = audio_data.len() * ANDROID_DIRECT_CHANNELS;
 
         if required_samples > self.scratch.len() {
-            eprintln!(
+            dev_eprintln!(
                 "[oboe-i32] burst {} frames > scratch {} frames — growing scratch",
                 audio_data.len(),
                 self.scratch.len() / ANDROID_DIRECT_CHANNELS,
@@ -1855,7 +1857,7 @@ fn open_android_output_stream(
                             ),
                         };
 
-                    eprintln!(
+                    dev_eprintln!(
                         "Android managed output opened '{}' (id {}, type {:?}) requested {} Hz -> actual {} Hz, api {:?}, sharing {:?}, format {:?}, channels {:?}",
                         selected_device.product_name,
                         selected_device.id,
@@ -1932,7 +1934,7 @@ fn select_android_output_device(target_sample_rate: u32) -> Result<AudioDeviceIn
     });
 
     for device in &devices {
-        eprintln!(
+        dev_eprintln!(
             "Android output candidate '{}' (id {}, type {:?}, sample_rates={:?}, channel_counts={:?}, formats={:?})",
             device.product_name,
             device.id,
@@ -2061,7 +2063,7 @@ pub(crate) fn audio_callback(
         };
         let (read, old_source) = sources.read(output);
         if let Some(source) = old_source {
-            eprintln!(
+            dev_eprintln!(
                 "[dop] gapless transition (old={})",
                 source.info.path.display()
             );
@@ -2087,7 +2089,7 @@ pub(crate) fn audio_callback(
 
         let (read, old_source) = sources.read(output);
         if let Some(source) = old_source {
-            eprintln!(
+            dev_eprintln!(
                 "[crossfade] gapless transition (old={})",
                 source.info.path.display()
             );
@@ -2146,7 +2148,7 @@ pub(crate) fn audio_callback(
     };
 
     if crossfader.is_active() && sources.next_mut().is_some() {
-        eprintln!(
+        dev_eprintln!(
             "[crossfade] callback mixing — position={}/{}",
             crossfader.position(),
             crossfader.duration_samples()
@@ -2191,7 +2193,7 @@ pub(crate) fn audio_callback(
         let _ = crossfader.mix(&buf_a[..needed], &buf_b[..needed], output, channels);
 
         if !crossfader.is_active() {
-            eprintln!("[crossfade] DONE — advancing to next track");
+            dev_eprintln!("[crossfade] DONE — advancing to next track");
             drop(crossfader);
             if let Some(source) = sources.advance_to_next() {
                 let _ = data.finished_tracks.try_send(source);
@@ -2528,7 +2530,7 @@ fn command_processing_loop(
                         // since the next track was pre-queued, so the buffer
                         // should be full by now.
                         if sources.next_has_enough_buffer(0.0) {
-                            eprintln!(
+                            dev_eprintln!(
                                 "[crossfade] TRIGGERING! remaining={:.3}s threshold={:.1}s",
                                 remaining,
                                 crossfader.duration_secs()
@@ -2548,7 +2550,7 @@ fn command_processing_loop(
                                     .try_send(AudioEvent::CrossfadeStarted { from_path, to_path });
                             }
                         } else {
-                            eprintln!(
+                            dev_eprintln!(
                                 "[crossfade] DELAYED - next buffer insufficient, waiting for more data"
                             );
                         }
@@ -2562,7 +2564,7 @@ fn command_processing_loop(
                     .unwrap_or(-1.0);
                 let threshold = crossfader.duration_secs() as f64;
                 if remaining > 0.0 && remaining <= threshold * 3.0 {
-                    eprintln!(
+                    dev_eprintln!(
                         "[crossfade] NEAR: active={} has_next={} has_current={} next_buffered={} remaining={:.3}s threshold={:.1}s",
                         crossfader.is_active(),
                         sources.has_next(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,25 @@ use jni::{
 static ANDROID_APP_CONTEXT: OnceLock<GlobalRef> = OnceLock::new();
 
 #[cfg(target_os = "android")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(target_os = "android")]
+static DEVELOPER_MODE: AtomicBool = AtomicBool::new(false);
+#[cfg(not(target_os = "android"))]
+use std::sync::atomic::AtomicBool;
+#[cfg(not(target_os = "android"))]
+static DEVELOPER_MODE: AtomicBool = AtomicBool::new(true);
+
+#[macro_export]
+macro_rules! dev_eprintln {
+    ($($arg:tt)*) => {
+        if crate::DEVELOPER_MODE.load(std::sync::atomic::Ordering::Relaxed) {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+#[cfg(target_os = "android")]
 fn initialize_android_app_context<'local>(
     env: &mut JNIEnv<'local>,
     context: &JObject<'local>,
@@ -57,7 +76,7 @@ fn initialize_android_app_context<'local>(
 pub extern "system" fn JNI_OnLoad(_vm: JavaVM, _reserved: *mut c_void) -> jni::sys::jint {
     android_logger::init_once(
         android_logger::Config::default()
-            .with_max_level(log::LevelFilter::Debug)
+            .with_max_level(log::LevelFilter::Off)
             .with_tag("RustUSB"),
     );
     jni::JNIVersion::V6.into()
@@ -87,11 +106,11 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeInitRustAndroi
                     log::warn!("[ANDROID] Failed to detect device profile: {}", error);
                 }
             }
-            eprintln!("Rust Android audio context initialized");
+            dev_eprintln!("Rust Android audio context initialized");
             1
         }
         Err(error) => {
-            eprintln!("Failed to initialize Android app context: {}", error);
+            dev_eprintln!("Failed to initialize Android app context: {}", error);
             0
         }
     }
@@ -138,7 +157,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeRegisterRustDi
     ) {
         Ok(device) => device,
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "Failed to prepare Android direct USB DAC registration: {}",
                 error
             );
@@ -149,7 +168,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeRegisterRustDi
     match crate::uac2::register_android_usb_device(device) {
         Ok(()) => 1,
         Err(error) => {
-            eprintln!("Failed to register Android direct USB DAC: {}", error);
+            dev_eprintln!("Failed to register Android direct USB DAC: {}", error);
             0
         }
     }
@@ -205,7 +224,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDirectU
     match crate::uac2::set_android_usb_playback_format(playback_format) {
         Ok(()) => 1,
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "Failed to update Android direct USB playback format: {}",
                 error
             );
@@ -238,7 +257,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDirectU
     match crate::uac2::set_android_usb_lock_enabled(enabled != 0) {
         Ok(()) => 1,
         Err(error) => {
-            eprintln!("Failed to update Android direct USB lock state: {}", error);
+            dev_eprintln!("Failed to update Android direct USB lock state: {}", error);
             0
         }
     }
@@ -294,7 +313,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDirectU
     match crate::uac2::android_direct_set_hardware_volume(volume) {
         Ok(()) => 1,
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "Failed to set Android direct USB hardware volume: {}",
                 error
             );
@@ -345,7 +364,7 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDirectU
     match crate::uac2::android_direct_set_hardware_mute(muted != 0) {
         Ok(()) => 1,
         Err(error) => {
-            eprintln!("Failed to set Android direct USB hardware mute: {}", error);
+            dev_eprintln!("Failed to set Android direct USB hardware mute: {}", error);
             0
         }
     }
@@ -521,4 +540,20 @@ pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeIsRustDirectUs
     _activity: JObject<'_>,
 ) -> jboolean {
     0
+}
+
+#[cfg(target_os = "android")]
+#[no_mangle]
+pub extern "system" fn Java_com_mossapps_flick_MainActivity_nativeSetRustDeveloperMode(
+    _env: JNIEnv<'_>,
+    _activity: JObject<'_>,
+    enabled: jboolean,
+) {
+    DEVELOPER_MODE.store(enabled != 0, Ordering::Relaxed);
+    let level = if enabled != 0 {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Off
+    };
+    log::set_max_level(level);
 }

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -1,3 +1,5 @@
+use crate::dev_eprintln;
+
 use crate::audio::commands::AudioEvent;
 use crate::audio::engine::{audio_callback, AudioCallbackData};
 use crate::uac2::{iso_packet_scheduler::IsoPacketScheduler, AudioControlParser, DescriptorIter};
@@ -35,17 +37,17 @@ fn set_audio_thread_priority() -> Result<(), std::io::Error> {
         let result = libc::sched_setscheduler(0, libc::SCHED_FIFO, &param);
         if result != 0 {
             let err = std::io::Error::last_os_error();
-            eprintln!(
+            dev_eprintln!(
                 "[AudioSched] SCHED_FIFO failed (errno={}): {}",
                 err.raw_os_error().unwrap_or(-1),
                 err
             );
             libc::setpriority(libc::PRIO_PROCESS, 0, -16);
-            eprintln!("[AudioSched] set nice=-16");
+            dev_eprintln!("[AudioSched] set nice=-16");
             return Err(err);
         }
     }
-    eprintln!("[AudioSched] SCHED_FIFO priority=2 acquired");
+    dev_eprintln!("[AudioSched] SCHED_FIFO priority=2 acquired");
     Ok(())
 }
 
@@ -1022,7 +1024,7 @@ fn complete_pending_android_usb_clear_if_idle() {
         return;
     }
 
-    eprintln!("Android USB direct: applying deferred clear after session stop");
+    dev_eprintln!("Android USB direct: applying deferred clear after session stop");
     clear_android_usb_device_state();
 }
 
@@ -1030,7 +1032,7 @@ fn complete_pending_android_usb_clear_if_idle() {
 /// unrecoverable errors to ensure the next attempt can proceed.
 pub fn force_release_usb_session() {
     if USB_SESSION_ACTIVE.swap(false, Ordering::SeqCst) {
-        eprintln!("Android USB direct: force-released USB session guard");
+        dev_eprintln!("Android USB direct: force-released USB session guard");
     }
     complete_pending_android_usb_clear_if_idle();
 }
@@ -1040,7 +1042,7 @@ pub fn register_android_usb_device(device: AndroidDirectUsbDevice) -> Result<(),
     if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
         if let Some(current_state) = guard.as_ref() {
             if is_same_android_usb_device(&current_state.device, &device) {
-                eprintln!(
+                dev_eprintln!(
                     "Android USB direct: ignoring duplicate registration for '{}' while the session is active",
                     device.product_name
                 );
@@ -1122,7 +1124,7 @@ pub fn set_android_usb_playback_format(
         && state.playback_format == sanitized
         && state.requested_playback_format == sanitized
     {
-        eprintln!(
+        dev_eprintln!(
             "[USB] Keeping active direct USB verification state for unchanged playback format"
         );
         return Ok(());
@@ -1251,7 +1253,7 @@ pub fn set_android_usb_lock_enabled(enabled: bool) -> Result<(), String> {
 pub fn clear_android_usb_device() {
     USB_SESSION_CLEAR_PENDING.store(true, Ordering::SeqCst);
     if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
-        eprintln!("Android USB direct: deferring clear until the active session stops");
+        dev_eprintln!("Android USB direct: deferring clear until the active session stops");
         return;
     }
 
@@ -1323,7 +1325,7 @@ pub fn android_direct_debug_state() -> AndroidDirectUsbDebugState {
     let lifecycle_state = DIRECT_USB_LIFECYCLE_STATE.lock().clone();
     let usb_session_active = USB_SESSION_ACTIVE.load(Ordering::SeqCst);
     if usb_session_active {
-        eprintln!("Android USB direct debug: USB_SESSION_ACTIVE=true");
+        dev_eprintln!("Android USB direct debug: USB_SESSION_ACTIVE=true");
     }
 
     let Some(state) = state else {
@@ -1678,7 +1680,7 @@ fn negotiate_android_direct_playback_format(
                         reported_rate,
                     );
                     if let Some(message) = last_message {
-                        eprintln!("Android USB direct: {}", message);
+                        dev_eprintln!("Android USB direct: {}", message);
                     }
                     return Ok(requested_format);
                 }
@@ -1732,7 +1734,7 @@ fn negotiate_android_direct_playback_format(
                 requested_format.sample_rate,
             ) {
                 Ok(()) => {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] UAC1 SET_CUR: endpoint=0x{:02x} rate={}Hz",
                         candidate.endpoint_address, requested_format.sample_rate
                     );
@@ -1744,7 +1746,7 @@ fn negotiate_android_direct_playback_format(
                     ));
                 }
                 Err(e) => {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] UAC1 SET_CUR failed for endpoint=0x{:02x}: {}",
                         candidate.endpoint_address, e
                     );
@@ -1783,7 +1785,7 @@ fn negotiate_android_direct_playback_format(
                     actual_rate, requested_format.sample_rate
                 )
             };
-            eprintln!("{}", inferred_message);
+            dev_eprintln!("{}", inferred_message);
             last_message = Some(inferred_message);
         } else {
             let message = format!(
@@ -1804,7 +1806,7 @@ fn negotiate_android_direct_playback_format(
             reported_rate,
         );
         if let Some(message) = last_message {
-            eprintln!("Android USB direct: {}", message);
+            dev_eprintln!("Android USB direct: {}", message);
         }
         Ok(effective_format)
     })();
@@ -1955,7 +1957,7 @@ fn sanitize_android_usb_playback_format(
 fn prepare_direct_usb_libusb() {
     DIRECT_USB_DISCOVERY_DISABLED.call_once(|| {
         if let Err(error) = disable_device_discovery() {
-            eprintln!(
+            dev_eprintln!(
                 "Android USB direct: failed to disable libusb device discovery: {}",
                 error
             );
@@ -2072,12 +2074,12 @@ fn set_android_usb_engine_state(state: AndroidDirectUsbEngineState, reason: Opti
     lifecycle_state.engine_state = state;
     lifecycle_state.reason = reason;
     if previous != state {
-        eprintln!(
+        dev_eprintln!(
             "Android USB direct engine state: {:?} -> {:?}",
             previous, state
         );
     }
-    eprintln!(
+    dev_eprintln!(
         "[USB][STATE] {}{}",
         android_direct_usb_engine_state_label(state),
         lifecycle_state
@@ -2214,7 +2216,7 @@ impl AndroidDirectUsbClaimedHandle {
 
 fn configure_kernel_driver_detach(handle: &DeviceHandle<Context>) {
     if !supports_detach_kernel_driver() {
-        eprintln!(
+        dev_eprintln!(
             "Android USB direct: libusb kernel-driver detach is not supported on this platform"
         );
         return;
@@ -2222,15 +2224,15 @@ fn configure_kernel_driver_detach(handle: &DeviceHandle<Context>) {
 
     match handle.set_auto_detach_kernel_driver(true) {
         Ok(()) => {
-            eprintln!("Android USB direct: enabled libusb auto-detach for claimed interfaces");
+            dev_eprintln!("Android USB direct: enabled libusb auto-detach for claimed interfaces");
         }
         Err(UsbError::NotSupported) => {
-            eprintln!(
+            dev_eprintln!(
                 "Android USB direct: libusb auto-detach is not supported for this device handle"
             );
         }
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "Android USB direct: failed to enable libusb auto-detach: {}",
                 error
             );
@@ -2272,7 +2274,7 @@ fn claim_interface_with_recovery(
                 }
 
                 if let Ok(()) = handle.claim_interface(interface_number) {
-                    eprintln!(
+                    dev_eprintln!(
                         "Android USB direct claimed interface {} after kernel-driver recovery",
                         interface_number
                     );
@@ -2284,7 +2286,7 @@ fn claim_interface_with_recovery(
                 thread::sleep(Duration::from_millis(CLAIM_RETRY_DELAY_MS));
                 match handle.claim_interface(interface_number) {
                     Ok(()) => {
-                        eprintln!(
+                        dev_eprintln!(
                             "Android USB direct claimed interface {} on retry {} after {}ms settle",
                             interface_number,
                             attempt,
@@ -2754,7 +2756,7 @@ fn refresh_android_usb_hardware_volume_snapshot_with_handle(
                 return Ok((normalized, muted));
             }
             Err(e) => {
-                eprintln!("[VolFlow] GET_CUR attempt {} failed: {e}", attempt + 1);
+                dev_eprintln!("[VolFlow] GET_CUR attempt {} failed: {e}", attempt + 1);
                 last_err = Some(e);
                 if attempt < GET_CUR_RETRIES - 1 {
                     std::thread::sleep(Duration::from_millis(RETRY_DELAY_MS));
@@ -2799,7 +2801,7 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
         .clone()
         .ok_or_else(|| "Android direct USB hardware volume is unavailable".to_string())?;
     let claimed_handle = open_transient_usb_handle(&state.device)
-        .inspect_err(|e| eprintln!("[VolFlow] open_transient_usb_handle failed: {e}"))?;
+        .inspect_err(|e| dev_eprintln!("[VolFlow] open_transient_usb_handle failed: {e}"))?;
 
     let target_raw = quantize_hardware_volume(
         volume,
@@ -2807,7 +2809,7 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
         control.max_volume_raw,
         control.resolution_raw,
     );
-    eprintln!(
+    dev_eprintln!(
         "[VolFlow] min={} max={} res={} -> raw={target_raw}",
         control.min_volume_raw, control.max_volume_raw, control.resolution_raw
     );
@@ -2819,11 +2821,11 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
         UAC2_FEATURE_UNIT_VOLUME_CONTROL,
         target_raw,
     );
-    write_result.inspect_err(|e| eprintln!("[VolFlow] write_feature_unit failed: {e}"))?;
+    write_result.inspect_err(|e| dev_eprintln!("[VolFlow] write_feature_unit failed: {e}"))?;
 
     let (normalized, muted) =
         refresh_android_usb_hardware_volume_snapshot_with_handle(&claimed_handle.handle, &control)
-            .inspect_err(|e| eprintln!("[VolFlow] refresh_snapshot failed: {e}"))?;
+            .inspect_err(|e| dev_eprintln!("[VolFlow] refresh_snapshot failed: {e}"))?;
 
     let expected = quantize_then_normalize(volume, &control);
     let step = if control.resolution_raw > 0 {
@@ -2834,7 +2836,7 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
     let span = ((control.max_volume_raw - control.min_volume_raw) as f64).max(1.0);
     let tolerance = (step / span * 0.6).max(1e-6);
     if (normalized - expected).abs() > tolerance {
-        eprintln!(
+        dev_eprintln!(
             "[VolFlow] post-SET_CUR volume mismatch: expected={expected:.3} got={normalized:.3}"
         );
         return Err(format!(
@@ -2845,7 +2847,7 @@ pub fn android_direct_set_hardware_volume(volume: f64) -> Result<(), String> {
 
     LAST_SET_HW_VOLUME.store(target_raw, Ordering::Release);
     set_hardware_volume_snapshot(Some(normalized), muted);
-    eprintln!("[VolFlow] SET_CUR OK: normalized={normalized:.3}");
+    dev_eprintln!("[VolFlow] SET_CUR OK: normalized={normalized:.3}");
     Ok(())
 }
 
@@ -2864,7 +2866,7 @@ pub fn android_direct_verify_hardware_volume_health() -> Result<bool, String> {
         .clone()
         .ok_or_else(|| "Android direct USB hardware volume is unavailable".to_string())?;
     let claimed_handle = open_transient_usb_handle(&state.device)
-        .inspect_err(|e| eprintln!("[VolFlow] health: open_transient_usb_handle failed: {e}"))?;
+        .inspect_err(|e| dev_eprintln!("[VolFlow] health: open_transient_usb_handle failed: {e}"))?;
 
     let current_raw = read_feature_unit_i16_control(
         &claimed_handle.handle,
@@ -2874,11 +2876,11 @@ pub fn android_direct_verify_hardware_volume_health() -> Result<bool, String> {
         UAC2_REQUEST_GET_CUR,
         UAC2_FEATURE_UNIT_VOLUME_CONTROL,
     )
-    .inspect_err(|e| eprintln!("[VolFlow] health: GET_CUR failed: {e}"))?;
+    .inspect_err(|e| dev_eprintln!("[VolFlow] health: GET_CUR failed: {e}"))?;
 
     let expected_raw = LAST_SET_HW_VOLUME.load(Ordering::Acquire);
     if current_raw != expected_raw {
-        eprintln!(
+        dev_eprintln!(
             "[VolFlow] HEALTH CHECK FAILED: expected_raw={} got_raw={}",
             expected_raw, current_raw
         );
@@ -3080,7 +3082,7 @@ fn ensure_android_usb_idle_lock() -> Result<(), String> {
         claimed_handle.ensure_interface_claimed(interface_number)?;
     }
 
-    eprintln!(
+    dev_eprintln!(
         "Android USB direct idle lock claimed '{}' interfaces {:?}",
         state.device.product_name, claimed_handle.claimed_interfaces
     );
@@ -3095,7 +3097,7 @@ pub fn create_android_usb_backend(
     preferred_sample_rate: u32,
 ) -> Result<Option<AndroidDirectUsbBackend>, String> {
     if USB_SESSION_CLEAR_PENDING.load(Ordering::SeqCst) {
-        eprintln!(
+        dev_eprintln!(
             "Android USB direct backend skipped: clear requested before startup for preferred {} Hz",
             preferred_sample_rate
         );
@@ -3110,13 +3112,13 @@ pub fn create_android_usb_backend(
             break;
         }
         if attempt == 0 {
-            eprintln!("Android USB direct: previous session still active, waiting for cleanup...");
+            dev_eprintln!("Android USB direct: previous session still active, waiting for cleanup...");
         }
         thread::sleep(Duration::from_millis(100));
     }
 
     if USB_SESSION_ACTIVE.swap(true, Ordering::SeqCst) {
-        eprintln!("Android USB direct: force-releasing stale USB session guard");
+        dev_eprintln!("Android USB direct: force-releasing stale USB session guard");
         force_release_usb_session();
         USB_SESSION_ACTIVE.store(true, Ordering::SeqCst);
     }
@@ -3142,7 +3144,7 @@ fn create_android_usb_backend_inner(
     let (state, playback_format, use_requested_playback_format) = {
         let guard = DIRECT_USB_STATE.lock();
         let Some(state) = guard.as_ref() else {
-            eprintln!(
+            dev_eprintln!(
                 "Android USB direct backend skipped: no registered DAC state for preferred {} Hz",
                 preferred_sample_rate
             );
@@ -3153,7 +3155,7 @@ fn create_android_usb_backend_inner(
             return Ok(None);
         };
         let Some(effective_playback_format) = state.playback_format else {
-            eprintln!(
+            dev_eprintln!(
                 "Android USB direct backend skipped: no effective playback format is configured for '{}' (preferred {} Hz, requested {:?})",
                 state.device.product_name,
                 preferred_sample_rate,
@@ -3174,7 +3176,7 @@ fn create_android_usb_backend_inner(
         {
             (effective_playback_format, false)
         } else if requested_playback_format.sample_rate == preferred_sample_rate {
-            eprintln!(
+            dev_eprintln!(
                     "Android USB direct backend: preferred {} Hz matched requested playback format for '{}' while effective playback format was {} Hz; using requested format",
                     preferred_sample_rate,
                     state.device.product_name,
@@ -3182,7 +3184,7 @@ fn create_android_usb_backend_inner(
                 );
             (requested_playback_format, true)
         } else {
-            eprintln!(
+            dev_eprintln!(
                     "Android USB direct backend skipped: preferred {} Hz did not match effective {} Hz or requested {} Hz for '{}'",
                     preferred_sample_rate,
                     effective_playback_format.sample_rate,
@@ -3246,7 +3248,7 @@ fn create_android_usb_backend_inner(
         ),
         None => "Clock NOT FOUND: no UAC2 clock entity in any AudioControl descriptor".to_string(),
     };
-    eprintln!(
+    dev_eprintln!(
         "[USB] Clock entity for '{}': {}",
         state.device.product_name, clock_detection_msg
     );
@@ -3315,7 +3317,7 @@ fn create_android_usb_backend_inner(
             .and_then(|status| status.reported_sample_rate),
     );
 
-    eprintln!(
+    dev_eprintln!(
         "[USB] Candidate device='{}' mode={:?} requested={}Hz effective={}Hz resampling={} endpoint=0x{:02x} interface={} alt={} clock={} feedbackEndpoint={} sync={:?} usage={:?} service={}us maxPacket={} speed={:?} fmt={} channels={} subslot={} bitResolution={} sampleRates={:?}",
         state.device.product_name,
         state.dac_mode,
@@ -3346,7 +3348,7 @@ fn create_android_usb_backend_inner(
         candidate.sample_rates,
     );
 
-    eprintln!(
+    dev_eprintln!(
         "[USB] Interface={} alt={} endpoint=0x{:02x} syncAddress=0x{:02x} interval={} serviceIntervalUs={} refresh={}",
         candidate.interface_number,
         candidate.alt_setting,
@@ -3422,11 +3424,11 @@ fn create_android_usb_backend_inner(
                     clock.interface_number,
                     clock_outcome.message.as_ref().map(|m| format!(", msg={}", m)).unwrap_or_default(),
                 );
-                eprintln!("{}", clock_result_msg);
+                dev_eprintln!("{}", clock_result_msg);
                 set_last_error(Some(clock_result_msg));
 
                 if !clock_outcome.clock_ok {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] SET_CUR {}Hz -> FAILED: DAC reported={}Hz, verified={}",
                         playback_format.sample_rate,
                         clock_outcome.reported_sample_rate.unwrap_or(0),
@@ -3435,14 +3437,14 @@ fn create_android_usb_backend_inner(
                 }
 
                 if clock_outcome.known_mismatch {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] SET_CUR {}Hz -> MISMATCH: DAC reports {}Hz",
                         playback_format.sample_rate,
                         clock_outcome.reported_sample_rate.unwrap_or_default(),
                     );
                 }
 
-                eprintln!(
+                dev_eprintln!(
                     "[USB] VALIDATION: usbClaimed={}, alt={}, endpoint=0x{:02x}, requestedRate={}Hz, dacRate={}Hz, verified={}",
                     claimed_handle.claimed_interfaces.contains(&candidate.interface_number),
                     candidate.alt_setting,
@@ -3473,8 +3475,8 @@ fn create_android_usb_backend_inner(
                             false,
                             Some(actual_rate),
                         );
-                        eprintln!("{}", message);
-                        eprintln!(
+                        dev_eprintln!("{}", message);
+                        dev_eprintln!(
                             "[USB] Actual sample rate={}Hz verified=false (reported by DAC, requested {}Hz)",
                             actual_rate,
                             playback_format.sample_rate,
@@ -3492,12 +3494,12 @@ fn create_android_usb_backend_inner(
                     {
                         reported_sample_rate = Some(playback_format.sample_rate);
                         clock_verification_passed = true;
-                        eprintln!(
+                        dev_eprintln!(
                             "Android USB direct: using GET_RANGE-verified fixed clock {} Hz on alt setting {} without SET_CUR",
                             playback_format.sample_rate, candidate.alt_setting
                         );
                     } else {
-                        eprintln!(
+                        dev_eprintln!(
                             "[USB] Cannot verify fixed clock {}Hz for alt {} from GET_RANGE — will refuse streaming",
                             playback_format.sample_rate, candidate.alt_setting,
                         );
@@ -3511,7 +3513,7 @@ fn create_android_usb_backend_inner(
                         );
                     }
                 } else {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] Cannot verify fixed clock {}Hz for alt {} because GET_RANGE is unavailable — will refuse streaming",
                         playback_format.sample_rate, candidate.alt_setting,
                     );
@@ -3546,7 +3548,7 @@ fn create_android_usb_backend_inner(
             false,
             None,
         );
-        eprintln!("{}", message);
+        dev_eprintln!("{}", message);
         set_last_error(Some(message));
     }
 
@@ -3625,12 +3627,12 @@ fn create_android_usb_backend_inner(
             clock.clock_id,
         ) {
             Ok(post_alt_rate) => {
-                eprintln!(
+                dev_eprintln!(
                     "[USB] GET_CUR (post-alt): clock {} reports {}Hz (expected {}Hz)",
                     clock.clock_id, post_alt_rate, playback_format.sample_rate,
                 );
                 if post_alt_rate != playback_format.sample_rate {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] DAC clock drifted after alt-setting change ({} -> {}Hz); re-issuing SET_CUR",
                         playback_format.sample_rate, post_alt_rate,
                     );
@@ -3652,7 +3654,7 @@ fn create_android_usb_backend_inner(
                         clock_verification_passed,
                         reported_sample_rate,
                     );
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] Re-SET_CUR result: clockOk={}, verified={}, reported={}Hz",
                         retry.clock_ok,
                         clock_verification_passed,
@@ -3661,7 +3663,7 @@ fn create_android_usb_backend_inner(
                 }
             }
             Err(error) => {
-                eprintln!(
+                dev_eprintln!(
                     "[USB] GET_CUR (post-alt): failed for clock {}: {}",
                     clock.clock_id, error,
                 );
@@ -3669,7 +3671,7 @@ fn create_android_usb_backend_inner(
         }
     }
 
-    eprintln!(
+    dev_eprintln!(
         "Android USB direct output opened '{}' requested {} Hz / {}-bit / {} ch, transport {} / {} ch / {}-byte subslot on endpoint 0x{:02x} (interface {}, alt {}, speed {:?})",
         state.device.product_name,
         playback_format.sample_rate,
@@ -3703,7 +3705,7 @@ fn create_android_usb_backend_inner(
             clock_control_attempted,
             clock_control_succeeded,
         );
-        eprintln!("[USB] {}", refusal);
+        dev_eprintln!("[USB] {}", refusal);
         set_last_error(Some(refusal.clone()));
         set_direct_mode_refusal_reason(Some(refusal.clone()));
         set_android_usb_engine_state(AndroidDirectUsbEngineState::Error, Some(refusal.clone()));
@@ -3721,7 +3723,7 @@ fn create_android_usb_backend_inner(
                 "USB direct refused: DAC clock mismatch (requested {}Hz, reported {}Hz)",
                 playback_format.sample_rate, rate,
             );
-            eprintln!("[USB] {}", refusal);
+            dev_eprintln!("[USB] {}", refusal);
             set_last_error(Some(refusal.clone()));
             set_direct_mode_refusal_reason(Some(refusal.clone()));
             set_android_usb_engine_state(AndroidDirectUsbEngineState::Error, Some(refusal.clone()));
@@ -3740,7 +3742,7 @@ fn create_android_usb_backend_inner(
             "USB direct refused: zero-size frame (subslot={}, channels={})",
             candidate.subslot_size, candidate.channels,
         );
-        eprintln!("[USB] {}", refusal);
+        dev_eprintln!("[USB] {}", refusal);
         set_last_error(Some(refusal.clone()));
         set_direct_mode_refusal_reason(Some(refusal.clone()));
         cleanup_claimed_handle(
@@ -3751,29 +3753,29 @@ fn create_android_usb_backend_inner(
         return Err(refusal);
     }
 
-    eprintln!("[USB] === PRE-STREAM VALIDATION ===");
-    eprintln!(
+    dev_eprintln!("[USB] === PRE-STREAM VALIDATION ===");
+    dev_eprintln!(
         "[USB]   requested_rate  = {}Hz",
         playback_format.sample_rate
     );
-    eprintln!(
+    dev_eprintln!(
         "[USB]   dac_reported    = {}Hz",
         reported_sample_rate.unwrap_or(0)
     );
-    eprintln!("[USB]   clock_verified  = {}", clock_verification_passed);
-    eprintln!("[USB]   bit_depth       = {}", playback_format.bit_depth);
-    eprintln!("[USB]   channels        = {}", playback_format.channels);
-    eprintln!("[USB]   subslot_size    = {} bytes", candidate.subslot_size);
-    eprintln!("[USB]   bytes_per_frame = {}", bytes_per_frame);
-    eprintln!(
+    dev_eprintln!("[USB]   clock_verified  = {}", clock_verification_passed);
+    dev_eprintln!("[USB]   bit_depth       = {}", playback_format.bit_depth);
+    dev_eprintln!("[USB]   channels        = {}", playback_format.channels);
+    dev_eprintln!("[USB]   subslot_size    = {} bytes", candidate.subslot_size);
+    dev_eprintln!("[USB]   bytes_per_frame = {}", bytes_per_frame);
+    dev_eprintln!(
         "[USB]   interval_us     = {}",
         candidate.service_interval_us
     );
-    eprintln!(
+    dev_eprintln!(
         "[USB]   max_packet_size = {} bytes",
         candidate.max_packet_bytes
     );
-    eprintln!("[USB] ============================");
+    dev_eprintln!("[USB] ============================");
     log_info!(
         "[USB] FINAL_STREAM_FORMAT: sample_rate_hz={} dac_reported_hz={:?} clock_verified={} \
          app_bit_depth={} transport_bit_resolution={} subslot_bytes={} channels={} \
@@ -3832,7 +3834,7 @@ fn create_android_usb_backend_inner(
         .spawn(move || {
             #[cfg(target_os = "android")]
             if set_audio_thread_priority().is_err() {
-                eprintln!("[AudioSched] Render thread running without SCHED_FIFO");
+                dev_eprintln!("[AudioSched] Render thread running without SCHED_FIFO");
             }
             run_usb_render_loop(
                 producer_callback_data,
@@ -3878,7 +3880,7 @@ fn create_android_usb_backend_inner(
         .spawn(move || {
             #[cfg(target_os = "android")]
             if set_audio_thread_priority().is_err() {
-                eprintln!("[AudioSched] Output thread running without SCHED_FIFO");
+                dev_eprintln!("[AudioSched] Output thread running without SCHED_FIFO");
             }
             run_usb_output_loop(
                 claimed_handle,
@@ -3915,7 +3917,7 @@ fn create_android_usb_backend_inner(
         DsdTransportMode::DoP => "DoP",
         DsdTransportMode::None => "None",
     };
-    eprintln!(
+    dev_eprintln!(
         "[USB] Streaming started device='{}' preferred={}Hz effective={}Hz requested={}Hz endpoint=0x{:02x} interface={} alt={} sample_rate={}Hz dsd_transport={}",
         backend_product_name,
         preferred_sample_rate,
@@ -3999,7 +4001,7 @@ fn run_usb_render_loop(
         audio_callback(&mut render_buffer, &callback_data, &event_tx);
         if cycle_start.elapsed() > chunk_deadline {
             let count = crate::audio::engine::XRUN_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
-            eprintln!(
+            dev_eprintln!(
                 "[Xrun] render cycle overrun: {:.1}ms > {}ms (total={})",
                 cycle_start.elapsed().as_secs_f64() * 1000.0,
                 ANDROID_USB_RENDER_CHUNK_MS,
@@ -4009,7 +4011,7 @@ fn run_usb_render_loop(
         if render_buffer.is_empty() {
             if !warned_no_frames {
                 let message = "USB stream active but no PCM frames received".to_string();
-                eprintln!("Android USB direct: {}", message);
+                dev_eprintln!("Android USB direct: {}", message);
                 set_last_error(Some(message));
                 warned_no_frames = true;
             }
@@ -4025,7 +4027,7 @@ fn run_usb_render_loop(
             convert_f32_to_pcm_samples(&render_buffer, &mut pcm_samples, playback_format.bit_depth)
         {
             let message = format!("Android USB direct PCM render conversion failed: {}", error);
-            eprintln!("{}", message);
+            dev_eprintln!("{}", message);
             set_last_error(Some(message.clone()));
             set_android_usb_engine_state(AndroidDirectUsbEngineState::Error, Some(message.clone()));
             let _ = event_tx.try_send(AudioEvent::Error { message });
@@ -4623,7 +4625,7 @@ fn run_usb_output_loop(
                             .update_feedback_frames_per_packet(feedback_report.frames_per_packet);
                         feedback_report_count = feedback_report_count.saturating_add(1);
                         if feedback_report_count <= 4 || feedback_report_count % 128 == 0 {
-                            eprintln!(
+                            dev_eprintln!(
                                 "[USB] Feedback endpoint 0x{:02x} {} bytes={:02x?} framesPerPacket={:.4} sampleRate≈{:.2}Hz",
                                 feedback_endpoint.address,
                                 transfer_type_label(feedback_endpoint.transfer_type),
@@ -4635,7 +4637,7 @@ fn run_usb_output_loop(
                     }
                     Ok(None) => {}
                     Err(error) => {
-                        eprintln!(
+                        dev_eprintln!(
                             "[USB] Feedback endpoint 0x{:02x} read failed: {}",
                             feedback_endpoint.address, error
                         );
@@ -4754,7 +4756,7 @@ fn run_usb_output_loop(
         let _ = event_tx.try_send(AudioEvent::Error {
             message: error.clone(),
         });
-        eprintln!("{}", error);
+        dev_eprintln!("{}", error);
     }
 
     drain_iso_transfer_slots(&context, &mut slots);
@@ -4967,7 +4969,7 @@ fn select_stream_candidate(
                     continue;
                 }
                 if endpoint.interval() == 0 {
-                    eprintln!(
+                    dev_eprintln!(
                         "Android USB direct skipping invalid isochronous endpoint=0x{:02x} on interface {} alt {} because bInterval=0",
                         endpoint.address(),
                         descriptor.interface_number(),
@@ -4996,7 +4998,7 @@ fn select_stream_candidate(
                     bytes_per_frame,
                 );
 
-                eprintln!(
+                dev_eprintln!(
                     "Android USB direct stream candidate interface={} alt={} endpoint=0x{:02x} interval={} service={}us max_packet={} required={} sync={:?} usage={:?} fmt={} channels={} subslot={} bit_resolution={} sample_rates={:?} penalty={}",
                     descriptor.interface_number(),
                     descriptor.setting_number(),
@@ -5016,7 +5018,7 @@ fn select_stream_candidate(
                 );
 
                 if endpoint.synch_address() != 0 && feedback_endpoint.is_none() {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] Skipping async endpoint=0x{:02x} on interface {} alt {} because feedback endpoint 0x{:02x} was not found",
                         endpoint.address(),
                         descriptor.interface_number(),
@@ -5173,7 +5175,7 @@ fn find_audio_control_clock(
             }
 
             let extra = descriptor.extra();
-            eprintln!(
+            dev_eprintln!(
                 "[USB] AudioControl interface {} alt {} extra bytes: {} bytes",
                 descriptor.interface_number(),
                 descriptor.setting_number(),
@@ -5181,7 +5183,7 @@ fn find_audio_control_clock(
             );
 
             if extra.is_empty() {
-                eprintln!(
+                dev_eprintln!(
                     "[USB] AudioControl interface {} has empty extra bytes; \
                      attempting raw GET_DESCRIPTOR fallback",
                     descriptor.interface_number(),
@@ -5216,7 +5218,7 @@ fn find_audio_control_clock(
                         UAC2_INPUT_TERMINAL | UAC2_OUTPUT_TERMINAL if length >= 8 => {
                             let terminal_id = extra[index + 3];
                             let c_source_id = extra[index + 7];
-                            eprintln!(
+                            dev_eprintln!(
                                 "[USB] Terminal id={} subtype={} -> bCSourceID={}",
                                 terminal_id,
                                 if desc_subtype == UAC2_INPUT_TERMINAL {
@@ -5230,7 +5232,7 @@ fn find_audio_control_clock(
                         }
                         UAC2_CLOCK_SOURCE if length >= 4 => {
                             let clock_id = extra[index + 3];
-                            eprintln!(
+                            dev_eprintln!(
                                 "[USB] Clock Source id={} on AC interface {}",
                                 clock_id, ac_iface,
                             );
@@ -5249,7 +5251,7 @@ fn find_audio_control_clock(
                 {
                     // Verify this c_source_id is actually a clock source.
                     if clock_source_ids.iter().any(|(cid, _)| *cid == c_source_id) {
-                        eprintln!(
+                        dev_eprintln!(
                             "[USB] Clock resolved via topology: bTerminalLink={} -> bCSourceID={} on AC interface {}",
                             tl, c_source_id, ac_iface,
                         );
@@ -5258,12 +5260,12 @@ fn find_audio_control_clock(
                             clock_id: c_source_id,
                         });
                     }
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] Terminal {} references bCSourceID={} but no matching Clock Source entity found; falling back",
                         tl, c_source_id,
                     );
                 } else {
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] bTerminalLink={} not found in AC descriptor terminals; falling back to first clock",
                         tl,
                     );
@@ -5272,7 +5274,7 @@ fn find_audio_control_clock(
 
             // Fallback: return the first Clock Source entity.
             if let Some(&(clock_id, iface)) = clock_source_ids.first() {
-                eprintln!(
+                dev_eprintln!(
                     "[USB] Using first Clock Source id={} on AC interface {} (fallback)",
                     clock_id, iface,
                 );
@@ -5284,7 +5286,7 @@ fn find_audio_control_clock(
         }
     }
 
-    eprintln!("[USB] No AudioControl clock source entity found in any interface descriptor");
+    dev_eprintln!("[USB] No AudioControl clock source entity found in any interface descriptor");
     None
 }
 
@@ -5592,7 +5594,7 @@ fn discover_stream_sample_rate_ranges(
     match get_sampling_frequency_ranges(handle, clock.interface_number, clock.clock_id) {
         Ok(ranges) => ranges,
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "[USB] GET_RANGE probe failed for streaming interface {} via clock {} on AC interface {}: {}",
                 streaming_interface_number,
                 clock.clock_id,
@@ -5717,13 +5719,13 @@ fn apply_sampling_frequency(
     // reprogrammed by another app / alt-setting change.
     match get_sampling_frequency(handle, interface_number, clock_id) {
         Ok(current_rate) => {
-            eprintln!(
+            dev_eprintln!(
                 "[USB] GET_CUR (pre-SET): clock {} on interface {} reports {}Hz (target={}Hz)",
                 clock_id, interface_number, current_rate, sample_rate,
             );
         }
         Err(error) => {
-            eprintln!(
+            dev_eprintln!(
                 "[USB] GET_CUR (pre-SET): failed for clock {} on interface {}: {}",
                 clock_id, interface_number, error,
             );
@@ -5762,14 +5764,14 @@ fn apply_sampling_frequency(
                     // Rate verified — also check clock validity if supported.
                     let clock_valid = match get_clock_validity(handle, interface_number, clock_id) {
                         Ok(valid) => {
-                            eprintln!(
+                            dev_eprintln!(
                                 "[USB] Clock Validity: clock {} valid={} (after SET_CUR {}Hz)",
                                 clock_id, valid, sample_rate,
                             );
                             Some(valid)
                         }
                         Err(e) => {
-                            eprintln!(
+                            dev_eprintln!(
                                 "[USB] Clock Validity: not supported for clock {} ({}); assuming valid",
                                 clock_id, e,
                             );
@@ -5777,14 +5779,14 @@ fn apply_sampling_frequency(
                         }
                     };
                     if clock_valid == Some(false) {
-                        eprintln!(
+                        dev_eprintln!(
                             "[USB] Clock {} reports INVALID after SET_CUR {}Hz; retrying",
                             clock_id, sample_rate,
                         );
                         thread::sleep(Duration::from_millis(settle_delay_ms));
                         continue;
                     }
-                    eprintln!(
+                    dev_eprintln!(
                         "[USB] SET_CUR verified: {} Hz on clock {} interface {} after attempt {}",
                         sample_rate, clock_id, interface_number, attempt,
                     );


### PR DESCRIPTION
# Summary

- Add full ListenBrainz scrobble service with API client, auth, rate limiting, offline queue, Riverpod providers, and settings tile
- Add developer mode with conditional logging utility (`devLog`) replacing all `debugPrint`/`eprintln!` across 30+ Dart and Rust files
- Add paginated loading with smart date grouping to recently played screen
- Add static MediaStore file removal method and delete song from repository before file deletion
- Add confirmation dialog before enabling 432 Hz tuning
- Bump version to `0.19.0-beta.1+15`

# Changes

## ListenBrainz Scrobbling

- Add ListenBrainz API client (164 lines) with rate limit handling
- Add `ListenBrainzAuthService` (74 lines) for token validation and session management
- Add `ListenBrainzCredentials` class for token and username storage
- Add freezed models for ListenBrainz session and listen entries (592 lines generated)
- Add offline-safe scrobble queue (106 lines) with SharedPreferences persistence
- Add `ListenBrainzScrobbleService` (126 lines) for tracking playback
- Add Riverpod providers (586 lines generated) with settings, auth, and scrobbling
- Add ListenBrainz settings tile (793 lines) with token input and status display
- Add scrobbling on track start/end and app resume
- Add ListenBrainz to integrations settings screen

## Developer Mode Logging

- Add `devLog` utility function for conditional debug logging
- Add developer mode with JNI method toggle in `MainActivity`
- Add developer mode preference to Rust FFI
- Replace all `eprintln!` with `dev_eprintln!` across Android Direct USB and audio engine modules
- Replace all `debugPrint` calls with `devLog` across 30+ Dart services, providers, and widgets

## Recently Played

- Refactor `getRecentHistory` to support pagination
- Add paginated loading and smart date grouping to recently played screen (486 lines rewritten)
- Make song info reactive in bottom sheet actions

## Song Deletion

- Add static method to remove file from MediaStore
- Delete song from repository before file deletion for safer cleanup

## UI & Preferences

- Add confirmation dialog before enabling 432 Hz tuning in UAC2 preferences
- Refactor full player screen (491 lines changed) with improved responsive layout

## Version

- Bump version to `0.19.0-beta.1+15`

## Files Changed

- `pubspec.yaml`
- `lib/app/app.dart`
- `lib/main.dart`
- `lib/core/utils/dev_log.dart`
- `lib/services/player_service.dart`
- `lib/services/player_provider.dart`
- `lib/providers/lastfm_provider.dart`
- `lib/providers/listenbrainz_provider.dart`
- `lib/providers/listenbrainz_provider.g.dart`
- `lib/providers/providers.dart`
- `lib/services/listenbrainz/listenbrainz_api_client.dart`
- `lib/services/listenbrainz/listenbrainz_auth_service.dart`
- `lib/services/listenbrainz/listenbrainz_credentials.dart`
- `lib/services/listenbrainz/listenbrainz_models.dart`
- `lib/services/listenbrainz/listenbrainz_models.freezed.dart`
- `lib/services/listenbrainz/listenbrainz_models.g.dart`
- `lib/services/listenbrainz/listenbrainz_scrobble_service.dart`
- `lib/services/listenbrainz/listenbrainz_scrobble_queue.dart`
- `lib/features/settings/widgets/listenbrainz_settings_tile.dart`
- `lib/features/settings/screens/integrations_settings_screen.dart`
- `lib/features/settings/screens/settings_screen.dart`
- `lib/features/settings/screens/uac2_preferences_screen.dart`
- `lib/features/songs/screens/songs_screen.dart`
- `lib/features/songs/widgets/song_actions_bottom_sheet.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/player/widgets/ambient_background.dart`
- `lib/features/recap/screens/listening_recap_screen.dart`
- `lib/data/repositories/recently_played_repository.dart`
- `lib/services/music_folder_service.dart`
- `rust/src/lib.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/audio/decoder.rs`
- `rust/src/audio/engine.rs`
- `android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt`
- Plus 30+ other Dart files with `debugPrint` → `devLog` replacements