### PR TITLE
Normalize embedded album art with content-based cache keys and promote image dependency

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -3106,7 +3106,7 @@ class MainActivity: FlutterActivity() {
             val permissionIntent = PendingIntent.getBroadcast(
                 this,
                 REQUEST_USB_PERMISSION,
-                Intent(ACTION_USB_PERMISSION),
+                Intent(ACTION_USB_PERMISSION).setPackage(packageName),
                 PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
             usbPermissionReceiver = object : BroadcastReceiver() {

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 
 import '../data/repositories/song_repository.dart';
@@ -39,21 +39,22 @@ class AlbumArtService {
       return existingPath;
     }
 
-    final cacheKey = _cacheKey(audioSourcePath);
-    final cached = await _cacheManager.getFileFromCache(cacheKey);
-    final cachedPath = cached?.file.path;
-    if (await _isUsableImagePath(cachedPath)) {
-      unawaited(_persistArtworkPath(audioSourcePath, cachedPath));
-      return cachedPath;
-    }
-
-    final future = _inFlightResolutions.putIfAbsent(cacheKey, () async {
-      final bytes = await _loadArtworkBytes(audioSourcePath);
-      if (bytes == null || bytes.isEmpty) {
+    final future = _inFlightResolutions.putIfAbsent(audioSourcePath, () async {
+      final raw = await _loadArtworkBytes(audioSourcePath);
+      if (raw == null || raw.isEmpty) {
         await _persistArtworkPath(audioSourcePath, null);
         return null;
       }
 
+      final cacheKey = _cacheKey(raw);
+      final cached = await _cacheManager.getFileFromCache(cacheKey);
+      final cachedPath = cached?.file.path;
+      if (await _isUsableImagePath(cachedPath)) {
+        unawaited(_persistArtworkPath(audioSourcePath, cachedPath));
+        return cachedPath;
+      }
+
+      final bytes = await _normalizeArtworkBytes(raw);
       final extension = _detectFileExtension(bytes);
       final file = await _cacheManager.putFile(
         cacheKey,
@@ -68,7 +69,7 @@ class AlbumArtService {
     try {
       return await future;
     } finally {
-      _inFlightResolutions.remove(cacheKey);
+      _inFlightResolutions.remove(audioSourcePath);
     }
   }
 
@@ -128,6 +129,10 @@ class AlbumArtService {
     return rust_scanner.extractEmbeddedArtwork(path: audioSourcePath);
   }
 
+  Future<Uint8List> _normalizeArtworkBytes(Uint8List raw) {
+    return compute(_normalizeArtworkIsolate, raw);
+  }
+
   Future<void> _persistArtworkPath(
     String audioSourcePath,
     String? albumArtPath,
@@ -145,8 +150,8 @@ class AlbumArtService {
     }
   }
 
-  String _cacheKey(String audioSourcePath) {
-    final digest = md5.convert(utf8.encode(audioSourcePath));
+  String _cacheKey(Uint8List bytes) {
+    final digest = md5.convert(bytes);
     return 'embedded-artwork:${digest.toString()}';
   }
 
@@ -191,4 +196,34 @@ class AlbumArtService {
 
     return 'jpg';
   }
+}
+
+const int _artworkMaxDimension = 1000;
+const int _artworkPassthroughBytes = 512 * 1024;
+const int _artworkJpegQuality = 85;
+
+Uint8List _normalizeArtworkIsolate(Uint8List raw) {
+  if (raw.length < _artworkPassthroughBytes) {
+    return raw;
+  }
+
+  final decoded = img.decodeImage(raw);
+  if (decoded == null) {
+    return raw;
+  }
+
+  final img.Image target;
+  if (decoded.width >= decoded.height) {
+    target = decoded.width > _artworkMaxDimension
+        ? img.copyResize(decoded, width: _artworkMaxDimension)
+        : decoded;
+  } else {
+    target = decoded.height > _artworkMaxDimension
+        ? img.copyResize(decoded, height: _artworkMaxDimension)
+        : decoded;
+  }
+
+  return Uint8List.fromList(
+    img.encodeJpg(target, quality: _artworkJpegQuality),
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -603,7 +603,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   home_widget: ^0.7.0
   freezed_annotation: ^3.0.0
   http: ^1.2.0
+  image: ^4.8.0
   image_picker: ^1.1.2
   isar_community: ^3.3.2
   isar_community_flutter_libs: ^3.3.2


### PR DESCRIPTION
# Summary

- Normalize embedded album art by resizing and re-encoding as JPEG for storage efficiency and consistency
- Compute cache keys from raw image content instead of source path for artwork deduplication
- Promote `image: ^4.8.0` dependency to direct main

# Changes

## Artwork Caching

- Rework artwork caching to normalize large images by resizing and re-encoding as JPEG
- Compute cache keys from raw image content rather than source path
- Enable deduplication of identical artwork across different source paths

## Dependencies

- Add `image: ^4.8.0` as direct dependency
- Update `pubspec.lock` accordingly

## Files Changed

- `lib/services/album_art_service.dart`
- `pubspec.yaml`
- `pubspec.lock`