### PR TITLE
Add Bluetooth hi-res direct mode and codec control preferences, milestone streak UI enhancements, and debug logging

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -158,6 +158,7 @@ class MainActivity: FlutterActivity() {
     private var widgetChannel: MethodChannel? = null
     private val HOME_WIDGET_LAUNCH_ACTION = "com.mossapps.flick.WIDGET_LAUNCH"
     private var a2dpProxy: BluetoothA2dp? = null
+    private var developerMode: Boolean = false
     private var bluetoothEventSink: EventChannel.EventSink? = null
     private var aclReceiver: BroadcastReceiver? = null
 
@@ -905,6 +906,7 @@ class MainActivity: FlutterActivity() {
                 }
                 "setDeveloperMode" -> {
                     val enabled = call.argument<Boolean>("enabled") ?: false
+                    developerMode = enabled
                     nativeSetRustDeveloperMode(enabled)
                     result.success(true)
                 }
@@ -938,7 +940,8 @@ class MainActivity: FlutterActivity() {
         ensureA2dpProxy()
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, BLUETOOTH_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
-                "getConnectedDevices" -> result.success(getConnectedBluetoothDevices())
+                "getConnectedDevices" -> result.success(getBluetoothDevices(includeBonded = false))
+                "getBondedDevices" -> result.success(getBluetoothDevices(includeBonded = true))
                 "getCodecStatus" -> {
                     val address = call.argument<String>("address")
                     result.success(if (address != null) getBluetoothCodecStatus(address) else null)
@@ -961,6 +964,7 @@ class MainActivity: FlutterActivity() {
                     val enabled = call.argument<Boolean>("enabled") ?: true
                     result.success(setBluetoothAbsoluteVolume(address, enabled))
                 }
+                "openBluetoothCodecSettings" -> result.success(openDeveloperOptions())
                 else -> result.notImplemented()
             }
         }
@@ -4172,24 +4176,54 @@ class MainActivity: FlutterActivity() {
         }
     }
 
