### PR TITLE
Improve USB audio with isochronous feedback and AAudio handling, add wrap-around queue, rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Flick
----
+
 <p align="center">
   <img src="docs/app_screenshots/flick_banner.png" alt="Flick Banner" width="100%">
 </p>
@@ -11,369 +11,52 @@
 </p>
 
 ---
-Flick is an Android music player built with Flutter and Rust. The Rust engine handles bit-perfect PCM, native DSD, and DoP output to USB DACs and the DAP internal audio path, with a DSP chain (EQ, convolution reverb, crossfade).
 
-> **GitHub Releases**: builds at [GitHub Releases](https://github.com/anomalyco/opencode/releases) or the [Google Play Store](https://play.google.com/store/apps/details?id=com.mossapps.flick).
+An Android music player with a Rust audio engine. Bit-perfect PCM and native DSD to USB DACs, hi-res on DAPs, plus a full DSP chain.
 
-## Key Features
+Builds at [GitHub Releases](https://github.com/moss-apps/flick) or the [Play Store](https://play.google.com/store/apps/details?id=com.mossapps.flick).
 
-### Audio Engine
-- Rust audio engine; UAC 2.0 USB DAC support for bit-perfect PCM and native DSD
-- DSD bit order per source format (LSB/MSB); per-DAC quirk overrides (byte order, bit reverse, subslot size) from a unified quirk DB
-- I32 integer AAudio streams for DoP/DSD on DAP internal paths — raw bit patterns, no format conversion
-- DAP bit-perfect via Oboe/AAudio exclusive mode on qualified devices (FiiO, iBasso, HiBy, Shanling, Astell&Kern, Cayin, Sony Walkman)
-- `just_audio` fallback where USB audio is unsupported
-- 31-band parametric EQ (20 Hz–20 kHz, 1/3-octave) with preamp; preset import/export (JSON/TXT)
-- Dynamics (compressor/limiter), spatial/time FX, playback speed (0.5×–2.0×)
-- Convolution reverb from impulse-response WAV files (`convolver_enable`/`convolver_mix`/`convolver_load_ir`/`convolver_clear`)
-- Crossfade between tracks with selectable `CrossfadeCurve`; pending config held in atomics, survives engine recreation
-- Gapless playback
-- Bluetooth: A2DP codec info + battery level, low-latency mode (Rust Oboe), pause-on-disconnect, reconnect resume, Android 12+ connect permission
-- DSD playback (experimental): Native, DoP, PCM decimation for DSF/DFF/WavPack DSD
-- Manual engine selector with auto-detection
+## What it does
 
-### USB Audio Class 2.0 (UAC 2.0)
-- Rust implementation for USB DAC/AMP detection and enumeration
-- Android-side detection with keyword matching and AudioManager fallback
-- Audio Control and Audio Streaming interface descriptor parsing
-- Isochronous transfer engine for direct USB access; standard playback routes through Android's native USB DAC handling
-- Hot-plug detection with toast notifications
-- Bit-perfect PCM and native DSD bitstream delivery to external USB DACs
-- USB volume popup (slider + mute) for isochronous USB engines
-- Scoring-based output strategy selection
-- DAP signature registry for device detection (brand/model)
-- Unified quirk DB: per-device DSD transport overrides (byte order, bit order, byte reverse, subslot size) synced to the Rust engine before playback (e.g. MOONDROP Dawn Pro). 24-bit USB DoP uses corrected bits-per-frame; UAC2 alt-settings probed for DSD/DoP capability before stream start
-- UAC2 feature and multi-byte DSD slots active by default
+- **Rust audio engine** — bit-perfect USB DAC output (UAC 2.0), native DSD (DSF/DFF/WavPack), DoP, and DAP hi-res via Oboe/AAudio exclusive mode. Falls back to Android's standard pipeline when needed.
+- **31-band parametric EQ** with dynamics (compressor/limiter), convolution reverb from IR files, crossfade, and gapless playback.
+- **Library** — MediaStore scanner with differential sync, removable storage (SD/USB) via SAF, metadata editing that writes back to files, album art from MusicBrainz/iTunes/Deezer. CUE sheet support, EAC rip logs, duplicate detection.
+- **Lyrics** — search via LRCLib.net, synced LRC editor, plain text fallback.
+- **Widgets** — mini player, compact, and full-size widgets that work when the app is killed.
+- **Flick Replay** — daily/weekly/monthly/yearly listening recaps you can save as PNG.
+- **Last.fm scrobbling**, adaptive theming from album art, star ratings, sleep timer, waveform seek bar, FFT visualizer, vinyl disc animation.
+- Receives playback handoffs from [Latch](https://github.com/moss-apps/Latch).
 
-### Equalizer & Audio Effects
-- 31-band parametric EQ with preamp
-- Dynamics (compressor/limiter), spatial and time FX (balance, tempo, damp, filter, delay, size, mix, feedback, width)
-- Preset import/export (JSON/TXT)
-- Convolution reverb (IR WAV files) with dry/wet mix, on the equalizer screen
-- Android processing via `JustAudioProcessingController`
-- Visualizer: five animation styles (Bars, Wave, Curved Wave, Mirrored, Dots), five frequency modes, three movement styles, album-dominant-color preview
+## Tech
 
-### Library Management
-- MediaStore-based scanning with differential DB sync (~34× faster than filesystem walk)
-- Removable storage (SD/USB) scanning via Android SAF with per-volume MediaStore support; `FolderEntity` carries `isRemovable`, `mediaStoreVolume`, `volumeState`; unmount events fall back to instant SAF scan
-- Background metadata extraction; `MediaStoreObserverService` for live updates
-- Metadata via `lofty` (ID3, Vorbis comments) with DSD parsers (`dsf-meta`, `dff-meta`) for DSF/DFF/WavPack DSD
-- Isar database for library queries
-- Browse by songs, albums, artists, folders, playlists, favorites, recently played
-- Album list view with multi-select and queue-all
-- Album art import from MusicBrainz/Cover Art Archive, iTunes, Deezer
-- Delete songs from library or delete files
-- Android SAF content URIs staged to cache for playback (ALAC/AIFF/M4A via WAV conversion)
-- EAC-style rip log metadata (ripper, read mode, AccurateRip, CRCs) per track
-- CUE sheet track offset support
-- Duplicate detection and cleanup
-- Folder grid view with pagination
-- Swipe actions on song cards (queue / favorite; toggleable)
-- Multi-select (long-press) with batch queue/favorite
-- Metadata editor (title, artist, album, year, genre, track) via Rust with SAF writes; verified writes, pre-save validation, temp-file rollback, persisted write URI permission
-- Album/folder sorting (title, artist, duration, track count) with persistent prefs
-- Artist detail: Riverpod, dynamic color theming from album art, full-bleed image, cached `ArtistEntity`
-- Playlist detail: color theming from most-played song's art, info chips, "Other Playlists" section
+Flutter (Riverpod, just_audio, Isar) on the frontend. Rust (Symphonia, rusb, cpal/Oboe, lofty) on the backend, bridged with flutter_rust_bridge. Android-only, minSdk 26.
 
-### Playback
-- Shuffle and repeat (off / one / all)
-- Playback speed (0.5×–2.0×)
-- Sleep timer
-- Waveform seek bar
-- Audio visualizer: FFT-based, real mode via Android Visualizer API + simulated fallback
-- Queue management: Now Playing / Up Next / Manual, multi-select, batch remove, drag reorder, swipe dismiss
-- Online lyrics search (synced LRC or plain text) via LRCLib.net
-- Lyrics Sync Studio: timestamp editor, Simple and Advanced modes, time-shift, file import
-- Immersive full view: auto-hiding controls, full-bleed album art
-- Vinyl disc morph: tap album art to spin a radial-gradient vinyl
-- Star ratings (1–5) with animated overlay
-- Song sharing as album art / lyric / minimal / solid color cards
-- Custom player action buttons (left/right slots: rating, share, lyrics, shuffle, etc.)
-- Milestone tracking: songs played (100/500/1000), listen time (10/50h), per-tier accents, collection view (Settings → Milestones)
-- Day streaks with flame popup + snooze; unique-artist milestone; emerald tier; category-grouped milestones
+## Build
 
-### Home Screen Widget
-- Mini player widget: album art, progress bar, transport controls; scrim overlay tracks album art presence
-- Compact 2×2 widget (`CompactWidgetProvider`) with its own preferences tab
-- Flagship widget: larger card and split-layout with theme support
-- Works when the app is killed
-- Customizable background opacity, accent, content visibility (Settings → Widgets)
-- Tabbed widget settings with swipe + animated transitions
-
-### Flick Replay (Listening Recap)
-- Daily, weekly, monthly, yearly recaps
-- Hero cards: total plays, top song, listen time, active days, peak hour
-- Ranked top songs and top artists posters
-- Poster backgrounds: default gradient, blurred album art, camera photos
-- Save recaps to gallery as PNG
-
-### Ecosystem Integration
-- Part of the Moss app ecosystem
-- Latch integration: receives playback handoffs from Latch
-- Cross-app playback from external sources via Latch
-- Shared infrastructure: Last.fm scrobbling, adaptive theming, library scanning across Moss apps
-
-### User Interface
-- Adaptive theme from album artwork colors
-- Glassmorphism elements
-- Mini player and full player screens
-- Visualizer toggle in full player (replaces album art)
-- High refresh rate support (90 Hz/120 Hz)
-- Responsive layout
-- Immersive full view
-- Player layout customization (artwork scale, text size/placement, metadata visibility)
-- Reorderable bottom nav (show/hide per button)
-- Fast index: collapsible alphabetical scroll overlay
-
-### In-App Updates
-- Google Play InAppUpdate API
-- Automatic update checks when online
-- Manual scan/install from settings
-- Flexible (background) updates
-- Patch notes from GitHub Releases API
-
-### Support & Donations
-- In-app donation screen (Play Store fees, audio testing gear, DSD development)
-- Ko-fi donations
-- Heart button in settings header
-
-## Moss Ecosystem
-
-Flick is part of the **Moss ecosystem** — a suite of interconnected apps sharing infrastructure.
-
-### Apps
-- **Flick**: audiophile music player with UAC 2.0 support
-- **Latch**: [moss-apps/Latch](https://github.com/moss-apps/Latch)
-
-### Cross-App Integration
-Flick integrates with other Moss apps via platform channels:
-- **Playback handoff**: receives songs from Latch via `ExternalPlaybackService`
-- **Shared audio infrastructure**: audio processing, EQ, library scanning are shared across Moss apps
-- **Last.fm**: scrobbling continues regardless of which app initiated playback
-
-### Using Flick with Latch
-To switch a song playing in Latch to Flick's audio engine (EQ, effects, UAC 2.0 DAC):
-1. The playback intent routes to Flick
-2. Flick handles metadata extraction and playback
-3. Last.fm scrobbling continues
-
-## Roadmap
-
-- MQA support
-- Poweramp-style EQ filters (incl. low-pass)
-- Android audio settings
-- Internal hi-res audio settings
-- USB audio tweaks
-- Themes and broader UI customization
-- Further performance optimizations
-
-## Technology Stack
-
-### Frontend (Flutter)
-| Package | Purpose |
-|---------|---------|
-| `flutter_riverpod` | State management |
-| `just_audio` | Audio playback (Android) |
-| `isar_community` | Local database |
-| `flutter_rust_bridge` | Rust/Flutter FFI |
-| `rive` | Complex animations |
-| `fl_chart` | Equalizer visualization |
-| `flutter_cache_manager` | Image caching |
-| `freezed` | Immutable data classes |
-| `in_app_update` | Google Play In-App Updates |
-| `home_widget` | Android home screen widget |
-| `image_picker` | Camera/photo selection |
-| `permission_handler` | Runtime permissions |
-
-### Backend (Rust)
-| Crate | Purpose |
-|-------|--------|
-| `symphonia` | Audio decoding (MP3, FLAC, WAV, OGG, M4A/ALAC, AIFF) |
-| `rusb` | USB device access (UAC 2.0) |
-| `lofty` | Audio metadata parsing (MP3, FLAC, WAV, OGG, M4A/ALAC, AIFF, WavPack) |
-| `dsf-meta` | DSF file metadata reading |
-| `dff-meta` | DFF/DSDIFF file metadata reading |
-| `id3` | ID3 tag access for DSD formats |
-| `wavpack-sys` | WavPack DSD decoding (FFI to libwavpack) |
-| `cpal` | Cross-platform audio I/O (Oboe/AAudio on Android) |
-| `oboe` | Low-latency Android audio (CPAL backend) |
-| `rubato` | Sample rate conversion |
-| `rayon` | Parallel processing |
-| `ringbuf` | Lock-free ring buffer |
-| `crossbeam-channel` | Multi-threaded message passing |
-| `tracing` | Logging and diagnostics |
-
-## Project Structure
-
-```
-flick_player/
-├── lib/                          # Flutter/Dart source
-│   ├── main.dart                 # Application entry point
-│   ├── app/                      # Main app shell widget
-│   ├── core/                     # Constants, themes, utilities
-│   ├── data/                     # Database and repositories
-│   ├── features/                 # Feature modules
-│   │   ├── albums/               # Albums browsing
-│   │   ├── artists/              # Artists browsing
-│   │   ├── favorites/            # Favorites management
-│   │   ├── folders/              # Folder browser
-│   │   ├── player/               # Player screens and widgets
-│   │   │   ├── screens/
-│   │   │   │   └── full_player_screen.dart    # Full player with visualizer toggle
-│   │   │   └── widgets/
-│   │   │       ├── audio_visualizer.dart      # FFT-based 48-bar visualizer
-│   │   │       ├── waveform_seek_bar.dart     # Waveform seek bar
-│   │   │       └── ...
-│   │   ├── playlists/            # Playlist management
-│   │   ├── recently_played/      # Recently played tracks
-│   │   ├── recap/                # Flick Replay (listening recaps)
-│   │   │   └── screens/
-│   │   │       └── listening_recap_screen.dart  # Recap with poster generation
-│   │   ├── settings/             # Settings and equalizer
-│   │   │   ├── equalizer_screen.dart     # Equalizer UI with preset management
-│   │   │   └── ...                       # Other settings screens
-│   │   └── songs/                # Song library
-│   │       └── widgets/
-│   │           └── song_actions_bottom_sheet.dart  # Song actions with delete
-│   ├── models/                   # Data models
-│   ├── providers/                # Riverpod providers
-│   ├── services/                 # Business logic services
-│   │   ├── album_art_import_service.dart     # Online album art (MusicBrainz/iTunes/Deezer)
-│   │   ├── eq_preset_service.dart            # EQ preset management
-│   │   ├── eq_preset_file_service.dart       # EQ preset import/export (JSON/TXT)
-│   │   ├── equalizer_service.dart            # EQ and FX application
-│   │   ├── android_audio_processing_service.dart # Android audio processing
-│   │   ├── player_service.dart               # Playback control
-│   │   ├── uac2_service.dart                 # USB audio device management
-│   │   ├── visualizer_service.dart           # Android Visualizer FFT bridge
-│   │   ├── lyrics_service.dart               # Lyrics loading, parsing, editing
-│   │   ├── online_lyrics_service.dart        # LRCLib.net lyrics search
-│   │   ├── widget_sync_service.dart          # Home screen widget state sync
-│   │   ├── bluetooth_service.dart            # Bluetooth device/codec management
-│   │   └── widget_intent_handler.dart        # Widget action dispatch
-│   └── widgets/                 # Reusable widgets
-├── rust/                         # Rust backend
-│   └── src/
-│       ├── api/                  # FFI API bindings
-│       ├── audio/                # Audio engine
-│       │   ├── engine.rs         # Core audio engine
-│       │   ├── decoder.rs        # PCM decoder (Symphonia)
-│       │   ├── decoder_handle.rs # Decoder dispatch
-│       │   ├── dsd_engine/       # DSD decoding (DSF, DFF, WavPack)
-│       │   │   ├── dsd_thread.rs
-│       │   │   └── format/       # DSF, DFF, WavPack decoders
-│       │   ├── resampler.rs      # Sample rate conversion
-│       │   ├── equalizer.rs      # 31-band parametric EQ
-│       │   ├── fx.rs             # Spatial and time effects
-│       │   ├── convolver/        # Direct-time-domain IR convolution reverb
-│       │   ├── dynamics.rs       # Compressor/limiter
-│       │   ├── crossfader.rs     # Crossfade engine (CrossfadeCurve)
-│       │   ├── source.rs         # Gapless playback queue
-│       │   └── strategy.rs       # Output strategy selection
-│       └── uac2/                 # USB Audio Class 2.0
-│           ├── device.rs         # Device representation
-│           ├── backend.rs        # USB backend
-│           ├── connection_manager.rs
-│           ├── capabilities.rs   # Device capability detection
-│           ├── format_negotiation.rs
-│           ├── descriptors/      # USB descriptor parsing
-│           ├── transfer.rs       # Isochronous transfers
-│           └── audio_pipeline.rs # Format conversion
-├── test/                         # Test files
-│   └── services/
-│       └── eq_preset_file_service_test.dart # EQ preset file service tests
-├── docs/                         # Architecture documentation
-├── android/                      # Android platform code
-│   ├── app/src/main/kotlin/com/ultraelectronica/flick/
-│   │   ├── MainActivity.kt               # Android entry point + content URI staging
-│   │   └── audiofx/
-│   │       └── JustAudioProcessingController.kt # Android audio effects
-│   └── copy_ndk_libs.sh         # NDK libc++_shared.so copier
-└── pubspec.yaml                  # Flutter dependencies
-```
-
-## Getting Started
-
-### Prerequisites
-- Flutter SDK 3.10+
-- Rust toolchain (stable)
-- Android SDK (minSdk 26 / Android 8.0+)
-- USB host (OTG) for UAC 2.0
-
-### Installation
 ```bash
-git clone <repository-url>
-cd flick_player
 flutter pub get
 cd rust && cargo fetch && cd ..
+flutter run
 ```
 
-### Running
-```bash
-flutter run                    # debug mode
-flutter run -d <device-id>     # specific device
-```
+Or `flutter build apk --release`.
 
-### Building
-```bash
-flutter build apk --debug
-flutter build apk --release
-```
+## Docs
 
-## Platform-Specific Notes
-
-### Android
-Flick is Android-only. The audio engine selects one of:
-
-- **USB Direct**: bit-perfect via the Rust UAC 2.0 isochronous engine through external USB DACs
-- **DAP Native**: hi-res through the internal DAC via Oboe/AAudio exclusive mode on qualified DAPs
-- **Mixer Bit-Perfect**: Android mixer with bit-perfect format matching (Android 14+)
-- **Mixer Matched / Resampled Fallback**: standard mixer paths when exact format matching isn't possible
-- **just_audio fallback**: standard playback where advanced audio is unsupported
-
-UAC 2.0 DAC/AMP detection uses the USB Host API. The pipeline-info and transfer-stats widgets were removed when UAC2 routing shifted to Android's native USB DAC handling. The core UAC2 engine (discovery, descriptor parsing, isochronous transfers) remains in the Rust backend.
-
-- **Requirements**: USB host (OTG). `android.hardware.usb.host` is declared optional, so the app installs on devices without it.
-- **Permissions**: on UAC 2.0 attach, the app lists the device and requests access. Grant when prompted. `Uac2Service.instance.requestPermission(deviceName)` — on Android, `deviceName` is in `Uac2DeviceInfo.serial` when the device has no serial string.
-- **Device filter**: only UAC 2.0 devices (class 0x01, subclass 0x02, protocol 0x20) are listed.
-
-## Architecture
-
-Feature-based with separation of concerns:
-
-- **Services**: audio playback, library, device communication
-- **Providers**: Riverpod reactive state
-- **Feature modules**: self-contained screens, widgets, logic
-- **Rust backend**: audio processing and USB via `flutter_rust_bridge`
-
-The Rust backend exposes real-time engine control, audio DSP, and direct USB device access for UAC 2.0.
-
-## Documentation
-
-Architecture and design notes live in [`docs/`](docs/). Release history is in [`CHANGELOG.md`](CHANGELOG.md). Key references:
-
-- [`docs/DSD_ARCHITECTURE.md`](docs/DSD_ARCHITECTURE.md) — DSD/DSF/DFF/WavPack engine
-- [`docs/LIBRARY_SCAN_ARCHITECTURE.md`](docs/LIBRARY_SCAN_ARCHITECTURE.md) — MediaStore + SAF scanner
-- [`docs/uac2/`](docs/uac2/) — USB Audio Class 2.0 subsystem
-- [`docs/hardware_volume_control.md`](docs/hardware_volume_control.md) — three-tier volume control
+- [`docs/DSD_ARCHITECTURE.md`](docs/DSD_ARCHITECTURE.md)
+- [`docs/LIBRARY_SCAN_ARCHITECTURE.md`](docs/LIBRARY_SCAN_ARCHITECTURE.md)
+- [`docs/hardware_volume_control.md`](docs/hardware_volume_control.md)
+- [`docs/uac2/`](docs/uac2/)
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
-
-Open-source and free. No premium features, ads, or paid components.
+MIT. No ads, no premium features, no tracking.
 
 ## Contributors
 
 - [@Harleythetech](https://github.com/Harleythetech)
-- [@MagosVox](https://github.com/MagosVox) — bit-perfect USB DAC expertise
+- [@MagosVox](https://github.com/MagosVox)
 
-## Contributing
+---
 
-Contributions welcome. Ensure changes pass linting and testing before opening pull requests.
-
-## Transparency
-
-I build this with [OpenCode](https://opencode.ai). It writes some of the
-comments and docs, and it's bailed me out of more than a few nasty-ass bugs.
-The code, the design calls, and the fuck-ups are all mine.
+I build this with [OpenCode](https://opencode.ai). It writes some of the comments and docs, and it's bailed me out of more than a few nasty-ass bugs. The code, the design calls, and the fuck-ups are all mine.

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -68,6 +68,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     _artistArt = widget.artistArt;
     _artistArtSourcePath = widget.artistArtSourcePath;
     _scrollController.addListener(_onScroll);
+    _buildAlbumGroups();
     _loadExtras();
     _resolveAndSaveArtistArt();
     _extractArtistColor();
@@ -160,7 +161,9 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     return Color.lerp(_darkBase, _artistColor!, blend)!;
   }
 
-  Map<String, List<Song>> get _albumGroups {
+  late final List<MapEntry<String, List<Song>>> _albumGroups;
+
+  void _buildAlbumGroups() {
     final groups = <String, List<Song>>{};
     for (final song in widget.songs) {
       final album = song.album ?? 'Unknown Album';
@@ -169,7 +172,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     for (final entry in groups.entries) {
       entry.value.sort(_compareAlbumSongs);
     }
-    return groups;
+    _albumGroups = groups.entries.toList();
   }
 
   static int _compareAlbumSongs(Song a, Song b) {
@@ -293,7 +296,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final albumGroups = _albumGroups;
     final bgColor = _tintBackground(_backgroundBlend);
 
     return DisplayModeWrapper(
@@ -360,7 +362,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
                                   overflow: TextOverflow.ellipsis,
                                 ),
                                 Text(
-                                  '${albumGroups.length} albums • ${widget.songs.length} songs',
+                                  '${_albumGroups.length} albums • ${widget.songs.length} songs',
                                   style: Theme.of(context)
                                       .textTheme
                                       .bodySmall
@@ -410,7 +412,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
                       background: _buildAppBarBackground(
                         context,
                         resolvedBg,
-                        albumGroups.length,
+                        _albumGroups.length,
                       ),
                     ),
                   ),
@@ -558,13 +560,13 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
                     ),
                     sliver: SliverList(
                       delegate: SliverChildBuilderDelegate((context, index) {
-                        final albumEntry = albumGroups.entries.toList()[index];
+                        final albumEntry = _albumGroups[index];
                         return _AlbumSection(
                           albumName: albumEntry.key,
                           songs: albumEntry.value,
                           onSongTap: _playSong,
                         );
-                      }, childCount: albumGroups.length),
+                      }, childCount: _albumGroups.length),
                     ),
                   ),
                 ],

--- a/lib/features/folders/screens/folders_screen.dart
+++ b/lib/features/folders/screens/folders_screen.dart
@@ -1145,27 +1145,37 @@ class _FolderBrowserScreenState extends ConsumerState<FolderBrowserScreen> {
   ) {
     return NotificationListener<ScrollNotification>(
       onNotification: (_) => true,
-      child: ListView(
-        padding: EdgeInsets.only(bottom: AppConstants.navBarHeight + 120),
-        children: [
-        if (subfolders.isNotEmpty) ...[
-          _buildSubfolderGrid(context, subfolders),
-          if (songs.isNotEmpty)
-            const SizedBox(height: AppConstants.spacingMd),
-        ],
-        for (final song in songs)
-          Padding(
-            key: ValueKey(song.id),
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppConstants.spacingLg,
-              vertical: AppConstants.spacingXxs,
+      child: CustomScrollView(
+        slivers: [
+          if (subfolders.isNotEmpty)
+            SliverToBoxAdapter(child: _buildSubfolderGrid(context, subfolders)),
+          if (subfolders.isNotEmpty && songs.isNotEmpty)
+            const SliverToBoxAdapter(
+              child: SizedBox(height: AppConstants.spacingMd),
             ),
-            child: _SongTile(
-              song: song,
-              onTap: () => _playSong(song, songs, subfolders),
+          SliverPadding(
+            padding: EdgeInsets.only(
+              bottom: AppConstants.navBarHeight + 120,
+            ),
+            sliver: SliverList.builder(
+              itemCount: songs.length,
+              itemBuilder: (context, index) {
+                final song = songs[index];
+                return Padding(
+                  key: ValueKey(song.id),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppConstants.spacingLg,
+                    vertical: AppConstants.spacingXxs,
+                  ),
+                  child: _SongTile(
+                    song: song,
+                    onTap: () => _playSong(song, songs, subfolders),
+                  ),
+                );
+              },
             ),
           ),
-      ],
+        ],
       ),
     );
   }

--- a/lib/features/recently_added/screens/recently_added_screen.dart
+++ b/lib/features/recently_added/screens/recently_added_screen.dart
@@ -358,11 +358,13 @@ class _RecentlyAddedScreenState extends State<RecentlyAddedScreen> {
         return aIndex.compareTo(bIndex);
       });
 
-    var itemCount = 0;
+    final rows = <_RecentlyAddedRow>[];
     for (final section in sortedSections) {
-      itemCount += 1 + section.value.length;
+      rows.add(_RecentlyAddedRow.header(section.key, section.value.length));
+      for (final song in section.value) {
+        rows.add(_RecentlyAddedRow.song(song));
+      }
     }
-    if (_isLoadingMore) itemCount += 1;
 
     return ListView.builder(
       controller: _scrollController,
@@ -371,41 +373,31 @@ class _RecentlyAddedScreenState extends State<RecentlyAddedScreen> {
         right: AppConstants.spacingMd,
         bottom: AppConstants.navBarHeight + 120,
       ),
-      itemCount: itemCount,
+      itemCount: rows.length + (_isLoadingMore ? 1 : 0),
       itemBuilder: (context, index) {
-        var currentIndex = 0;
-        for (final section in sortedSections) {
-          if (index == currentIndex) {
-            return _buildSectionHeader(section.key, section.value.length);
-          }
-          currentIndex++;
-
-          if (index < currentIndex + section.value.length) {
-            final song = section.value[index - currentIndex];
-            return _RecentlyAddedTile(
-              key: ValueKey(
-                'recently_added_${song.id}_${song.dateAdded?.millisecondsSinceEpoch ?? 0}',
-              ),
-              song: song,
-              onTap: () async {
-                await _playerService.play(song);
-                if (context.mounted) {
-                  await NavigationHelper.navigateToFullPlayer(
-                    context,
-                    heroTag: 'recently_added_${song.id}',
-                  );
-                }
-              },
-            );
-          }
-          currentIndex += section.value.length;
-        }
-
-        if (_isLoadingMore && index == currentIndex) {
+        if (index >= rows.length) {
           return _buildLoadMoreIndicator();
         }
-
-        return const SizedBox.shrink();
+        final row = rows[index];
+        if (row.isHeader) {
+          return _buildSectionHeader(row.title!, row.count);
+        }
+        final song = row.song!;
+        return _RecentlyAddedTile(
+          key: ValueKey(
+            'recently_added_${song.id}_${song.dateAdded?.millisecondsSinceEpoch ?? 0}',
+          ),
+          song: song,
+          onTap: () async {
+            await _playerService.play(song);
+            if (context.mounted) {
+              await NavigationHelper.navigateToFullPlayer(
+                context,
+                heroTag: 'recently_added_${song.id}',
+              );
+            }
+          },
+        );
       },
     );
   }
@@ -711,4 +703,16 @@ class _MetadataChip extends StatelessWidget {
       ),
     );
   }
+}
+
+class _RecentlyAddedRow {
+  const _RecentlyAddedRow.header(this.title, this.count) : song = null;
+  const _RecentlyAddedRow.song(this.song)
+      : title = null,
+        count = 0;
+
+  final String? title;
+  final int count;
+  final Song? song;
+  bool get isHeader => song == null;
 }

--- a/lib/features/recently_played/screens/recently_played_screen.dart
+++ b/lib/features/recently_played/screens/recently_played_screen.dart
@@ -408,13 +408,13 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
         return aIndex.compareTo(bIndex);
       });
 
-    // Compute how many list items we need, including section headers and
-    // the optional bottom loading indicator.
-    var itemCount = 0;
+    final rows = <_RecentlyPlayedRow>[];
     for (final section in sortedSections) {
-      itemCount += 1 + section.value.length;
+      rows.add(_RecentlyPlayedRow.header(section.key, section.value.length));
+      for (final entry in section.value) {
+        rows.add(_RecentlyPlayedRow.entry(entry));
+      }
     }
-    if (_isLoadingMore) itemCount += 1;
 
     return ListView.builder(
       controller: _scrollController,
@@ -423,44 +423,32 @@ class _RecentlyPlayedScreenState extends State<RecentlyPlayedScreen> {
         right: AppConstants.spacingMd,
         bottom: AppConstants.navBarHeight + 120,
       ),
-      itemCount: itemCount,
+      itemCount: rows.length + (_isLoadingMore ? 1 : 0),
       itemBuilder: (context, index) {
-        var currentIndex = 0;
-        for (final section in sortedSections) {
-          if (index == currentIndex) {
-            return _buildSectionHeader(section.key, section.value.length);
-          }
-          currentIndex++;
-
-          if (index < currentIndex + section.value.length) {
-            final entryIndex = index - currentIndex;
-            final entry = section.value[entryIndex];
-            return _RecentlyPlayedTile(
-              key: ValueKey(
-                'recent_${entry.song.id}_${entry.playedAt.millisecondsSinceEpoch}',
-              ),
-              song: entry.song,
-              playedAt: entry.playedAt,
-              onTap: () async {
-                await _playerService.play(entry.song);
-                if (context.mounted) {
-                  await NavigationHelper.navigateToFullPlayer(
-                    context,
-                    heroTag: 'recent_song_${entry.song.id}',
-                  );
-                }
-              },
-            );
-          }
-          currentIndex += section.value.length;
-        }
-
-        // Bottom loading indicator
-        if (_isLoadingMore && index == currentIndex) {
+        if (index >= rows.length) {
           return _buildLoadMoreIndicator();
         }
-
-        return const SizedBox.shrink();
+        final row = rows[index];
+        if (row.isHeader) {
+          return _buildSectionHeader(row.title!, row.count);
+        }
+        final entry = row.entry!;
+        return _RecentlyPlayedTile(
+          key: ValueKey(
+            'recent_${entry.song.id}_${entry.playedAt.millisecondsSinceEpoch}',
+          ),
+          song: entry.song,
+          playedAt: entry.playedAt,
+          onTap: () async {
+            await _playerService.play(entry.song);
+            if (context.mounted) {
+              await NavigationHelper.navigateToFullPlayer(
+                context,
+                heroTag: 'recent_song_${entry.song.id}',
+              );
+            }
+          },
+        );
       },
     );
   }
@@ -766,4 +754,16 @@ class _MetadataChip extends StatelessWidget {
       ),
     );
   }
+}
+
+class _RecentlyPlayedRow {
+  const _RecentlyPlayedRow.header(this.title, this.count) : entry = null;
+  const _RecentlyPlayedRow.entry(this.entry)
+      : title = null,
+        count = 0;
+
+  final String? title;
+  final int count;
+  final RecentlyPlayedEntry? entry;
+  bool get isHeader => entry == null;
 }

--- a/lib/features/settings/screens/library_settings_screen.dart
+++ b/lib/features/settings/screens/library_settings_screen.dart
@@ -15,6 +15,7 @@ import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/settings/screens/duplicate_cleaner_screen.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/providers/providers.dart';
+import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/android_audio_device_service.dart';
 import 'package:flick/services/library_scan_preferences_service.dart';
 import 'package:flick/services/library_scanner_service.dart';
@@ -47,6 +48,8 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
   bool _isXiaomiDevice = false;
   bool _scanSettingsExpanded = false;
   bool _libraryExpanded = false;
+  int _artworkCacheBytes = -1;
+  bool _isClearingCache = false;
 
   late final AnimationController _vinylController;
 
@@ -65,6 +68,7 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
     _loadLibraryData();
     _syncFoldersToDatabase();
     _loadAndroidDeviceNotices();
+    _refreshCacheSize();
   }
 
   @override