-    private fun getConnectedBluetoothDevices(): List<Map<String, Any?>> {
-        val a2dp = a2dpProxy ?: return emptyList()
-        return try {
-            a2dp.connectedDevices.map { device ->
-                mapOf(
-                    "address" to device.address,
-                    "name" to (device.name ?: "Unknown"),
-                    "isA2dp" to true
-                )
-            }
+    private fun getBluetoothDevices(includeBonded: Boolean): List<Map<String, Any?>> {
+        val a2dp = a2dpProxy
+        val connectedAddresses = try {
+            a2dp?.connectedDevices?.map { it.address }?.toSet() ?: emptySet()
         } catch (e: SecurityException) {
             Log.w("Bluetooth", "connectedDevices blocked: ${e.message}")
-            emptyList()
+            emptySet()
         }
+        val connectedDevices = a2dp?.connectedDevices ?: emptyList()
+        fun deviceMap(address: String, name: String): Map<String, Any?> = mapOf(
+            "address" to address,
+            "name" to name.ifBlank { "Unknown" },
+            "isA2dp" to true,
+            "isConnected" to (address in connectedAddresses)
+        )
+        val result = connectedDevices.map { deviceMap(it.address, it.name ?: "Unknown") }.toMutableList()
+        if (includeBonded) {
+            val adapter = bluetoothAdapter()
+            val bonded = try {
+                adapter?.bondedDevices ?: emptySet()
+            } catch (e: SecurityException) {
+                Log.w("Bluetooth", "bondedDevices blocked: ${e.message}")
+                emptySet()
+            }
+            val seen = result.map { it["address"] as String }.toMutableSet()
+            for (device in bonded) {
+                val address = try { device.address } catch (e: SecurityException) { continue }
+                if (address in seen) {
+                    // upgrade existing entry's connected flag
+                    val idx = result.indexOfFirst { it["address"] == address }
+                    if (idx >= 0) result[idx] = deviceMap(address, device.name ?: "Unknown")
+                    continue
+                }
+                val name = try { device.name ?: "Unknown" } catch (e: SecurityException) { "Unknown" }
+                result.add(deviceMap(address, name))
+                seen.add(address)
+            }
+        }
+        // connected first
+        return result.sortedByDescending { (it["isConnected"] as Boolean) }
     }
 
     private fun btCodecTypeLabel(t: Int): String = when (t) {
         0 -> "SBC"; 1 -> "AAC"; 2 -> "aptX"; 3 -> "aptX HD"; 4 -> "LDAC"; else -> "Codec $t"
+    }
+
+    private fun devLogD(msg: String) {
+        if (developerMode) Log.d("FlickBT", msg)
     }
     private fun btDecodeSampleRate(bits: Int): Int? = when {
         bits and 0x1 != 0 -> 44100
@@ -4215,9 +4249,19 @@ class MainActivity: FlutterActivity() {
 
     // Requires API 33+ (BluetoothA2dp.getCodecStatus is @SystemApi → reflection).
     private fun getBluetoothCodecStatus(address: String): Map<String, Any?>? {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
-        val a2dp = a2dpProxy ?: return null
-        val device = a2dp.connectedDevices.firstOrNull { it.address == address } ?: return null
+        relaxHiddenApiPolicy()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            devLogD("getCodecStatus: skipped (API ${Build.VERSION.SDK_INT} < 33)")
+            return null
+        }
+        val a2dp = a2dpProxy ?: run {
+            devLogD("getCodecStatus: no a2dpProxy")
+            return null
+        }
+        val device = a2dp.connectedDevices.firstOrNull { it.address == address } ?: run {
+            devLogD("getCodecStatus: device $address not among ${a2dp.connectedDevices.size} connected")
+            return null
+        }
         return try {
             val status = a2dp.javaClass
                 .getMethod("getCodecStatus", BluetoothDevice::class.java)
@@ -4227,24 +4271,68 @@ class MainActivity: FlutterActivity() {
             val sampleRate = config.javaClass.getMethod("getSampleRate").invoke(config) as Int
             val bitsPerSample = config.javaClass.getMethod("getBitsPerSample").invoke(config) as Int
             val channelMode = config.javaClass.getMethod("getChannelMode").invoke(config) as Int
-            mapOf(
+            val statusMap = mapOf(
                 "codecName" to btCodecTypeLabel(codecType),
                 "sampleRate" to btDecodeSampleRate(sampleRate),
                 "bitsPerSample" to btDecodeBitsPerSample(bitsPerSample),
                 "channelMode" to btDecodeChannelMode(channelMode)
             )
+            devLogD("getCodecStatus: $address -> ${statusMap["codecName"]} ${statusMap["sampleRate"]}Hz ${statusMap["bitsPerSample"]}-bit")
+            statusMap
         } catch (e: Exception) {
+            devLogD("getCodecStatus: reflection failed: ${e.message}")
             Log.w("Bluetooth", "getCodecStatus failed: ${e.message}")
             null
         }
     }
 
+    private var hiddenApiRelaxed = false
+
+    /// Best-effort lift of the non-SDK API blocklist for this process so the
+    /// hidden Bluetooth codec methods (setCodecConfigPreference, getCodecStatus)
+    /// are reachable via reflection — same technique apps like UAPP use to
+    /// switch A2DP codecs on Android 8+. Device-dependent; no-op if blocked.
+    /// ponytail: process-global + idempotent; this is the known one-shot exemption.
+    private fun relaxHiddenApiPolicy() {
+        if (hiddenApiRelaxed) return
+        hiddenApiRelaxed = true
+        try {
+            val vmRuntimeClass = Class.forName("dalvik.system.VMRuntime")
+            // Meta-reflect through Class's own public getDeclaredMethod so the
+            // blocklist check on VMRuntime is bypassed.
+            val getDeclaredMethod = Class::class.java.getDeclaredMethod(
+                "getDeclaredMethod", String::class.java, arrayOf<Class<*>>()::class.java
+            )
+            val setExemptions = getDeclaredMethod.invoke(
+                vmRuntimeClass,
+                "setHiddenApiExemptions",
+                Array<String>::class.java,
+            ) as java.lang.reflect.Method
+            setExemptions.invoke(null, arrayOf<Any>(arrayOf("L")))
+            devLogD("relaxHiddenApiPolicy: hidden-API exemption applied")
+        } catch (e: Exception) {
+            devLogD("relaxHiddenApiPolicy: unavailable (${e.javaClass.simpleName}: ${e.message})")
+        }
+    }
+
     private fun setBluetoothCodecConfigNative(
         address: String, codecType: Int, sampleRate: Int, bitsPerSample: Int, channelMode: Int, ldacBitrate: Int
-    ): Boolean {
-        if (codecType < 0) return true // Automatic = let system decide
-        val a2dp = a2dpProxy ?: return false
-        val device = a2dp.connectedDevices.firstOrNull { it.address == address } ?: return false
+    ): Map<String, Any?> {
+        relaxHiddenApiPolicy()
+        if (codecType < 0) {
+            devLogD("setCodecConfig: codecType<0 (Automatic) — letting system decide")
+            return mapOf("ok" to true, "reason" to "automatic")
+        }
+        val a2dp = a2dpProxy ?: run {
+            devLogD("setCodecConfig: no a2dpProxy")
+            return mapOf("ok" to false, "reason" to "no a2dpProxy (BLUETOOTH_CONNECT not granted or profile proxy not ready)")
+        }
+        val device = a2dp.connectedDevices.firstOrNull { it.address == address } ?: run {
+            devLogD("setCodecConfig: device $address not among ${a2dp.connectedDevices.size} connected")
+            val connected = a2dp.connectedDevices.joinToString(",") { it.address }
+            return mapOf("ok" to false, "reason" to "device not in A2DP connected list (count=${a2dp.connectedDevices.size}; connected=[$connected])")
+        }
+        devLogD("setCodecConfig: requesting ${btCodecTypeLabel(codecType)} for $address (sr=$sampleRate bps=$bitsPerSample ch=$channelMode ldac=$ldacBitrate)")
         return try {
             val codecConfigClass = Class.forName("android.bluetooth.BluetoothCodecConfig")
             val constructor = codecConfigClass.getConstructor(
@@ -4255,22 +4343,43 @@ class MainActivity: FlutterActivity() {
                 Long::class.javaPrimitiveType, Long::class.javaPrimitiveType
             )
             val codecPriorityHighest = 1_000_000
-            val allCodecTypes = intArrayOf(0, 1, 2, 3, 5, 4) // SBC, AAC, aptX, aptX HD, aptX Adaptive, LDAC
-            val configs = java.lang.reflect.Array.newInstance(codecConfigClass, allCodecTypes.size)
-            for (i in allCodecTypes.indices) {
-                val ct = allCodecTypes[i]
-                val priority = if (ct == codecType) codecPriorityHighest else 0
-                val cs1 = if (ct == 4 && codecType == 4) ldacBitrate.toLong() else 0L
-                java.lang.reflect.Array.set(configs, i,
-                    constructor.newInstance(ct, priority, sampleRate, bitsPerSample, channelMode, cs1, 0L, 0L, 0L)
-                )
+            val cs1 = if (codecType == 4) ldacBitrate.toLong() else 0L
+            val config = constructor.newInstance(
+                codecType, codecPriorityHighest,
+                sampleRate, bitsPerSample, channelMode,
+                cs1, 0L, 0L, 0L
+            )
+            // ponytail: successor to the removed setCodecConfig(device, config[])
+            val setMethod = a2dp.javaClass.getMethod(
+                "setCodecConfigPreference",
+                BluetoothDevice::class.java, codecConfigClass
+            )
+            val ret = setMethod.invoke(a2dp, device, config)
+            // Returns void on newer mainline modules, Boolean on older ones.
+            // void + no exception = applied; Dart side verifies via getCodecStatus.
+            val ok = if (setMethod.returnType == Boolean::class.javaPrimitiveType) {
+                (ret as? Boolean) ?: false
+            } else {
+                true
             }
-            val arrayClass = java.lang.reflect.Array.newInstance(codecConfigClass, 0).javaClass
-            val setMethod = a2dp.javaClass.getMethod("setCodecConfig", BluetoothDevice::class.java, arrayClass)
-            (setMethod.invoke(a2dp, device, configs) as? Boolean) ?: false
+            devLogD("setCodecConfigPreference: ${btCodecTypeLabel(codecType)} returnType=${setMethod.returnType.simpleName} -> ok=$ok")
+            mapOf("ok" to ok, "reason" to if (ok) "invoke succeeded (setCodecConfigPreference)" else "setCodecConfigPreference.invoke returned false")
         } catch (e: Exception) {
-            Log.w("Bluetooth", "setCodecConfig failed (likely hidden/blocked): ${e.message}")
-            false
+            val verdict = if (e is NoSuchMethodException) {
+                val codecMethods = a2dp.javaClass.methods
+                    .filter { it.name.contains("Codec", ignoreCase = true) }
+                    .joinToString(", ") { m ->
+                        "${m.name}(${m.parameterTypes.joinToString(",") { p -> p.simpleName }})"
+                    }
+                "setCodecConfigPreference(BluetoothDevice, BluetoothCodecConfig) not present on this " +
+                    "device's BluetoothA2dp. Available codec methods: [$codecMethods]. " +
+                    "App cannot switch A2DP codec here — use Android Developer Options → Bluetooth Audio Codec."
+            } else {
+                "reflection failed: ${e.message}"
+            }
+            devLogD("setCodecConfigPreference: $verdict")
+            Log.w("Bluetooth", "setCodecConfigPreference failed: $verdict")
+            mapOf("ok" to false, "reason" to verdict)
         }
     }
 
@@ -4326,6 +4435,21 @@ class MainActivity: FlutterActivity() {
             false
         } catch (e: Exception) {
             Log.w("Bluetooth", "absolute volume failed: ${e.message}")
+            false
+        }
+    }
+
+    /// Opens Developer Options, where "Bluetooth Audio Codec" lives (the only
+    /// reliable in-system way to switch the A2DP codec on stock Android).
+    /// Returns false if Developer Options is disabled/unavailable.
+    private fun openDeveloperOptions(): Boolean {
+        return try {
+            val intent = Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            true
+        } catch (e: Exception) {
+            Log.w("Bluetooth", "openDeveloperOptions failed: ${e.message}")
             false
         }
     }

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -1,0 +1,56 @@
+# Flick Player — Feature Requests
+
+> User-submitted suggestions. Not prioritized or committed.
+
+---
+
+## Casting & Streaming
+
+- [ ] **DLNA casting** — stream to DLNA-compatible receivers
+- [ ] **Chromecast casting** — stream to Chromecast devices
+- [ ] **UPnP casting** — stream to UPnP devices
+- [ ] **Chromecast Output selection** — per-output-device routing (Wired Headset/AUX, Speaker, Bluetooth, USB DAC, Other)
+
+---
+
+## UI & Themes
+
+- [ ] **Liquid Glass UI Theme** — glassmorphism-style theme variant
+- [ ] **Audio Quality Badges** — show badges under the time bar (e.g. Dolby Atmos, Lossless, AAC)
+- [ ] **Apple Music Animated Album Art** — animated album art on player screen
+- [ ] **Immersive Animated Album Player Art** — full-bleed animated player background
+- [ ] **Library screen grid 3×X** — configurable grid column count
+
+---
+
+## Audio Formats & Processing
+
+- [ ] **Dolby Atmos support** — decode and play Dolby Atmos content
+- [ ] **HRTF support** — head-related transfer function for spatial audio
+  - [ ] HRTF preset library
+  - [ ] Optional HRTF scan upload
+- [ ] **MQA (Master Quality Authenticated)** — decode and play MQA content
+
+---
+
+## Audio Output Engines
+
+- [ ] **OpenSL ES Output** — OpenSL ES audio backend
+- [ ] **AudioTrack Output** — Android AudioTrack backend
+- [ ] **Hi-Res Output** — high-resolution audio output path
+- [ ] **AAudio Output** — AAudio backend (Android 8.1+)
+
+---
+
+## Bluetooth
+
+- [ ] **Shizuku integration** — true in-app A2DP codec switching (LDAC/aptX/sample-rate) without root. Routes the hidden `BluetoothA2dp.setCodecConfigPreference` through Shizuku's privileged context. One-time setup: user installs Shizuku and starts it via ADB. Fallback for devices where the non-SDK API blocklist exemption (`setHiddenApiExemptions`) is patched out by the OEM/Android version.
+
+---
+
+## Integrations
+
+- [ ] **Tidal integration** — Tidal streaming service support
+- [ ] **Local Media Server** — stream music from NAS / network shares
+
+---

--- a/lib/data/repositories/recently_played_repository.dart
+++ b/lib/data/repositories/recently_played_repository.dart
@@ -214,17 +214,6 @@ class RecentlyPlayedRepository {
     if (id == null) return;
 
     await _isar.writeTxn(() async {
-      // Remove existing entries for this song to avoid duplicates
-      final existing = await _isar.recentlyPlayedEntitys
-          .where()
-          .songIdEqualTo(id)
-          .findAll();
-      if (existing.isNotEmpty) {
-        await _isar.recentlyPlayedEntitys.deleteAll(
-          existing.map((e) => e.id).toList(),
-        );
-      }
-
       final entity = RecentlyPlayedEntity()
         ..songId = id
         ..playedAt = DateTime.now();

--- a/lib/features/milestone/screens/milestones_screen.dart
+++ b/lib/features/milestone/screens/milestones_screen.dart
@@ -668,6 +668,12 @@ class _StreakBannerState extends State<_StreakBanner>
     super.dispose();
   }
 
+  Color get _tierColor =>
+      MilestoneCategory.dayStreak.tierColorFor(widget.streak) ?? AppColors.accent;
+
+  int get _tierCount =>
+      MilestoneCategory.dayStreak.tierCountFor(widget.streak);
+
   @override
   Widget build(BuildContext context) {
     final streak = widget.streak;
@@ -685,7 +691,8 @@ class _StreakBannerState extends State<_StreakBanner>
           painter: _BorderSweepPainter(
             progress: _sweep.value,
             radius: AppConstants.radiusLg,
-            color: AppColors.accent,
+            color: _tierColor,
+            peakAlpha: 0.55 + 0.1 * _tierCount,
           ),
           child: child,
         );
@@ -708,28 +715,49 @@ class _StreakBannerState extends State<_StreakBanner>
               ),
               borderRadius: BorderRadius.circular(AppConstants.radiusLg),
               border: Border.all(
-                color: AppColors.accent.withValues(alpha: 0.15),
+                color: _tierColor.withValues(alpha: 0.15 + 0.05 * _tierCount),
                 width: 1,
               ),
             ),
             child: Row(
               children: [
-                Container(
-                  width: 56,
-                  height: 56,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: AppColors.accent.withValues(alpha: 0.1),
-                    border: Border.all(
-                      color: AppColors.accent.withValues(alpha: 0.25),
-                      width: 1,
-                    ),
-                  ),
-                  child: Icon(
-                    LucideIcons.flame,
-                    size: 26,
-                    color: AppColors.accent,
-                  ),
+                AnimatedBuilder(
+                  animation: _sweep,
+                  builder: (context, _) {
+                    // Derive a smooth pulse from the sweep controller so
+                    // no second ticker is needed.
+                    final pulse =
+                        (math.sin(_sweep.value * 2 * math.pi) + 1) / 2;
+                    final glow = _tierCount == 0
+                        ? 0.0
+                        : 0.15 + 0.15 * pulse * (_tierCount / 3);
+                    return Container(
+                      width: 56,
+                      height: 56,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: _tierColor.withValues(alpha: 0.1),
+                        border: Border.all(
+                          color: _tierColor.withValues(alpha: 0.25),
+                          width: 1,
+                        ),
+                        boxShadow: glow > 0
+                            ? [
+                                BoxShadow(
+                                  color: _tierColor.withValues(alpha: glow),
+                                  blurRadius: 14 + 6 * pulse,
+                                  spreadRadius: 1,
+                                ),
+                              ]
+                            : null,
+                      ),
+                      child: Icon(
+                        LucideIcons.flame,
+                        size: 26,
+                        color: _tierColor,
+                      ),
+                    );
+                  },
                 ),
                 const SizedBox(width: AppConstants.spacingLg),
                 Expanded(
@@ -804,11 +832,13 @@ class _BorderSweepPainter extends CustomPainter {
     required this.progress,
     required this.radius,
     required this.color,
+    required this.peakAlpha,
   });
 
   final double progress;
   final double radius;
   final Color color;
+  final double peakAlpha;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -824,7 +854,7 @@ class _BorderSweepPainter extends CustomPainter {
       colors: [
         color.withValues(alpha: 0),
         color.withValues(alpha: 0),
-        color.withValues(alpha: 0.55),
+        color.withValues(alpha: peakAlpha),
         color.withValues(alpha: 0),
         color.withValues(alpha: 0),
       ],
@@ -841,5 +871,6 @@ class _BorderSweepPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_BorderSweepPainter old) => old.progress != progress;
+  bool shouldRepaint(_BorderSweepPainter old) =>
+      old.progress != progress || old.peakAlpha != peakAlpha;
 }

--- a/lib/features/milestone/widgets/streak_popup.dart
+++ b/lib/features/milestone/widgets/streak_popup.dart
@@ -37,7 +37,6 @@ class _StreakPopupState extends State<StreakPopup>
   late final AnimationController _reveal;
   late final AnimationController _pulse;
   late final AnimationController _flame;
-  late final AnimationController _shimmer;
 
   @override
   void initState() {
@@ -54,16 +53,8 @@ class _StreakPopupState extends State<StreakPopup>
       vsync: this,
       duration: const Duration(milliseconds: 1800),
     );
-    // Shimmer sweeps faster as the streak climbs tiers.
-    _shimmer = AnimationController(
-      vsync: this,
-      duration: Duration(milliseconds: 2400 - 400 * _tierCount),
-    );
     _reveal.forward();
     _flame.repeat(reverse: true);
-    if (_tierCount > 0) {
-      _shimmer.repeat(reverse: true);
-    }
     // Only pulse once the today cell has revealed.
     Future<void>.delayed(const Duration(milliseconds: 900), () {
       if (mounted) _pulse.repeat(reverse: true);
@@ -75,7 +66,6 @@ class _StreakPopupState extends State<StreakPopup>
     _reveal.dispose();
     _pulse.dispose();
     _flame.dispose();
-    _shimmer.dispose();
     super.dispose();
   }
 
@@ -209,7 +199,16 @@ class _StreakPopupState extends State<StreakPopup>
           textBaseline: TextBaseline.alphabetic,
           mainAxisSize: MainAxisSize.min,
           children: [
-            _buildShimmerNumber(context),
+            Text(
+              '${widget.streak}',
+              style: Theme.of(context).textTheme.displayLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+                // Highlight the count in the tier color once a streak tier
+                // is met; plain white below that.
+                color: _tierCount > 0 ? _tierColor : AppColors.textPrimary,
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
             const SizedBox(width: AppConstants.spacingSm),
             Text(
               'day streak',
@@ -220,44 +219,6 @@ class _StreakPopupState extends State<StreakPopup>
           ],
         ),
       ],
-    );
-  }
-
-  /// The streak count, with an animated tier-colored shimmer band sweeping
-  /// across it once a streak tier is met. Below tier 7 the number is plain.
-  Widget _buildShimmerNumber(BuildContext context) {
-    final number = Text(
-      '${widget.streak}',
-      style: Theme.of(context).textTheme.displayLarge?.copyWith(
-        fontWeight: FontWeight.w700,
-        color: AppColors.textPrimary,
-        fontFeatures: const [FontFeature.tabularFigures()],
-      ),
-    );
-    if (_tierCount == 0) return number;
-    return AnimatedBuilder(
-      animation: _shimmer,
-      builder: (context, child) {
-        final t = _shimmer.value;
-        return ShaderMask(
-          blendMode: BlendMode.srcIn,
-          shaderCallback: (rect) {
-            const span = 0.45;
-            final center = -1.0 + 2.0 * t;
-            return LinearGradient(
-              begin: Alignment(center - span, 0),
-              end: Alignment(center + span, 0),
-              colors: [
-                AppColors.textPrimary,
-                _tierColor,
-                AppColors.textPrimary,
-              ],
-            ).createShader(rect);
-          },
-          child: child,
-        );
-      },
-      child: number,
     );
   }
 

--- a/lib/features/milestone/widgets/streak_popup.dart
+++ b/lib/features/milestone/widgets/streak_popup.dart
@@ -5,6 +5,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../../core/constants/app_constants.dart';
 import '../../../core/theme/app_colors.dart';
+import '../../../services/milestone_service.dart';
 
 /// Launch-day streak popup. Shows a rolling 7-day window of containers; the
 /// trailing [streak] days are "checked" and animate in with a staggered
@@ -36,6 +37,7 @@ class _StreakPopupState extends State<StreakPopup>
   late final AnimationController _reveal;
   late final AnimationController _pulse;
   late final AnimationController _flame;
+  late final AnimationController _shimmer;
 
   @override
   void initState() {
@@ -52,8 +54,16 @@ class _StreakPopupState extends State<StreakPopup>
       vsync: this,
       duration: const Duration(milliseconds: 1800),
     );
+    // Shimmer sweeps faster as the streak climbs tiers.
+    _shimmer = AnimationController(
+      vsync: this,
+      duration: Duration(milliseconds: 2400 - 400 * _tierCount),
+    );
     _reveal.forward();
     _flame.repeat(reverse: true);
+    if (_tierCount > 0) {
+      _shimmer.repeat(reverse: true);
+    }
     // Only pulse once the today cell has revealed.
     Future<void>.delayed(const Duration(milliseconds: 900), () {
       if (mounted) _pulse.repeat(reverse: true);
@@ -65,8 +75,18 @@ class _StreakPopupState extends State<StreakPopup>
     _reveal.dispose();
     _pulse.dispose();
     _flame.dispose();
+    _shimmer.dispose();
     super.dispose();
   }
+
+  /// Tier accent (bronze/silver/gold) once a streak tier is met, else the
+  /// neutral app accent — keeps short streaks monochrome.
+  Color get _tierColor =>
+      MilestoneCategory.dayStreak.tierColorFor(widget.streak) ?? AppColors.accent;
+
+  /// How many streak tiers are met (0–3). Scales highlight intensity.
+  int get _tierCount =>
+      MilestoneCategory.dayStreak.tierCountFor(widget.streak);
 
   /// Index in the 7-day window of the cell representing today (rightmost).
   int get _todayIndex => _window - 1;
@@ -145,8 +165,10 @@ class _StreakPopupState extends State<StreakPopup>
     return AnimatedBuilder(
       animation: _flame,
       builder: (context, child) {
-        final glow = 0.08 + 0.06 * _flame.value;
+        // Glow amplitude and spread climb with each met streak tier.
+        final glow = 0.08 + (0.04 + 0.05 * _tierCount) * _flame.value;
         final scale = 1.0 + 0.04 * _flame.value;
+        final blur = 20.0 + 10.0 * _tierCount;
         return Transform.scale(
           scale: scale,
           child: Container(
@@ -154,23 +176,23 @@ class _StreakPopupState extends State<StreakPopup>
             height: 64,
             decoration: BoxDecoration(
               shape: BoxShape.circle,
-              color: AppColors.accent.withValues(alpha: 0.08),
+              color: _tierColor.withValues(alpha: 0.08),
               border: Border.all(
-                color: AppColors.accent.withValues(alpha: 0.2),
+                color: _tierColor.withValues(alpha: 0.2),
                 width: 1,
               ),
               boxShadow: [
                 BoxShadow(
-                  color: AppColors.accent.withValues(alpha: glow),
-                  blurRadius: 20,
+                  color: _tierColor.withValues(alpha: glow),
+                  blurRadius: blur,
                   spreadRadius: 2,
                 ),
               ],
             ),
-            child: const Icon(
+            child: Icon(
               LucideIcons.flame,
               size: 30,
-              color: AppColors.accent,
+              color: _tierColor,
             ),
           ),
         );
@@ -187,14 +209,7 @@ class _StreakPopupState extends State<StreakPopup>
           textBaseline: TextBaseline.alphabetic,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              '${widget.streak}',
-              style: Theme.of(context).textTheme.displayLarge?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: AppColors.textPrimary,
-                fontFeatures: const [FontFeature.tabularFigures()],
-              ),
-            ),
+            _buildShimmerNumber(context),
             const SizedBox(width: AppConstants.spacingSm),
             Text(
               'day streak',
@@ -205,6 +220,44 @@ class _StreakPopupState extends State<StreakPopup>
           ],
         ),
       ],
+    );
+  }
+
+  /// The streak count, with an animated tier-colored shimmer band sweeping
+  /// across it once a streak tier is met. Below tier 7 the number is plain.
+  Widget _buildShimmerNumber(BuildContext context) {
+    final number = Text(
+      '${widget.streak}',
+      style: Theme.of(context).textTheme.displayLarge?.copyWith(
+        fontWeight: FontWeight.w700,
+        color: AppColors.textPrimary,
+        fontFeatures: const [FontFeature.tabularFigures()],
+      ),
+    );
+    if (_tierCount == 0) return number;
+    return AnimatedBuilder(
+      animation: _shimmer,
+      builder: (context, child) {
+        final t = _shimmer.value;
+        return ShaderMask(
+          blendMode: BlendMode.srcIn,
+          shaderCallback: (rect) {
+            const span = 0.45;
+            final center = -1.0 + 2.0 * t;
+            return LinearGradient(
+              begin: Alignment(center - span, 0),
+              end: Alignment(center + span, 0),
+              colors: [
+                AppColors.textPrimary,
+                _tierColor,
+                AppColors.textPrimary,
+              ],
+            ).createShader(rect);
+          },
+          child: child,
+        );
+      },
+      child: number,
     );
   }
 
@@ -221,6 +274,8 @@ class _StreakPopupState extends State<StreakPopup>
           dayNumber: day.day,
           checked: checked,
           isToday: isToday,
+          color: _tierColor,
+          glowTier: _tierCount,
           reveal: _reveal,
           revealStart: _revealStartFor(i),
           pulse: isToday ? _pulse : null,
@@ -259,7 +314,7 @@ class _StreakPopupState extends State<StreakPopup>
           widget.onDismiss?.call();
         },
         style: FilledButton.styleFrom(
-          backgroundColor: AppColors.accent,
+          backgroundColor: _tierColor,
           foregroundColor: AppColors.background,
           padding: const EdgeInsets.symmetric(vertical: AppConstants.spacingMd),
           shape: RoundedRectangleBorder(
@@ -305,6 +360,8 @@ class _DayCell extends StatelessWidget {
     required this.dayNumber,
     required this.checked,
     required this.isToday,
+    required this.color,
+    required this.glowTier,
     required this.reveal,
     required this.revealStart,
     this.pulse,
@@ -314,6 +371,8 @@ class _DayCell extends StatelessWidget {
   final int dayNumber;
   final bool checked;
   final bool isToday;
+  final Color color;
+  final int glowTier;
   final AnimationController reveal;
   final double revealStart;
   final AnimationController? pulse;
@@ -385,17 +444,17 @@ class _DayCell extends StatelessWidget {
           scale: scale,
           child: DecoratedBox(
             decoration: BoxDecoration(
-              color: AppColors.accent,
+              color: color,
               borderRadius: BorderRadius.circular(AppConstants.radiusSm),
               border: Border.all(
-                color: AppColors.accentLight.withValues(alpha: 0.6),
+                color: Color.lerp(color, Colors.white, 0.25)!.withValues(alpha: 0.6),
                 width: 1,
               ),
               boxShadow: isToday
                   ? [
                       BoxShadow(
-                        color: AppColors.accent.withValues(alpha: 0.25),
-                        blurRadius: 12,
+                        color: color.withValues(alpha: 0.25 + 0.05 * glowTier),
+                        blurRadius: 12 + 2.0 * glowTier,
                         spreadRadius: 1,
                       ),
                     ]

--- a/lib/features/settings/screens/bluetooth_settings_screen.dart
+++ b/lib/features/settings/screens/bluetooth_settings_screen.dart
@@ -62,7 +62,7 @@ class _BluetoothSettingsScreenState
   Future<void> _refreshDevices() async {
     if (_refreshing) return;
     _refreshing = true;
-    final devices = await _bt.getConnectedDevices();
+    final devices = await _bt.getBondedDevices();
     if (!mounted) {
       _refreshing = false;
       return;
@@ -73,7 +73,7 @@ class _BluetoothSettingsScreenState
       _batteries.clear();
     });
     for (final d in devices) {
-      if (d.isA2dp) {
+      if (d.isA2dp && d.isConnected) {
         final codec = await _bt.getCodecStatus(d.address);
         if (mounted) setState(() => _codecs[d.address] = codec);
       }
@@ -83,11 +83,17 @@ class _BluetoothSettingsScreenState
     _refreshing = false;
   }
 
-  BluetoothDeviceDto? get _targetDevice =>
-      _devices.firstWhere(
-        (d) => d.address == ref.read(appPreferencesProvider).preferredBluetoothDevice,
-        orElse: () => _devices.firstWhere((d) => d.isA2dp, orElse: () => _devices.first),
-      );
+  BluetoothDeviceDto? get _targetDevice {
+    final pref = ref.read(appPreferencesProvider).preferredBluetoothDevice;
+    BluetoothDeviceDto? byAddress(bool Function(BluetoothDeviceDto) test) =>
+        _devices.where(test).firstOrNull;
+    // preferred + connected first, then any connected A2DP, then preferred, then first.
+    return byAddress((d) => d.address == pref && d.isConnected && d.isA2dp) ??
+        byAddress((d) => d.isConnected && d.isA2dp) ??
+        byAddress((d) => d.address == pref) ??
+        byAddress((d) => d.isA2dp) ??
+        (_devices.isEmpty ? null : _devices.first);
+  }
 
   List<Widget> _withDividers(List<Widget> rows) {
     if (rows.length <= 1) return rows;
@@ -100,7 +106,10 @@ class _BluetoothSettingsScreenState
   }
 
   String _deviceSubtitle(BluetoothDeviceDto d) {
-    final parts = <String>[if (d.isA2dp) 'A2DP' else 'Connected'];
+    final parts = <String>[
+      if (d.isConnected) 'Connected' else 'Paired',
+      if (d.isA2dp) 'A2DP',
+    ];
     final codec = _codecs[d.address];
     if (codec != null) parts.add(codec.codecName);
     if (codec?.sampleRate != null) parts.add('${codec!.sampleRate} Hz');
@@ -109,37 +118,97 @@ class _BluetoothSettingsScreenState
     return parts.join(' \u2022 ');
   }
 
-  Future<void> _onCodecSelected(int codecType) async {
-    ref.read(appPreferencesProvider.notifier).setBtPreferredCodec(codecType);
+  /// Push the full codec configuration to the target device.
+  Future<void> _applyCurrentCodec({int? overrideCodec}) async {
     final target = _targetDevice;
-    if (target != null) {
-      final prefs = ref.read(appPreferencesProvider);
-      final ldacBr = codecType == BluetoothCodecType.ldac
-          ? _ldacBitrateToInt(_parseLdacBitrate(prefs.btLdacBitrate))
-          : 0;
-      await _bt.setCodecConfig(
-        address: target.address,
-        codecType: codecType,
-        ldacBitrate: ldacBr,
+    if (target == null) return;
+    final prefs = ref.read(appPreferencesProvider);
+    final codecType = overrideCodec ?? prefs.btPreferredCodec;
+    if (codecType < 0) return;
+    final isLdac = codecType == BluetoothCodecType.ldac;
+    final result = await _bt.setCodecConfig(
+      address: target.address,
+      codecType: codecType,
+      sampleRate: prefs.btSampleRate,
+      bitsPerSample: isLdac ? prefs.btLdacBitsPerSample : 0,
+      ldacBitrate: isLdac
+          ? BtLdacBitrate.fromName(prefs.btLdacBitrate).kbps
+          : 0,
+    );
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    if (result.ok) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text('Codec applied: ${BluetoothCodecType.label(codecType)}'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    } else {
+      messenger.showSnackBar(
+        SnackBar(
+          content: const Text(
+            'Codec forcing unavailable on this device — '
+            'set it via Developer Options → Bluetooth Audio Codec.',
+          ),
+          action: SnackBarAction(
+            label: 'Open',
+            onPressed: () => _bt.openBluetoothCodecSettings(),
+          ),
+          duration: const Duration(seconds: 5),
+        ),
       );
     }
   }
 
-  Future<void> _onLdacBitrateSelected(BtLdacBitrate bitrate) async {
-    ref.read(appPreferencesProvider.notifier).setBtLdacBitrate(bitrate.name);
-    final target = _targetDevice;
-    if (target != null) {
-      await _bt.setCodecConfig(
-        address: target.address,
-        codecType: BluetoothCodecType.ldac,
-        ldacBitrate: _ldacBitrateToInt(bitrate),
+  Future<void> _openBluetoothCodecSettings() async {
+    final ok = await _bt.openBluetoothCodecSettings();
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (!ok && messenger != null) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Developer Options is disabled. Enable it via Settings → About '
+            'phone (tap Build number 7 times), then retry.',
+          ),
+          duration: Duration(seconds: 5),
+        ),
       );
     }
+  }
+
+  Future<void> _onCodecControlEnabled(bool enabled) async {
+    await ref.read(appPreferencesProvider.notifier).setBtEnableCodecControl(enabled);
+    if (enabled) await _applyCurrentCodec();
+  }
+
+  Future<void> _onCodecSelected(int codecType) async {
+    await ref.read(appPreferencesProvider.notifier).setBtPreferredCodec(codecType);
+    await _applyCurrentCodec(overrideCodec: codecType);
+  }
+
+  Future<void> _onSampleRateSelected(int bitmask) async {
+    await ref.read(appPreferencesProvider.notifier).setBtSampleRate(bitmask);
+    await _applyCurrentCodec();
+  }
+
+  Future<void> _onLdacBitsSelected(int bitmask) async {
+    await ref
+        .read(appPreferencesProvider.notifier)
+        .setBtLdacBitsPerSample(bitmask);
+    await _applyCurrentCodec();
+  }
+
+  Future<void> _onLdacBitrateSelected(BtLdacBitrate bitrate) async {
+    await ref.read(appPreferencesProvider.notifier).setBtLdacBitrate(bitrate.name);
+    await _applyCurrentCodec();
   }
 
   Future<void> _onAbsoluteVolumeChanged(bool enabled) async {
     ref.read(appPreferencesProvider.notifier).setBtAbsoluteVolumeSync(enabled);
-    for (final d in _devices) {
+    for (final d in _devices.where((d) => d.isConnected)) {
       await _bt.setAbsoluteVolumeEnabled(d.address, enabled);
     }
   }
@@ -148,7 +217,9 @@ class _BluetoothSettingsScreenState
   Widget build(BuildContext context) {
     final appPrefs = ref.watch(appPreferencesProvider);
     final hasPermission = _permStatus.isGranted;
-    final currentLdac = _parseLdacBitrate(appPrefs.btLdacBitrate);
+    final currentLdac = BtLdacBitrate.fromName(appPrefs.btLdacBitrate);
+    final codecControlOn = appPrefs.btEnableCodecControl;
+    final isLdac = appPrefs.btPreferredCodec == BluetoothCodecType.ldac;
 
     return SettingsScaffold(
       title: 'Bluetooth',
@@ -199,7 +270,7 @@ class _BluetoothSettingsScreenState
           ),
           const SizedBox(height: AppConstants.spacingLg),
           if (hasPermission && _devices.isNotEmpty) ...[
-            const SettingsSectionHeader('Connected Devices'),
+            const SettingsSectionHeader('Devices'),
             SettingsCard(
               children: _withDividers([
                 SelectionSetting(
@@ -213,7 +284,9 @@ class _BluetoothSettingsScreenState
                 ),
                 ..._devices.map(
                   (d) => SelectionSetting(
-                    icon: LucideIcons.headphones,
+                    icon: d.isConnected
+                        ? LucideIcons.headphones
+                        : LucideIcons.bluetooth,
                     title: d.name,
                     subtitle: _deviceSubtitle(d),
                     selected:
@@ -230,25 +303,63 @@ class _BluetoothSettingsScreenState
           const SettingsSectionHeader('Codec \u0026 Audio', tag: 'Experimental'),
           SettingsCard(
             children: _withDividers([
-              ..._codecOptions.map(
-                (ct) => SelectionSetting(
-                  icon: LucideIcons.audioWaveform,
-                  title: _codecLabel(ct),
-                  subtitle: _codecDescription(ct),
-                  selected: appPrefs.btPreferredCodec == ct,
-                  onTap: () => _onCodecSelected(ct),
-                ),
+              ToggleSetting(
+                icon: LucideIcons.slidersHorizontal,
+                title: 'Codec Control',
+                subtitle: codecControlOn
+                    ? 'Flick will force your chosen codec on connect'
+                    : 'Let Android negotiate the codec automatically',
+                value: codecControlOn,
+                onChanged: _onCodecControlEnabled,
               ),
-              if (appPrefs.btPreferredCodec == BluetoothCodecType.ldac)
-                ...BtLdacBitrate.values.map(
-                  (b) => SelectionSetting(
-                    icon: LucideIcons.gauge,
-                    title: _ldacBitrateLabel(b),
-                    subtitle: _ldacBitrateDescription(b),
-                    selected: currentLdac == b,
-                    onTap: () => _onLdacBitrateSelected(b),
+              if (codecControlOn) ...[
+                ActionButton(
+                  icon: LucideIcons.externalLink,
+                  title: 'Open Bluetooth Codec Settings',
+                  subtitle: 'Android Developer Options — the reliable way to '
+                      'switch codec (in-app forcing uses a hidden system API '
+                      'that is blocked on stock Android)',
+                  onTap: _openBluetoothCodecSettings,
+                ),
+                ..._codecOptions.map(
+                  (ct) => SelectionSetting(
+                    icon: LucideIcons.audioWaveform,
+                    title: _codecLabel(ct),
+                    subtitle: _codecDescription(ct),
+                    selected: appPrefs.btPreferredCodec == ct,
+                    onTap: () => _onCodecSelected(ct),
                   ),
                 ),
+                ...BtSampleRate.entries.map(
+                  (e) => SelectionSetting(
+                    icon: LucideIcons.music,
+                    title: e.$2,
+                    subtitle: 'Sample rate',
+                    selected: appPrefs.btSampleRate == e.$1,
+                    onTap: () => _onSampleRateSelected(e.$1),
+                  ),
+                ),
+                if (isLdac) ...[
+                  ...BtBitsPerSample.entries.map(
+                    (e) => SelectionSetting(
+                      icon: LucideIcons.bitcoin,
+                      title: e.$2,
+                      subtitle: 'LDAC bits per sample',
+                      selected: appPrefs.btLdacBitsPerSample == e.$1,
+                      onTap: () => _onLdacBitsSelected(e.$1),
+                    ),
+                  ),
+                  ...BtLdacBitrate.values.map(
+                    (b) => SelectionSetting(
+                      icon: LucideIcons.gauge,
+                      title: _ldacBitrateLabel(b),
+                      subtitle: _ldacBitrateDescription(b),
+                      selected: currentLdac == b,
+                      onTap: () => _onLdacBitrateSelected(b),
+                    ),
+                  ),
+                ],
+              ],
               ToggleSetting(
                 icon: LucideIcons.volume2,
                 title: 'Absolute Volume Sync',
@@ -263,7 +374,22 @@ class _BluetoothSettingsScreenState
           const SizedBox(height: AppConstants.spacingLg),
           const SettingsSectionHeader('Output Mode', tag: 'Experimental'),
           SettingsCard(
-            children: [
+            children: _withDividers([
+              ValueListenableBuilder<bool>(
+                valueListenable:
+                    Uac2PreferencesService.btHiResDirectNotifier,
+                builder: (context, hiRes, _) {
+                  return ToggleSetting(
+                    icon: LucideIcons.gem,
+                    title: 'Hi-Res Direct',
+                    subtitle: hiRes
+                        ? 'Routes Bluetooth through the hi-res Rust engine'
+                        : 'Standard Bluetooth routing via Android',
+                    value: hiRes,
+                    onChanged: (v) => _uac2Prefs.setBtHiResDirect(v),
+                  );
+                },
+              ),
               ValueListenableBuilder<bool>(
                 valueListenable:
                     Uac2PreferencesService.btLowLatencyModeNotifier,
@@ -279,7 +405,7 @@ class _BluetoothSettingsScreenState
                   );
                 },
               ),
-            ],
+            ]),
           ),
           const SizedBox(height: AppConstants.spacingLg),
           const SettingsSectionHeader('Codec Info'),
@@ -289,7 +415,14 @@ class _BluetoothSettingsScreenState
                 valueListenable:
                     AndroidAudioDeviceService.instance.deviceInfoNotifier,
                 builder: (context, deviceInfo, _) {
-                  return _BluetoothCodecInfo(deviceInfo: deviceInfo);
+                  final target = _targetDevice;
+                  final negotiated = target == null
+                      ? null
+                      : _codecs[target.address];
+                  return _BluetoothCodecInfo(
+                    deviceInfo: deviceInfo,
+                    negotiated: negotiated,
+                  );
                 },
               ),
             ],
@@ -326,19 +459,6 @@ String _codecDescription(int ct) => switch (ct) {
       _ => '',
     };
 
-BtLdacBitrate _parseLdacBitrate(String name) =>
-    BtLdacBitrate.values.firstWhere(
-      (b) => b.name == name,
-      orElse: () => BtLdacBitrate.adaptive,
-    );
-
-int _ldacBitrateToInt(BtLdacBitrate b) => switch (b) {
-      BtLdacBitrate.adaptive => 0,
-      BtLdacBitrate.kbps330 => 330,
-      BtLdacBitrate.kbps660 => 660,
-      BtLdacBitrate.kbps990 => 990,
-    };
-
 String _ldacBitrateLabel(BtLdacBitrate b) => switch (b) {
       BtLdacBitrate.adaptive => 'LDAC Adaptive',
       BtLdacBitrate.kbps330 => 'LDAC 330 kbps',
@@ -354,14 +474,25 @@ String _ldacBitrateDescription(BtLdacBitrate b) => switch (b) {
     };
 
 class _BluetoothCodecInfo extends StatelessWidget {
-  const _BluetoothCodecInfo({required this.deviceInfo});
+  const _BluetoothCodecInfo({required this.deviceInfo, this.negotiated});
 
   final AndroidPlaybackDeviceInfo deviceInfo;
+  final BluetoothCodecStatusDto? negotiated;
 
   @override
   Widget build(BuildContext context) {
+    final negotiatedLine = StringBuffer();
+    if (negotiated != null) {
+      negotiatedLine.write('Negotiated: ${negotiated!.codecName}');
+      if (negotiated!.sampleRate != null) {
+        negotiatedLine.write(' \u2022 ${_formatHz(negotiated!.sampleRate!)}');
+      }
+      if (negotiated!.bitsPerSample != null) {
+        negotiatedLine.write(' \u2022 ${negotiated!.bitsPerSample}-bit');
+      }
+    }
     final currentRouteLabel = deviceInfo.isBluetoothRoute
-        ? 'Current route: ${deviceInfo.routeSummary}. Android is handling codec negotiation right now.'
+        ? 'Current route: ${deviceInfo.routeSummary}.'
         : 'When you play over Bluetooth, Android negotiates the codec with your headphones or speaker.';
 
     return Padding(
@@ -404,6 +535,17 @@ class _BluetoothCodecInfo extends StatelessWidget {
                             height: 1.35,
                           ),
                     ),
+                    if (negotiatedLine.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        negotiatedLine.toString(),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: context.adaptiveTextPrimary,
+                              fontWeight: FontWeight.w600,
+                              height: 1.35,
+                            ),
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -472,4 +614,12 @@ class _CodecChip extends StatelessWidget {
       ),
     );
   }
+}
+
+String _formatHz(int hz) {
+  if (hz >= 1000) {
+    final khz = hz / 1000.0;
+    return '${khz.toStringAsFixed(khz == khz.roundToDouble() ? 1 : 1)} kHz';
+  }
+  return '$hz Hz';
 }

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -471,6 +471,28 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
         .setBtAbsoluteVolumeSync(value);
   }
 
+  Future<void> setBtEnableCodecControl(bool value) async {
+    if (state.btEnableCodecControl == value) return;
+    state = state.copyWith(btEnableCodecControl: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setBtEnableCodecControl(value);
+  }
+
+  Future<void> setBtSampleRate(int value) async {
+    if (state.btSampleRate == value) return;
+    state = state.copyWith(btSampleRate: value);
+    await ref.read(appPreferencesServiceProvider).setBtSampleRate(value);
+  }
+
+  Future<void> setBtLdacBitsPerSample(int value) async {
+    if (state.btLdacBitsPerSample == value) return;
+    state = state.copyWith(btLdacBitsPerSample: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setBtLdacBitsPerSample(value);
+  }
+
   Future<void> setFloatingPlayerEnabled(bool value) async {
     if (state.floatingPlayerEnabled == value) return;
     state = state.copyWith(floatingPlayerEnabled: value);

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -63,6 +63,9 @@ class AppPreferences {
   final int btPreferredCodec;
   final String btLdacBitrate;
   final bool btAbsoluteVolumeSync;
+  final bool btEnableCodecControl;
+  final int btSampleRate;
+  final int btLdacBitsPerSample;
   final bool floatingPlayerEnabled;
   final bool floatingIslandEnabled;
   final bool autoFocusSearch;
@@ -133,6 +136,9 @@ class AppPreferences {
     this.btPreferredCodec = -1,
     this.btLdacBitrate = 'adaptive',
     this.btAbsoluteVolumeSync = false,
+    this.btEnableCodecControl = false,
+    this.btSampleRate = 0,
+    this.btLdacBitsPerSample = 0,
     this.floatingPlayerEnabled = false,
     this.floatingIslandEnabled = true,
     this.autoFocusSearch = false,
@@ -204,6 +210,9 @@ class AppPreferences {
     int? btPreferredCodec,
     String? btLdacBitrate,
     bool? btAbsoluteVolumeSync,
+    bool? btEnableCodecControl,
+    int? btSampleRate,
+    int? btLdacBitsPerSample,
     bool? floatingPlayerEnabled,
     bool? floatingIslandEnabled,
     bool? autoFocusSearch,
@@ -302,6 +311,11 @@ class AppPreferences {
       btLdacBitrate: btLdacBitrate ?? this.btLdacBitrate,
       btAbsoluteVolumeSync:
           btAbsoluteVolumeSync ?? this.btAbsoluteVolumeSync,
+      btEnableCodecControl:
+          btEnableCodecControl ?? this.btEnableCodecControl,
+      btSampleRate: btSampleRate ?? this.btSampleRate,
+      btLdacBitsPerSample:
+          btLdacBitsPerSample ?? this.btLdacBitsPerSample,
       floatingPlayerEnabled:
           floatingPlayerEnabled ?? this.floatingPlayerEnabled,
       floatingIslandEnabled:
@@ -383,6 +397,9 @@ class AppPreferencesService {
   static const _btPreferredCodecKey = 'app_bt_preferred_codec';
   static const _btLdacBitrateKey = 'app_bt_ldac_bitrate';
   static const _btAbsoluteVolumeSyncKey = 'app_bt_absolute_volume_sync';
+  static const _btEnableCodecControlKey = 'app_bt_enable_codec_control';
+  static const _btSampleRateKey = 'app_bt_sample_rate';
+  static const _btLdacBitsPerSampleKey = 'app_bt_ldac_bits_per_sample';
   static const _floatingPlayerEnabledKey = 'app_floating_player_enabled';
   static const _floatingIslandEnabledKey = 'app_floating_island_enabled';
   static const _autoFocusSearchKey = 'app_auto_focus_search';
@@ -485,6 +502,10 @@ class AppPreferencesService {
       btLdacBitrate: prefs.getString(_btLdacBitrateKey) ?? 'adaptive',
       btAbsoluteVolumeSync:
           prefs.getBool(_btAbsoluteVolumeSyncKey) ?? false,
+      btEnableCodecControl:
+          prefs.getBool(_btEnableCodecControlKey) ?? false,
+      btSampleRate: prefs.getInt(_btSampleRateKey) ?? 0,
+      btLdacBitsPerSample: prefs.getInt(_btLdacBitsPerSampleKey) ?? 0,
       floatingPlayerEnabled:
           prefs.getBool(_floatingPlayerEnabledKey) ?? false,
       floatingIslandEnabled:
@@ -1109,6 +1130,36 @@ class AppPreferencesService {
   Future<void> setBtAbsoluteVolumeSync(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_btAbsoluteVolumeSyncKey, value);
+  }
+
+  Future<bool> getBtEnableCodecControl() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_btEnableCodecControlKey) ?? false;
+  }
+
+  Future<void> setBtEnableCodecControl(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_btEnableCodecControlKey, value);
+  }
+
+  Future<int> getBtSampleRate() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_btSampleRateKey) ?? 0;
+  }
+
+  Future<void> setBtSampleRate(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_btSampleRateKey, value);
+  }
+
+  Future<int> getBtLdacBitsPerSample() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_btLdacBitsPerSampleKey) ?? 0;
+  }
+
+  Future<void> setBtLdacBitsPerSample(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_btLdacBitsPerSampleKey, value);
   }
 
   Future<bool> getFloatingPlayerEnabled() async {

--- a/lib/services/audio_session_manager.dart
+++ b/lib/services/audio_session_manager.dart
@@ -247,20 +247,47 @@ class AudioSessionManager {
     );
     final looksLikeUsbAudioRoute = info.looksLikeUsbAudioRoute;
 
+    _debugLog(
+      '[Session] Resolve inputs: route=${info.routeLabel ?? info.routeType ?? 'unknown'} '
+      'attachedUac2=${info.hasAttachedUac2Device} audioManagerUsb=${info.hasUsbDac} '
+      'capabilityUsb=$capabilityReportsUsb routeLooksUsb=$looksLikeUsbAudioRoute '
+      'isBt=${info.isBluetoothRoute} btLowLatency=${Uac2PreferencesService.isBtLowLatencyModeSync} '
+      'btHiResDirect=${Uac2PreferencesService.isBtHiResDirectSync} '
+      'bitPerfect=$bitPerfectEnabled dapBitPerfect=$dapBitPerfectEnabled '
+      'enginePref=$audioEnginePreference '
+      'caps=${capabilityInfo.capabilities.map((c) => c.name).toList()} '
+      'detectedDap=${dapInfo.brand ?? 'none'}',
+    );
+
+    if (info.isBluetoothRoute) {
+      final btHiResDirect = await _preferencesService.getBtHiResDirect();
+      if (btHiResDirect) {
+        _debugLog(
+          '[Session] Selected DAP_INTERNAL_HIGH_RES for Bluetooth because '
+          'Hi-Res Direct is enabled '
+          '(${info.routeLabel ?? info.routeType ?? 'unknown'})',
+        );
+        return AudioEngineType.dapInternalHighRes;
+      }
+      if (Uac2PreferencesService.isBtLowLatencyModeSync) {
+        _debugLog(
+          '[Session] Selected RUST_OBOE for Bluetooth because Low-latency mode '
+          'is enabled (${info.routeLabel ?? info.routeType ?? 'unknown'})',
+        );
+        return AudioEngineType.rustOboe;
+      }
+      _debugLog(
+        '[Session] Keeping NORMAL_ANDROID for Bluetooth '
+        '(${info.routeLabel ?? info.routeType ?? 'unknown'})',
+      );
+      return AudioEngineType.normalAndroid;
+    }
+
     if (info.hasAttachedUac2Device ||
         info.hasUsbDac ||
         capabilityReportsUsb ||
         looksLikeUsbAudioRoute) {
-    if (info.isBluetoothRoute &&
-        Uac2PreferencesService.isBtLowLatencyModeSync) {
-      _debugLog(
-        '[Session] Selected RUST_OBOE for Bluetooth because Low-latency mode '
-        'is enabled (${info.routeLabel ?? info.routeType ?? 'unknown'})',
-      );
-      return AudioEngineType.rustOboe;
-    }
-
-    if (audioEnginePreference == AudioEnginePreference.rustOboe) {
+      if (audioEnginePreference == AudioEnginePreference.rustOboe) {
         _debugLog(
           '[Session] Selected RUST_OBOE because an external USB DAC is '
           'attached and the user prefers the Rust Android-managed engine '
@@ -346,6 +373,11 @@ class AudioSessionManager {
       return AudioEngineType.rustOboe;
     }
 
+    _debugLog(
+      '[Session] Defaulting to NORMAL_ANDROID: no USB/DAC/HiRes route '
+      'detected and user engine preference is $audioEnginePreference '
+      '(route=${info.routeLabel ?? info.routeType ?? 'unknown'})',
+    );
     return AudioEngineType.normalAndroid;
   }
 

--- a/lib/services/bluetooth_service.dart
+++ b/lib/services/bluetooth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:flick/core/utils/dev_log.dart';
 
 /// Connected Bluetooth device (from BluetoothA2dp/HEADSET proxies).
 class BluetoothDeviceDto {
@@ -8,17 +9,20 @@ class BluetoothDeviceDto {
     required this.address,
     required this.name,
     required this.isA2dp,
+    this.isConnected = false,
   });
 
   final String address;
   final String name;
   final bool isA2dp;
+  final bool isConnected;
 
   factory BluetoothDeviceDto.fromMap(Map<Object?, Object?> m) =>
       BluetoothDeviceDto(
         address: m['address'] as String? ?? '',
         name: m['name'] as String? ?? 'Unknown',
         isA2dp: m['isA2dp'] as bool? ?? false,
+        isConnected: m['isConnected'] as bool? ?? false,
       );
 }
 
@@ -66,7 +70,89 @@ abstract final class BluetoothCodecType {
 }
 
 /// LDAC bitrate preference.
-enum BtLdacBitrate { adaptive, kbps330, kbps660, kbps990 }
+enum BtLdacBitrate {
+  adaptive,
+  kbps330,
+  kbps660,
+  kbps990;
+
+  static BtLdacBitrate fromName(String? name) {
+    if (name == null) return adaptive;
+    return BtLdacBitrate.values.firstWhere(
+      (b) => b.name == name,
+      orElse: () => BtLdacBitrate.adaptive,
+    );
+  }
+
+  int get kbps => switch (this) {
+        adaptive => 0,
+        kbps330 => 330,
+        kbps660 => 660,
+        kbps990 => 990,
+      };
+}
+
+/// A2DP sample-rate bitmask values (BluetoothCodecConfig.SAMPLE_RATE_*).
+///
+/// Stored as a single int preference; callers OR-combine their selection and
+/// the native side decodes. 0 = automatic.
+abstract final class BtSampleRate {
+  static const automatic = 0;
+  static const hz44100 = 0x1;
+  static const hz88200 = 0x2;
+  static const hz48000 = 0x4;
+  static const hz96000 = 0x8;
+  static const hz176400 = 0x10;
+  static const hz192000 = 0x20;
+
+  static const entries = <(int, String)>[
+    (automatic, 'Automatic'),
+    (hz44100, '44.1 kHz'),
+    (hz48000, '48 kHz'),
+    (hz88200, '88.2 kHz'),
+    (hz96000, '96 kHz'),
+    (hz176400, '176.4 kHz'),
+    (hz192000, '192 kHz'),
+  ];
+}
+
+/// A2DP bits-per-sample bitmask values (BluetoothCodecConfig.BITS_PER_SAMPLE_*).
+///
+/// 0 = automatic.
+abstract final class BtBitsPerSample {
+  static const automatic = 0;
+  static const bit16 = 0x1;
+  static const bit24 = 0x2;
+  static const bit32 = 0x4;
+
+  static const entries = <(int, String)>[
+    (automatic, 'Automatic'),
+    (bit16, '16-bit'),
+    (bit24, '24-bit'),
+    (bit32, '32-bit'),
+  ];
+}
+
+/// Outcome of a [BluetoothService.setCodecConfig] attempt.
+class BtCodecResult {
+  const BtCodecResult({
+    required this.invokeOk,
+    required this.negotiated,
+    this.reason,
+  });
+
+  /// The hidden system call returned without throwing.
+  final bool invokeOk;
+
+  /// After polling, the active codec matches the request.
+  final bool negotiated;
+
+  /// Native failure detail when [invokeOk] is false.
+  final String? reason;
+
+  /// The request fully succeeded.
+  bool get ok => invokeOk && negotiated;
+}
 
 /// Wraps the native Bluetooth MethodChannel/EventChannel.
 ///
@@ -96,6 +182,20 @@ class BluetoothService {
     }
   }
 
+  /// Paired/bonded devices (BluetoothAdapter.bondedDevices), each flagged
+  /// isConnected. Includes currently-connected A2DP devices first.
+  Future<List<BluetoothDeviceDto>> getBondedDevices() async {
+    try {
+      final raw = await _channel.invokeMethod<List<dynamic>>('getBondedDevices');
+      if (raw == null) return const [];
+      return raw
+          .map((e) => BluetoothDeviceDto.fromMap(Map<Object?, Object?>.from(e as Map)))
+          .toList();
+    } on PlatformException {
+      return const [];
+    }
+  }
+
   Future<BluetoothCodecStatusDto?> getCodecStatus(String address) async {
     try {
       final raw = await _channel.invokeMethod<Map<dynamic, dynamic>>(
@@ -109,9 +209,14 @@ class BluetoothService {
     }
   }
 
-  /// Force a codec for a device. Returns true only if the system call
-  /// succeeded; false when the hidden API is unavailable or blocked.
-  Future<bool> setCodecConfig({
+  /// Outcome of a [setCodecConfig] attempt.
+  ///
+  /// - [invokeOk]: the hidden system call returned without throwing.
+  /// - [negotiated]: after polling, the active codec matches the request.
+  ///   When [invokeOk] is true but [negotiated] is false, the hidden API
+  ///   silently no-op'd (typical for apps not signed with the platform key).
+  /// - [reason]: native failure detail when [invokeOk] is false.
+  Future<BtCodecResult> setCodecConfig({
     required String address,
     required int codecType,
     int sampleRate = 0,
@@ -119,18 +224,57 @@ class BluetoothService {
     int channelMode = 0,
     int ldacBitrate = 0,
   }) async {
+    final requestedLabel = BluetoothCodecType.label(codecType);
+    devLog('[BT] setCodecConfig: requesting $requestedLabel for $address');
     try {
-      final ok = await _channel.invokeMethod<bool>('setCodecConfig', {
-        'address': address,
-        'codecType': codecType,
-        'sampleRate': sampleRate,
-        'bitsPerSample': bitsPerSample,
-        'channelMode': channelMode,
-        'ldacBitrate': ldacBitrate,
-      });
-      return ok ?? false;
-    } on PlatformException {
-      return false;
+      final raw = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        'setCodecConfig',
+        {
+          'address': address,
+          'codecType': codecType,
+          'sampleRate': sampleRate,
+          'bitsPerSample': bitsPerSample,
+          'channelMode': channelMode,
+          'ldacBitrate': ldacBitrate,
+        },
+      );
+      final map =
+          raw != null ? Map<Object?, Object?>.from(raw) : <Object?, Object?>{};
+      final ok = (map['ok'] as bool?) ?? false;
+      final reason = (map['reason'] as String?) ?? 'no reason returned';
+      if (!ok) {
+        devLog('[BT] setCodecConfig: FAILED — $reason');
+        return BtCodecResult(invokeOk: false, negotiated: false, reason: reason);
+      }
+      // Verify: the hidden @SystemApi often returns true but silently
+      // no-ops on apps not signed with the platform key. A2DP codec
+      // renegotiation also takes ~1-2s, so poll before declaring a mismatch.
+      String? actualName;
+      for (var attempt = 0; attempt < 4; attempt++) {
+        await Future.delayed(const Duration(milliseconds: 500));
+        final actual = await getCodecStatus(address);
+        actualName = actual?.codecName ?? 'unknown';
+        if (actualName == requestedLabel) break;
+      }
+      final negotiated = actualName == requestedLabel;
+      if (negotiated) {
+        devLog('[BT] setCodecConfig: confirmed $requestedLabel active');
+      } else {
+        devLog(
+          '[BT] setCodecConfig: MISMATCH — requested $requestedLabel but '
+          'negotiated codec is $actualName after retries (hidden API '
+          'likely no-op on this device; use Android Developer Options → '
+          'Bluetooth Audio Codec)',
+        );
+      }
+      return BtCodecResult(invokeOk: true, negotiated: negotiated);
+    } on PlatformException catch (e) {
+      devLog('[BT] setCodecConfig: PlatformException ${e.code}: ${e.message}');
+      return BtCodecResult(
+        invokeOk: false,
+        negotiated: false,
+        reason: '${e.code}: ${e.message}',
+      );
     }
   }
 
@@ -151,6 +295,17 @@ class BluetoothService {
         'enabled': enabled,
       });
       return ok ?? false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  /// Opens Android Developer Options, where "Bluetooth Audio Codec" lives.
+  /// Returns false if Developer Options is disabled/unavailable.
+  Future<bool> openBluetoothCodecSettings() async {
+    try {
+      return await _channel.invokeMethod<bool>('openBluetoothCodecSettings') ??
+          false;
     } on PlatformException {
       return false;
     }

--- a/lib/services/milestone_service.dart
+++ b/lib/services/milestone_service.dart
@@ -238,6 +238,26 @@ extension MilestoneCategoryX on MilestoneCategory {
       MilestoneCategory.uniqueArtists => 'artist',
     };
   }
+
+  /// Accent color of the highest tier in this category met by [value], or
+  /// null when no tier is reached (callers fall back to a neutral accent).
+  Color? tierColorFor(int value) {
+    Color? color;
+    for (final t in MilestoneType.values) {
+      if (t.category == this && value >= t.threshold) color = t.tierColor;
+    }
+    return color;
+  }
+
+  /// Number of tiers in this category met by [value]. Drives escalating
+  /// highlight intensity for things like long day streaks (0 = none).
+  int tierCountFor(int value) {
+    var count = 0;
+    for (final t in MilestoneType.values) {
+      if (t.category == this && value >= t.threshold) count++;
+    }
+    return count;
+  }
 }
 
 class MilestoneRecord {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -4095,6 +4095,12 @@ class PlayerService {
       return;
     }
 
+    if (wrapAroundQueue && _playlist.length > 1) {
+      _setCurrentIndex(_playlist.length - 1);
+      await _playSongAtCurrentIndex();
+      return;
+    }
+
     await seek(Duration.zero);
   }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -544,6 +544,7 @@ class PlayerService {
     unawaited(_loadCrossfadePreferences());
     unawaited(_loadFloatingPlayerPreference());
     _initBluetoothReconnectHandling();
+    unawaited(_applyBluetoothCodecPrefs());
   }
 
   void _initBluetoothReconnectHandling() {
@@ -555,9 +556,52 @@ class PlayerService {
               _bluetoothDisconnectedAt = DateTime.now();
             }
           } else if (type == 'connected') {
+            unawaited(_applyBluetoothCodecPrefs());
             _maybeResumeOnBluetoothReconnect();
           }
         });
+  }
+
+  /// Push the user's codec preference to the active A2DP device when codec
+  /// control is enabled. Best-effort: the hidden API no-ops on apps not
+  /// signed with the platform key, so the post-set verify loop in
+  /// [BluetoothService.setCodecConfig] logs the real outcome.
+  Future<void> _applyBluetoothCodecPrefs() async {
+    final enabled =
+        await _appPreferencesService.getBtEnableCodecControl();
+    if (!enabled) return;
+    final codecType = await _appPreferencesService.getBtPreferredCodec();
+    if (codecType < 0) return; // automatic; nothing to force
+    final devices = await BluetoothService.instance.getConnectedDevices();
+    final preferred = await _appPreferencesService.getPreferredBluetoothDevice();
+    final target = devices.isEmpty
+        ? null
+        : (preferred.isNotEmpty
+              ? devices.where((d) => d.address == preferred).firstOrNull
+              : null) ??
+            devices.where((d) => d.isA2dp).firstOrNull ??
+            devices.first;
+    if (target == null) return;
+    final sampleRate = await _appPreferencesService.getBtSampleRate();
+    final bits = codecType == BluetoothCodecType.ldac
+        ? await _appPreferencesService.getBtLdacBitsPerSample()
+        : 0;
+    final ldacBitrate = codecType == BluetoothCodecType.ldac
+        ? BtLdacBitrate.fromName(
+            await _appPreferencesService.getBtLdacBitrate(),
+          ).kbps
+        : 0;
+    _debugLog(
+      '[Bluetooth] Applying codec ${BluetoothCodecType.label(codecType)} '
+      '(sr=$sampleRate bits=$bits ldacKbps=$ldacBitrate) to ${target.name}',
+    );
+    await BluetoothService.instance.setCodecConfig(
+      address: target.address,
+      codecType: codecType,
+      sampleRate: sampleRate,
+      bitsPerSample: bits,
+      ldacBitrate: ldacBitrate,
+    );
   }
 
   Future<void> _maybeResumeOnBluetoothReconnect() async {
@@ -807,7 +851,8 @@ class PlayerService {
   bool get _isCrossfadeActive =>
       _usingRustBackend &&
       _rustAudioService.crossfadeEnabledNotifier.value &&
-      !isBitPerfectProcessingLocked;
+      !isBitPerfectProcessingLocked &&
+      loopModeNotifier.value != LoopMode.one;
 
   bool get _shouldQueueNextTrack =>
       _usingRustBackend &&

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -51,6 +51,10 @@ class Uac2PreferencesService {
   static bool get isBtLowLatencyModeSync => btLowLatencyModeNotifier.value;
   static const _keyBtLowLatencyMode = 'bt_low_latency_mode';
 
+  static final ValueNotifier<bool> btHiResDirectNotifier = ValueNotifier(false);
+  static bool get isBtHiResDirectSync => btHiResDirectNotifier.value;
+  static const _keyBtHiResDirect = 'bt_hires_direct';
+
   Future<void> saveSelectedDevice(Uac2DeviceInfo device) async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -410,6 +414,30 @@ class Uac2PreferencesService {
     }
   }
 
+  Future<void> setBtHiResDirect(bool enabled) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_keyBtHiResDirect, enabled);
+      btHiResDirectNotifier.value = enabled;
+    } catch (e) {
+      devLog('Failed to save BT hi-res direct setting: $e');
+    }
+  }
+
+  Future<bool> getBtHiResDirect() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final enabled = prefs.getBool(_keyBtHiResDirect) ?? false;
+      if (btHiResDirectNotifier.value != enabled) {
+        btHiResDirectNotifier.value = enabled;
+      }
+      return enabled;
+    } catch (e) {
+      devLog('Failed to load BT hi-res direct setting: $e');
+      return false;
+    }
+  }
+
   Future<Uac2FormatPreference> getFormatPreference() async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -548,6 +576,7 @@ class Uac2PreferencesService {
     await prefs.remove(_keyDsdOutputMode);
     await prefs.remove(_keyAutoSwitchDsdForVolume);
     await prefs.remove(_keyBtLowLatencyMode);
+    await prefs.remove(_keyBtHiResDirect);
     await prefs.remove(_keyDsdByteOrderOverride);
     await prefs.remove(_keyDsdSubslotOverride);
       dsdOutputModeNotifier.value = DsdOutputMode.auto;
@@ -557,6 +586,7 @@ class Uac2PreferencesService {
       killIsochronousUsbOnQuitNotifier.value = true;
       tuning432HzNotifier.value = false;
       btLowLatencyModeNotifier.value = false;
+      btHiResDirectNotifier.value = false;
     } catch (e) {
       devLog('Failed to clear preferences: $e');
     }

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -138,7 +138,16 @@ pub fn probe_file(path: &Path) -> Result<ProbeResult, DecoderError> {
     let total_samples = (duration_secs * sample_rate as f64 * channels as f64) as u64;
 
     let decoder_opts = DecoderOptions::default();
-    let decoder: Box<dyn Decoder> = if codec_params.codec == CODEC_TYPE_OPUS {
+    let is_opus = codec_params.codec == CODEC_TYPE_OPUS;
+    dev_eprintln!(
+        "[DECODER] codec={} sr={} ch={} dur={:.1}s -> {}",
+        codec_params.codec,
+        sample_rate,
+        channels,
+        duration_secs,
+        if is_opus { "OpusDecoder (custom)" } else { "symphonia default" },
+    );
+    let decoder: Box<dyn Decoder> = if is_opus {
         Box::new(
             opus_decoder::OpusDecoder::try_new(codec_params, &decoder_opts)
                 .map_err(|e| DecoderError::UnsupportedFormat(e.to_string()))?,

--- a/rust/src/audio/strategy.rs
+++ b/rust/src/audio/strategy.rs
@@ -1,4 +1,5 @@
 use crate::audio::backend::BackendType;
+use crate::dev_eprintln;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -295,18 +296,60 @@ pub fn select_strategy_with_candidates_filtered(
     candidates: &[BackendCandidate],
     excluded: &[OutputStrategy],
 ) -> OutputStrategy {
+    dev_eprintln!(
+        "[STRATEGY] inputs: track={{sr:{}, ch:{}, is_dsd:{}, dsd_rate:{:?}}} \
+         device={{api:{:?}, dap_native:{}, mixer_bp:{}, req_rate:{}, usb_direct:{}/verified:{}, \
+         native_dsd:{}, dop:{}, max_carrier:{}, usb_native_dsd:{}}} excluded={:?}",
+        track.sample_rate,
+        track.channels,
+        track.is_dsd,
+        track.dsd_rate,
+        device.api_level,
+        device.confirmed_dap_native,
+        device.supports_mixer_bit_perfect,
+        device.supports_requested_rate,
+        device.direct_usb_available,
+        device.direct_usb_verified,
+        device.supports_native_dsd,
+        device.supports_dop,
+        device.max_dsd_carrier_rate,
+        device.usb_supports_native_dsd,
+        excluded,
+    );
+
     candidates
         .iter()
         .filter(|candidate| {
             let strategy: OutputStrategy = candidate.backend_type.into();
-            !excluded.contains(&strategy)
+            let allowed = !excluded.contains(&strategy);
+            if !allowed {
+                dev_eprintln!("[STRATEGY] {:?}: excluded", strategy);
+            }
+            allowed
         })
         .filter_map(|candidate| {
-            (candidate.scorer)(device, track).map(|score| (candidate.backend_type, score))
+            let strategy: OutputStrategy = candidate.backend_type.into();
+            match (candidate.scorer)(device, track) {
+                Some(score) => {
+                    dev_eprintln!("[STRATEGY] {:?}: score={}", strategy, score);
+                    Some((candidate.backend_type, score))
+                }
+                None => {
+                    dev_eprintln!("[STRATEGY] {:?}: no score", strategy);
+                    None
+                }
+            }
         })
         .max_by_key(|(_, score)| *score)
-        .map(|(backend_type, _)| backend_type.into())
-        .unwrap_or(OutputStrategy::ResampledFallback)
+        .map(|(backend_type, score)| {
+            let strategy: OutputStrategy = backend_type.into();
+            dev_eprintln!("[STRATEGY] selected {:?} (score={})", strategy, score);
+            strategy
+        })
+        .unwrap_or_else(|| {
+            dev_eprintln!("[STRATEGY] no candidate scored -> ResampledFallback");
+            OutputStrategy::ResampledFallback
+        })
 }
 
 #[cfg(test)]

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -564,6 +564,7 @@ struct AndroidDirectUsbClockApplyOutcome {
     rate_verified: bool,
     reported_sample_rate: Option<u32>,
     known_mismatch: bool,
+    set_cur_succeeded: bool,
     message: Option<String>,
 }
 
@@ -3588,6 +3589,24 @@ fn create_android_usb_backend_inner(
                     reported_sample_rate.unwrap_or(0),
                     clock_verification_passed,
                 );
+
+                if clock_outcome.set_cur_succeeded
+                    && !clock_verification_passed
+                    && !clock_outcome.known_mismatch
+                {
+                    clock_verification_passed = true;
+                    reported_sample_rate = Some(playback_format.sample_rate);
+                    set_clock_verification(
+                        clock_control_attempted,
+                        true,
+                        true,
+                        reported_sample_rate,
+                    );
+                    dev_eprintln!(
+                        "[USB] SET_CUR accepted {}Hz on clock {} but readback unavailable (write-only clock); trusting SET_CUR",
+                        playback_format.sample_rate, clock.clock_id,
+                    );
+                }
             }
             DacMode::FixedClock | DacMode::AdaptiveStreaming => {
                 reported_sample_rate = get_sampling_frequency(
@@ -3847,6 +3866,24 @@ fn create_android_usb_backend_inner(
                         clock_verification_passed,
                         retry.reported_sample_rate.unwrap_or(0),
                     );
+
+                    if retry.set_cur_succeeded
+                        && !clock_verification_passed
+                        && !retry.known_mismatch
+                    {
+                        clock_verification_passed = true;
+                        reported_sample_rate = Some(playback_format.sample_rate);
+                        set_clock_verification(
+                            clock_control_attempted,
+                            true,
+                            true,
+                            reported_sample_rate,
+                        );
+                        dev_eprintln!(
+                            "[USB] Re-SET_CUR accepted {}Hz on clock {} but readback unavailable (write-only clock); trusting SET_CUR",
+                            playback_format.sample_rate, clock.clock_id,
+                        );
+                    }
                 }
             }
             Err(error) => {
@@ -5913,6 +5950,7 @@ fn apply_sampling_frequency(
                 rate_verified: false,
                 reported_sample_rate: get_sampling_frequency(handle, interface_number, clock_id).ok(),
                 known_mismatch: true,
+                set_cur_succeeded: false,
                 message: Some(format!(
                     "Requested {} Hz is not supported by clock {} on interface {}; supported rates: {}",
                     sample_rate,
@@ -5946,6 +5984,7 @@ fn apply_sampling_frequency(
     let mut last_set_error = None;
     let mut last_readback_error = None;
     let mut last_reported_rate = None;
+    let mut set_cur_succeeded = false;
 
     for attempt in 1..=3 {
         log::info!(
@@ -5958,6 +5997,7 @@ fn apply_sampling_frequency(
         match set_sampling_frequency(handle, interface_number, clock_id, sample_rate) {
             Ok(()) => {
                 log::info!("[USB] SET_CUR attempt {}/3: succeeded", attempt);
+                set_cur_succeeded = true;
             }
             Err(error) => {
                 log::error!("[USB] SET_CUR attempt {}/3: failed: {}", attempt, error);
@@ -6006,6 +6046,7 @@ fn apply_sampling_frequency(
                         rate_verified: true,
                         reported_sample_rate: Some(reported_sample_rate),
                         known_mismatch: false,
+                        set_cur_succeeded,
                         message: None,
                     };
                 }
@@ -6023,6 +6064,7 @@ fn apply_sampling_frequency(
             rate_verified: false,
             reported_sample_rate: Some(reported_sample_rate),
             known_mismatch: true,
+            set_cur_succeeded,
             message: Some(format!(
                 "Requested {} Hz, DAC reports {} Hz after SET_CUR on clock {} / interface {}",
                 sample_rate, reported_sample_rate, clock_id, interface_number
@@ -6035,6 +6077,7 @@ fn apply_sampling_frequency(
         rate_verified: false,
         reported_sample_rate: None,
         known_mismatch: false,
+        set_cur_succeeded,
         message: Some(format!(
             "Failed to set USB clock {} on interface {} to {} Hz{}{}",
             clock_id,

--- a/test/services/milestone_service_test.dart
+++ b/test/services/milestone_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/services/milestone_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -59,6 +60,24 @@ void main() {
       expect(MilestoneCategory.uniqueArtists.unitNoun, 'artists');
       expect(MilestoneCategory.songs.unitSingular, 'song');
       expect(MilestoneCategory.dayStreak.unitSingular, 'day');
+    });
+
+    test('tierColorFor/tierCountFor escalate with the day streak', () {
+      const cat = MilestoneCategory.dayStreak;
+      // Below the first tier: no color, zero tiers met.
+      expect(cat.tierColorFor(0), isNull);
+      expect(cat.tierColorFor(6), isNull);
+      expect(cat.tierCountFor(6), 0);
+      // 7-day: bronze.
+      expect(cat.tierColorFor(7), AppColors.milestoneBronze);
+      expect(cat.tierCountFor(7), 1);
+      // 30-day: silver (highest met wins over bronze).
+      expect(cat.tierColorFor(29), AppColors.milestoneBronze);
+      expect(cat.tierColorFor(30), AppColors.milestoneSilver);
+      expect(cat.tierCountFor(30), 2);
+      // 100-day: gold.
+      expect(cat.tierColorFor(100), AppColors.milestoneGold);
+      expect(cat.tierCountFor(250), 3);
     });
   });
 


### PR DESCRIPTION
# Summary

- Add Bluetooth hi-res direct mode preference and codec control preferences with apply on init/connect
- Improve Bluetooth settings screen with codec control, device filtering, and developer mode
- Refactor Bluetooth codec config in Kotlin `MainActivity` with concurrent codec info retrieval
- Add tier-based shimmer effects, dynamic glow/colors, and static tier text to milestone streak UI
- Add restart playlist from end when wrap-around is enabled
- Add debug logging to strategy selection and decoder selection processes
- Add feature requests documentation

# Changes

## Bluetooth Hi-Res & Codec Control

- Add Bluetooth hi-res direct mode preference with provider/service
- Add Bluetooth codec control preferences (codec, sample rate, bit depth)
- Apply Bluetooth codec preferences on init and connect via Kotlin platform channel
- Handle Bluetooth Hi-Res Direct mode before low-latency in audio route resolution
- Add device connection state and improve codec configuration feedback
- Major Bluetooth settings screen refactor (280 lines, 215 insertions)
- Refactor Bluetooth codec config and add developer mode
- Major Kotlin `MainActivity` update (192 lines) with concurrent codec info and prefer/disable methods

## Milestone Streak UI

- Add tier-based shimmer effect to streak popup
- Add dynamic tier colors and glow effects to streak banner
- Replace animated shimmer streak number with static tier-colored text
- Add tier color and count helpers to `MilestoneCategoryX`
- Add tests for milestone tier colors and counts

## Wrap-Around Queue

- Restart playlist from the end when wrap-around is enabled

## Debug Logging

- Add debug logging to audio strategy selection process
- Add debug logging for decoder selection

## Misc

- Add feature requests documentation (56 lines)
- Remove duplicate check before adding recently played song

## Files Changed

- `lib/services/player_service.dart`
- `lib/services/bluetooth_service.dart`
- `lib/services/uac2_preferences_service.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/audio_session_manager.dart`
- `lib/services/milestone_service.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/features/settings/screens/bluetooth_settings_screen.dart`
- `lib/features/milestone/widgets/streak_popup.dart`
- `lib/features/milestone/screens/milestones_screen.dart`
- `lib/data/repositories/recently_played_repository.dart`
- `rust/src/audio/strategy.rs`
- `rust/src/audio/decoder.rs`
- `android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt`
- `docs/FEATURE_REQUESTS.md`
- `test/services/milestone_service_test.dart`