@@ -165,6 +169,68 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
     messenger.showSnackBar(
       SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
     );
+  }
+
+  Future<void> _refreshCacheSize() async {
+    final bytes = await AlbumArtService.instance.getCacheSize();
+    if (mounted) setState(() => _artworkCacheBytes = bytes);
+  }
+
+  String get _cacheSizeLabel {
+    if (_isClearingCache) return 'Clearing...';
+    if (_artworkCacheBytes < 0) return 'Calculating size...';
+    return 'Using ${_formatBytes(_artworkCacheBytes)}';
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes <= 0) return '0 MB';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    var size = bytes.toDouble();
+    var unit = 0;
+    while (size >= 1024 && unit < units.length - 1) {
+      size /= 1024;
+      unit++;
+    }
+    return '${size.toStringAsFixed(size >= 100 || unit == 0 ? 0 : 1)} ${units[unit]}';
+  }
+
+  void _confirmClearArtworkCache() {
+    showDialog(
+      context: context,
+      builder: (context) => GlassDialog(
+        title: 'Clear Artwork Cache?',
+        content: Text(
+          'Cached album art (${_formatBytes(_artworkCacheBytes)}) will be removed. '
+          'Artwork reloads automatically as you browse.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+              _clearArtworkCache();
+            },
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _clearArtworkCache() async {
+    setState(() => _isClearingCache = true);
+    try {
+      await AlbumArtService.instance.clearCache();
+      await _refreshCacheSize();
+      if (mounted) _showToast('Artwork cache cleared');
+    } catch (e) {
+      if (mounted) _showToast('Failed to clear cache: $e');
+    } finally {
+      if (mounted) setState(() => _isClearingCache = false);
+    }
   }
 
   Future<void> _addFolder() async {
@@ -1084,6 +1150,18 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
               ],
               const SettingsDivider(),
               _buildExpandableScanSettings(libraryScanPreferences),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Storage'),
+          SettingsCard(
+            children: [
+              ActionButton(
+                icon: LucideIcons.image,
+                title: 'Clear Artwork Cache',
+                subtitle: _cacheSizeLabel,
+                onTap: _isClearingCache ? null : _confirmClearArtworkCache,
+              ),
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),

--- a/lib/features/settings/screens/playback_display_settings_screen.dart
+++ b/lib/features/settings/screens/playback_display_settings_screen.dart
@@ -55,6 +55,8 @@ class PlaybackDisplaySettingsScreen extends ConsumerWidget {
                   value,
                 ),
               ),
+              const SettingsDivider(),
+              _WrapAroundQueueTile(playerService: playerService),
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
@@ -171,6 +173,31 @@ class PlaybackDisplaySettingsScreen extends ConsumerWidget {
           const SizedBox(height: AppConstants.navBarHeight + 40),
         ],
       ),
+    );
+  }
+}
+
+class _WrapAroundQueueTile extends StatelessWidget {
+  const _WrapAroundQueueTile({required this.playerService});
+
+  final PlayerService playerService;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: playerService.wrapAroundQueueNotifier,
+      builder: (context, _) {
+        final enabled = playerService.wrapAroundQueueNotifier.value;
+        return ToggleSetting(
+          icon: LucideIcons.refreshCw,
+          title: 'Wrap-around Queue',
+          subtitle: enabled
+              ? 'Songs before the tapped track queue at the end'
+              : 'Stop at the end of the current list',
+          value: enabled,
+          onChanged: (value) => playerService.setWrapAroundQueue(value),
+        );
+      },
     );
   }
 }

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../data/repositories/song_repository.dart';
 import '../src/rust/api/scanner.dart' as rust_scanner;
@@ -15,7 +16,12 @@ class AlbumArtService {
   AlbumArtService._();
 
   static final AlbumArtService instance = AlbumArtService._();
-  static final DefaultCacheManager _cacheManager = DefaultCacheManager();
+  static const String _storeKey = 'flickArtworkCache';
+  static const Duration _cacheStalePeriod = Duration(days: 90);
+
+  static final CacheManager _cacheManager = CacheManager(
+    Config(_storeKey, stalePeriod: _cacheStalePeriod),
+  );
 
   final SongRepository _songRepository = SongRepository();
   final MusicFolderService _musicFolderService = MusicFolderService();
@@ -53,7 +59,6 @@ class AlbumArtService {
         cacheKey,
         bytes,
         fileExtension: extension,
-        maxAge: const Duration(days: 3650),
       );
 
       await _persistArtworkPath(audioSourcePath, file.path);
@@ -65,6 +70,44 @@ class AlbumArtService {
     } finally {
       _inFlightResolutions.remove(cacheKey);
     }
+  }
+
+  Future<int> getCacheSize() async {
+    var total = 0;
+    for (final dir in await _candidateCacheRoots()) {
+      for (final name in const [_storeKey, 'libCachedImageData']) {
+        final cacheDir = Directory('${dir.path}/$name');
+        if (!await cacheDir.exists()) continue;
+        try {
+          await for (final entity
+              in cacheDir.list(recursive: true, followLinks: false)) {
+            if (entity is File) total += await entity.length();
+          }
+        } catch (_) {}
+      }
+    }
+    return total;
+  }
+
+  Future<void> clearCache() async {
+    await _cacheManager.emptyCache();
+    // ponytail: also purge the legacy DefaultCacheManager store so existing
+    // users recover the multi-GB artwork build-up from before the hard cap.
+    await DefaultCacheManager().emptyCache();
+  }
+
+  Future<List<Directory>> _candidateCacheRoots() async {
+    final dirs = <Directory>[];
+    for (final future in [
+      getTemporaryDirectory(),
+      getApplicationCacheDirectory(),
+      getApplicationSupportDirectory(),
+    ]) {
+      try {
+        dirs.add(await future);
+      } catch (_) {}
+    }
+    return dirs;
   }
 
   Future<bool> _isUsableImagePath(String? path) async {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -392,6 +392,7 @@ class AppPreferencesService {
   static const _shuffleModeKey = 'playback_shuffle_mode';
   static const _loopModeKey = 'playback_loop_mode';
   static const _advanceListOrderKey = 'playback_advance_list_order';
+  static const _wrapAroundQueueKey = 'playback_wrap_around_queue';
 
   Future<AppPreferences> getPreferences() async {
     final prefs = await SharedPreferences.getInstance();
@@ -1028,6 +1029,16 @@ class AppPreferencesService {
   Future<void> setAdvanceListOrder(int value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_advanceListOrderKey, value);
+  }
+
+  Future<bool> getWrapAroundQueue() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_wrapAroundQueueKey) ?? true;
+  }
+
+  Future<void> setWrapAroundQueue(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_wrapAroundQueueKey, value);
   }
 
   Future<bool> getKeepPlayingOnQuit() async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -420,6 +420,10 @@ class PlayerService {
   AdvanceListOrder _advanceListOrder = AdvanceListOrder.alphabetical;
   AdvanceListOrder get advanceListOrder => _advanceListOrder;
 
+  // Wrap-around queue: tapping a song mid-list queues preceding songs at the end.
+  final ValueNotifier<bool> wrapAroundQueueNotifier = ValueNotifier(true);
+  bool get wrapAroundQueue => wrapAroundQueueNotifier.value;
+
   // Category shuffle tracking
   final Set<String> _playedCategoryIds = {};
 
@@ -3445,6 +3449,12 @@ class PlayerService {
     return operation;
   }
 
+  List<Song> _wrapAroundPlaylist(List<Song> songs, Song current) {
+    final start = songs.indexWhere((s) => s.id == current.id);
+    if (start <= 0) return songs;
+    return [...songs.sublist(start), ...songs.sublist(0, start)];
+  }
+
   Future<void> _playInternal(Song song, {List<Song>? playlist}) async {
     await initAudio();
     try {
@@ -3457,7 +3467,10 @@ class PlayerService {
       clearAbRepeat();
 
       if (playlist != null) {
-        _replacePlaybackContext(playlist);
+        final sourcePlaylist = wrapAroundQueueNotifier.value
+            ? _wrapAroundPlaylist(playlist, song)
+            : playlist;
+        _replacePlaybackContext(sourcePlaylist);
         _setCurrentIndex(_playlist.indexWhere((entry) => entry.id == song.id));
         if (isShuffleNotifier.value) {
           final shuffled = buildShufflePlaybackOrder(
@@ -3627,6 +3640,8 @@ class PlayerService {
     if (advanceIdx >= 0 && advanceIdx < AdvanceListOrder.values.length) {
       _advanceListOrder = AdvanceListOrder.values[advanceIdx];
     }
+    wrapAroundQueueNotifier.value =
+        await _appPreferencesService.getWrapAroundQueue();
   }
 
   Future<void> restoreLastPlayed() async {
@@ -4729,6 +4744,11 @@ class PlayerService {
   void setAdvanceListOrder(AdvanceListOrder order) {
     _advanceListOrder = order;
     unawaited(_appPreferencesService.setAdvanceListOrder(order.index));
+  }
+
+  void setWrapAroundQueue(bool value) {
+    wrapAroundQueueNotifier.value = value;
+    unawaited(_appPreferencesService.setWrapAroundQueue(value));
   }
 
   Future<void> _advanceForMode(LoopMode mode) async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -308,6 +308,7 @@ class PlayerService {
   final AlbumColorModePreferenceService _albumColorModePreferenceService =
       AlbumColorModePreferenceService();
   bool _priorityAnchorActive = false;
+  bool _midStreamUsbFallbackActive = false;
   late final AudioSessionManager _sessionManager;
   late final AudioEngineManager _playbackManager;
   RustAudioEngine? _rustEngine;
@@ -2159,6 +2160,29 @@ class PlayerService {
     };
     _rustAudioService.onError = (message) {
       _debugLog('[PlayerService] Rust backend error: $message');
+      if (Platform.isAndroid &&
+          !_midStreamUsbFallbackActive &&
+          currentEngineType == AudioEngineType.usbDacExperimental &&
+          _isDirectUsbStartupRefusal(message)) {
+        _midStreamUsbFallbackActive = true;
+        final song = currentSongNotifier.value;
+        final position = _lastPlaybackState?.position ?? Duration.zero;
+        unawaited(() async {
+          try {
+            final fellBack = await _handleDirectUsbStartupRefusal(
+              message,
+              song: song,
+              initialPosition: position,
+            );
+            if (!fellBack) {
+              await _refreshAudioOutputDiagnostics(reason: 'Rust backend error');
+            }
+          } finally {
+            _midStreamUsbFallbackActive = false;
+          }
+        }());
+        return;
+      }
       unawaited(_refreshAudioOutputDiagnostics(reason: 'Rust backend error'));
     };
   }
@@ -3788,6 +3812,7 @@ class PlayerService {
         normalized.contains('failed to set usb alt setting') ||
         normalized.contains('requires verified dac rate') ||
         normalized.contains('is not supported by clock') ||
+        normalized.contains('android usb direct') ||
         normalized.contains('usb dac disconnected') ||
         normalized.contains('usb session already active') ||
         normalized.contains('failed to claim usb interface');

--- a/rust/src/audio/device.rs
+++ b/rust/src/audio/device.rs
@@ -230,6 +230,9 @@ pub fn classify_device(signals: DeviceSignals) -> DeviceProfile {
 static ANDROID_DEVICE_PROFILE: OnceLock<DeviceProfile> = OnceLock::new();
 
 #[cfg(target_os = "android")]
+static ANDROID_API_LEVEL: OnceLock<u32> = OnceLock::new();
+
+#[cfg(target_os = "android")]
 pub fn cache_android_device_profile(profile: DeviceProfile) {
     let _ = ANDROID_DEVICE_PROFILE.set(profile);
 }
@@ -246,6 +249,29 @@ pub fn current_device_profile() -> Option<DeviceProfile> {
     }
 }
 
+// ponytail: AAudio SharingMode::Exclusive emits clipped garbage on pre-Android-10
+// OEM HALs (e.g. Samsung Note 8 / API 26): the stream reports the requested rate so
+// bit-perfect verification passes, but the DAC receives near-full-scale noise.
+// Require API 29+. The isochronous USB path is unaffected — it bypasses the HAL.
+const AAUDIO_EXCLUSIVE_MIN_API: u32 = 29;
+
+pub fn current_android_api_level() -> Option<u32> {
+    #[cfg(target_os = "android")]
+    {
+        ANDROID_API_LEVEL.get().copied()
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        None
+    }
+}
+
+pub fn android_supports_aaudio_exclusive() -> bool {
+    current_android_api_level()
+        .map(|level| level >= AAUDIO_EXCLUSIVE_MIN_API)
+        .unwrap_or(false)
+}
+
 #[cfg(target_os = "android")]
 pub fn detect_android_device_profile<'local>(
     env: &mut JNIEnv<'local>,
@@ -254,6 +280,9 @@ pub fn detect_android_device_profile<'local>(
     let manufacturer = get_build_field(env, "MANUFACTURER")?;
     let model = get_build_field(env, "MODEL")?;
     let brand = get_build_field(env, "BRAND")?;
+    if let Ok(level) = get_sdk_int(env) {
+        let _ = ANDROID_API_LEVEL.set(level.max(0) as u32);
+    }
     let manufacturer_match =
         detect_dap(&manufacturer, &brand, &model).map(|sig| sig.label.to_string());
     let audio_caps = match probe_audio_capabilities(env, context) {

--- a/rust/src/audio/device.rs
+++ b/rust/src/audio/device.rs
@@ -230,9 +230,6 @@ pub fn classify_device(signals: DeviceSignals) -> DeviceProfile {
 static ANDROID_DEVICE_PROFILE: OnceLock<DeviceProfile> = OnceLock::new();
 
 #[cfg(target_os = "android")]
-static ANDROID_API_LEVEL: OnceLock<u32> = OnceLock::new();
-
-#[cfg(target_os = "android")]
 pub fn cache_android_device_profile(profile: DeviceProfile) {
     let _ = ANDROID_DEVICE_PROFILE.set(profile);
 }
@@ -249,29 +246,6 @@ pub fn current_device_profile() -> Option<DeviceProfile> {
     }
 }
 
-// ponytail: AAudio SharingMode::Exclusive emits clipped garbage on pre-Android-10
-// OEM HALs (e.g. Samsung Note 8 / API 26): the stream reports the requested rate so
-// bit-perfect verification passes, but the DAC receives near-full-scale noise.
-// Require API 29+. The isochronous USB path is unaffected — it bypasses the HAL.
-const AAUDIO_EXCLUSIVE_MIN_API: u32 = 29;
-
-pub fn current_android_api_level() -> Option<u32> {
-    #[cfg(target_os = "android")]
-    {
-        ANDROID_API_LEVEL.get().copied()
-    }
-    #[cfg(not(target_os = "android"))]
-    {
-        None
-    }
-}
-
-pub fn android_supports_aaudio_exclusive() -> bool {
-    current_android_api_level()
-        .map(|level| level >= AAUDIO_EXCLUSIVE_MIN_API)
-        .unwrap_or(false)
-}
-
 #[cfg(target_os = "android")]
 pub fn detect_android_device_profile<'local>(
     env: &mut JNIEnv<'local>,
@@ -280,9 +254,6 @@ pub fn detect_android_device_profile<'local>(
     let manufacturer = get_build_field(env, "MANUFACTURER")?;
     let model = get_build_field(env, "MODEL")?;
     let brand = get_build_field(env, "BRAND")?;
-    if let Ok(level) = get_sdk_int(env) {
-        let _ = ANDROID_API_LEVEL.set(level.max(0) as u32);
-    }
     let manufacturer_match =
         detect_dap(&manufacturer, &brand, &model).map(|sig| sig.label.to_string());
     let audio_caps = match probe_audio_capabilities(env, context) {

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -11,7 +11,7 @@ use crate::audio::crossfader::Crossfader;
 use crate::audio::decoder::DecoderThread;
 use crate::audio::decoder_handle::{detect_file_type, DecoderHandle, FileType};
 #[cfg(target_os = "android")]
-use crate::audio::device::{android_supports_aaudio_exclusive, current_device_profile};
+use crate::audio::device::current_device_profile;
 use crate::audio::dsd_engine::DsdDecoderThread;
 use crate::audio::dynamics::DynamicsChain;
 use crate::audio::equalizer::Equalizer;
@@ -1628,8 +1628,7 @@ pub fn create_audio_engine(
         };
         managed_prefer_exclusive = dap_bit_perfect_enabled
             && device_profile.as_ref().is_some_and(|p| p.is_dap())
-            && !will_attempt_usb
-            && android_supports_aaudio_exclusive();
+            && !will_attempt_usb;
         let is_dsd_dop =
             dsd_rate.is_some() && matches!(desired_shared_strategy, OutputStrategy::DsdDoP);
         managed_use_integer = is_dsd_dop || desired_shared_strategy.is_dsd();
@@ -2050,7 +2049,11 @@ fn open_android_output_stream(
                     .set_usage(Usage::Media)
                     .set_content_type(ContentType::Music)
                     .set_channel_conversion_allowed(!bit_perfect_route)
-                    .set_format_conversion_allowed(!bit_perfect_route)
+                    // ponytail: keep format conversion ON even in bit-perfect. Integer-only USB
+                    // DACs (e.g. Audiocular) open the actual stream as int PCM; with conversion
+                    // off, Oboe writes f32 samples into an int buffer and the DAC emits full-scale
+                    // hash. Format conversion only adapts the container, it doesn't resample.
+                    .set_format_conversion_allowed(true)
                     .set_sample_rate_conversion_quality(if bit_perfect_route {
                         SampleRateConversionQuality::None
                     } else {

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -11,7 +11,7 @@ use crate::audio::crossfader::Crossfader;
 use crate::audio::decoder::DecoderThread;
 use crate::audio::decoder_handle::{detect_file_type, DecoderHandle, FileType};
 #[cfg(target_os = "android")]
-use crate::audio::device::current_device_profile;
+use crate::audio::device::{android_supports_aaudio_exclusive, current_device_profile};
 use crate::audio::dsd_engine::DsdDecoderThread;
 use crate::audio::dynamics::DynamicsChain;
 use crate::audio::equalizer::Equalizer;
@@ -1628,7 +1628,8 @@ pub fn create_audio_engine(
         };
         managed_prefer_exclusive = dap_bit_perfect_enabled
             && device_profile.as_ref().is_some_and(|p| p.is_dap())
-            && !will_attempt_usb;
+            && !will_attempt_usb
+            && android_supports_aaudio_exclusive();
         let is_dsd_dop =
             dsd_rate.is_some() && matches!(desired_shared_strategy, OutputStrategy::DsdDoP);
         managed_use_integer = is_dsd_dop || desired_shared_strategy.is_dsd();

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -4670,15 +4670,7 @@ fn run_usb_output_loop(
         candidate.service_interval_us,
     );
     let transfer_slot_count = ANDROID_USB_TRANSFER_QUEUE_DEPTH.max(1);
-    let feedback_endpoint = candidate
-        .feedback_endpoint
-        .filter(|feedback| feedback.transfer_type == TransferType::Interrupt);
-    if candidate.feedback_endpoint.is_some() && feedback_endpoint.is_none() {
-        log_info!(
-            "[USB] Skipping live isochronous feedback polling on endpoint 0x{:02x} to keep the libusb event loop single-threaded",
-            candidate.feedback_endpoint.unwrap().address,
-        );
-    }
+    let feedback_endpoint = candidate.feedback_endpoint;
     runtime_stats
         .transfer_queue_depth
         .store(transfer_slot_count, Ordering::Relaxed);
@@ -5002,10 +4994,7 @@ fn read_feedback_report(
 ) -> Result<Option<AndroidUsbFeedbackReport>, String> {
     let raw_bytes = match feedback_endpoint.transfer_type {
         TransferType::Interrupt => read_interrupt_feedback_packet(handle, feedback_endpoint)?,
-        TransferType::Isochronous => {
-            let _ = context;
-            return Ok(None);
-        }
+        TransferType::Isochronous => read_iso_feedback_packet(context, handle, feedback_endpoint)?,
         other => {
             return Err(format!(
                 "Unsupported feedback transfer type {}",
@@ -6755,7 +6744,6 @@ fn submit_iso_transfer(
     }
 }
 
-#[allow(dead_code)]
 fn read_iso_feedback_packet(
     context: &Context,
     handle: &DeviceHandle<Context>,


### PR DESCRIPTION
# Summary

- Enable isochronous feedback polling for Android USB output and remove AAudio exclusive-mode API check
- Add Android API level caching, AAudio exclusive mode guard, and handle mid-stream USB fallback on Rust backend refusal
- Add wrap-around queue playback preference with settings toggle
- Rewrite README with concise overview and updated links (26 lines from 369)
- Add artwork cache management with configurable stale period and library settings
- Refactor recently played/add screens to use row builder pattern and folder list to use slivers

# Changes

## USB Audio

- Enable isochronous feedback polling for Android USB output
- Remove AAudio exclusive-mode API check and hardcode format conversion
- Handle mid-stream USB fallback on Rust backend refusal
- Add Android-specific AAudio exclusive mode check
- Add Android API level caching and AAudio exclusive mode guard

## Wrap-Around Queue

- Add wrap-around queue playback preference with provider/service
- Add wrap-around queue toggle to playback display settings
- Handle queue end with wrap-around logic in player service

## README

- Rewrite README with concise overview and updated links (26 lines remaining, 343 removed)

## Artwork Cache

- Use custom `CacheManager` with configurable stale period
- Add artwork cache management to library settings screen (78 lines)
- Expose cache configuration in album art service

## Performance

- Refactor recently played screen to use row builder pattern
- Refactor `RecentlyAddedScreen` to build rows list for `ListView`
- Convert folder list to use slivers for performance

## Files Changed

- `rust/src/uac2/android_direct.rs`
- `rust/src/audio/device.rs`
- `rust/src/audio/engine.rs`
- `lib/services/player_service.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/album_art_service.dart`
- `lib/features/settings/screens/playback_display_settings_screen.dart`
- `lib/features/settings/screens/library_settings_screen.dart`
- `lib/features/songs/screens/recently_played_screen.dart`
- `lib/features/songs/screens/recently_added_screen.dart`
- `lib/features/folders/screens/folders_screen.dart`
- `README.md`