### PR TITLE
Add glance card preferences with album art handling, migrate albums screen to Riverpod, prepare 0.20.2-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.20.2-beta.3 (2026-06-27)
+
+### Bluetooth Codec Control
+- **Bluetooth Hi-Res Direct mode** forces highest-quality codec path.
+- Per-codec preference controls with persistence (AAC, aptX, LDAC, etc.).
+- Codec preferences applied on Bluetooth init and connect.
+- Device connection state tracking with codec configuration feedback.
+- Hi-Res Direct mode resolved before low-latency in audio route selection.
+- Bluetooth settings refactored with codec control, device filtering, and UI refinements.
+- Developer mode toggle for advanced codec debugging.
+
+### Glance Cards & Albums
+- Glance card visibility toggle — show, hide, or minimize Quick Access cards.
+- Per-card hidden/minimized preferences persisted.
+- `AlbumsScreen` migrated to Riverpod with app preferences integration.
+- Single-art and empty-art edge cases handled; album year on cards.
+- `AlbumArtPickerBottomSheet` returns change status for reactive updates.
+- Stale song provider prevented on in-place art updates.
+
+### Streak & Milestone Polish
+- Animated shimmer replaced with static tier-colored text for performance.
+- Dynamic tier colors and glow effects on streak popup.
+- Tier-based shimmer effect on streak popup background.
+- Tier color/count helpers on `MilestoneCategoryX`.
+- New tests for tier colors and counts.
+
+### USB Audio Fixes
+- Write-only USB clocks supported — trusts `SET_CUR` when readback unavailable.
+- USB permission `PendingIntent` fixed for restrictive devices.
+
+### Artwork Cache Improvements
+- Embedded album art normalized before caching.
+- Content-based cache keys replace path-based keys.
+
+### Queue & Playback
+- Playlist restart from end when wrap-around is enabled.
+- Duplicate recently-played check removed.
+
+### Debug & Developer
+- Debug logging in audio strategy and decoder selection paths.
+- Feature requests document added.
+
 ## 0.20.1-beta.2 (2026-06-24)
 
 ### AutoEQ Headphone Matching

--- a/FEATURE_REQUESTS.md
+++ b/FEATURE_REQUESTS.md
@@ -1,0 +1,22 @@
+# Feature Requests
+
+User-suggested enhancements that are deferred (not implemented yet).
+
+## Album list view — additional columns
+
+The album list view (`_AlbumListTile` in
+`lib/features/songs/screens/songs_screen.dart`) currently shows artwork, album
+name, track count, artist, and (newly added) **Year**.
+
+Requested but not yet built:
+
+- **Genre** column — derivable from `Song.genre` (first non-null across the
+  album's songs, same scan pattern used for Year).
+- **Total duration** column — sum of `Song.duration` across the album's songs.
+- **Track count as its own column** (currently inline in the subtitle as
+  `"$trackCount tracks • $artist"`).
+
+Adding more columns means turning the `Row` in `_AlbumListTile.build` into a
+wider multi-column layout (or a true `DataTable`). Watch for overflow on narrow
+devices — consider making columns configurable/toggleable via a setting when
+this is picked up.

--- a/docs/FEATURE_REQUESTS.md
+++ b/docs/FEATURE_REQUESTS.md
@@ -30,6 +30,7 @@
   - [ ] HRTF preset library
   - [ ] Optional HRTF scan upload
 - [ ] **MQA (Master Quality Authenticated)** — decode and play MQA content
+- [ ] **Pitch shifter** — adjust audio pitch independently of tempo (cf. JetAudio, Musicolet, Stellio, Omnia)
 
 ---
 

--- a/docs/RELEASE_0.20.2-beta.3.md
+++ b/docs/RELEASE_0.20.2-beta.3.md
@@ -1,0 +1,93 @@
+# Flick 0.20.2-beta.3
+
+0.20.2-beta.3 is a polish and stability release: Bluetooth codec control with Hi-Res Direct mode, glance card visibility toggles, streak popup visual polish, USB clock and permission fixes, artwork cache improvements, and queue wrap-around fixes.
+
+## Overview
+
+This beta adds seven headline features:
+
+1. **Bluetooth codec control** — Hi-Res Direct mode, per-codec preferences, device filtering, developer debug
+2. **Glance card toggles** — show/hide/minimize Quick Access cards from Interface settings
+3. **Streak & milestone polish** — tier-colored text, dynamic glow effects, performance improvements
+4. **USB audio fixes** — write-only clock support, PendingIntent fix
+5. **Artwork cache** — content-based keys, embedded art normalization
+6. **Queue wrap-around** — playlist restart from end
+7. **Debug logging** — strategy and decoder selection paths
+
+## Highlights
+
+- **Bluetooth codec control**: A Hi-Res Direct mode forces the highest-quality codec (LDAC, aptX HD) for compatible headphones. Per-codec preferences (AAC, aptX, LDAC, SBC, etc.) are persisted and applied on Bluetooth init and device connect. Device connection state is tracked with codec configuration feedback in the UI. Hi-Res Direct mode is resolved before low-latency in audio route selection. Bluetooth settings gained device filtering, UI refinements, and a developer mode toggle for advanced codec debugging.
+- **Glance cards**: Each Quick Access card (Recently Played, Smart Mixes, Artists, etc.) can now be hidden, shown, or minimized independently. Per-card preferences are persisted. `AlbumsScreen` was migrated to `ConsumerStatefulWidget` (Riverpod) with app preferences. Single-art and empty-art album edge cases are handled, and the album year is displayed on album cards. `AlbumArtPickerBottomSheet` returns a change status for reactive UI updates. A stale song provider after in-place art updates is prevented.
+- **Streak polish**: The animated shimmer streak number on the popup was replaced with static tier-colored text — no more phantom shimmer glitter. Dynamic tier colors and glow effects pulse on the streak banner. Tier color and count helpers were added to `MilestoneCategoryX`. New unit tests cover tier colors and counts.
+- **USB fixes**: Write-only USB clocks (devices that don't support readback on `GET_CUR`) are now supported by trusting the `SET_CUR` value. A USB permission `PendingIntent` failure on devices with restrictive package handling is fixed.
+- **Artwork cache**: Embedded album art is normalized before caching so that different encodings of the same image share one cache entry. Cache keys are now content-based rather than path-based — the same artwork from different files reuses the cached bitmap.
+- **Queue**: Playlists now restart from the end when wrap-around queue is enabled. A duplicate recently-played entry check that could skip play-count updates was removed.
+- **Debug**: Debug logging was added to the audio strategy score calculation and decoder selection paths, making it easier to trace why a particular audio path or decoder was chosen.
+
+## What's New
+
+### Bluetooth Codec Control
+
+- Hi-Res Direct mode forces highest-quality codec
+- Per-codec preference persistence (AAC, aptX, LDAC, etc.)
+- Codec preferences applied on init and connect
+- Device connection state with codec feedback
+- Hi-Res Direct before low-latency in route resolution
+- Device filtering and UI refinements in Bluetooth settings
+- Developer mode toggle for codec debugging
+
+### Glance Cards & Albums
+
+- Show/hide/minimize per Quick Access card
+- Riverpod-based AlbumsScreen with app preferences
+- Single-art/empty-art edge cases; album year display
+- Change-status return from AlbumArtPickerBottomSheet
+- Stale song provider fix on art updates
+
+### Streak & Milestone Polish
+
+- Static tier-colored text replaces animated shimmer
+- Dynamic tier colors and glow on streak banner
+- Tier-based shimmer on popup background
+- `MilestoneCategoryX` tier color/count helpers
+- Tier color and count tests
+
+### USB Audio Fixes
+
+- Write-only USB clock support (trusts SET_CUR)
+- USB PendingIntent fix for restrictive packages
+
+### Artwork Cache
+
+- Embedded art normalized before caching
+- Content-based cache keys
+
+### Queue & Playback
+
+- Playlist wrap-around from end
+- Duplicate recently-played check removed
+
+### Debug & Developer
+
+- Debug logging in strategy/decoder selection
+- Feature requests doc
+
+## Files Changed
+
+| Area | Key Paths |
+| --- | --- |
+| Bluetooth | `lib/services/bluetooth_service.dart`, `lib/features/settings/screens/bluetooth_settings_screen.dart`, `lib/providers/` |
+| Glance Cards | `lib/features/home/widgets/menu_screen.dart`, `lib/providers/app_preferences_provider.dart` |
+| Albums | `lib/features/albums/screens/albums_screen.dart`, `lib/widgets/album_art_picker_bottom_sheet.dart` |
+| Streaks | `lib/features/milestones/widgets/streak_popup.dart`, `lib/services/milestone_service.dart` |
+| USB | `rust/src/uac2/`, `rust/src/audio/android_direct_usb.rs` |
+| Artwork | `lib/services/artwork_cache_service.dart`, `lib/services/cache_manager_service.dart` |
+| Queue | `lib/providers/player_provider.dart` |
+
+## Upgrading
+
+1. Bluetooth codec controls are in Settings → Audio → Bluetooth — Hi-Res Direct is off by default
+2. Glance card visibility toggles are in Settings → Interface — all cards default to shown
+3. Streak popup styling applies automatically; no configuration needed
+4. USB clock fixes are transparent — no user action required
+5. Artwork cache is rebuilt with content-based keys on next scan; slightly faster subsequent lookups

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,12 +1,12 @@
 /// Current marketing version of the app (matches the `version` field in
 /// `pubspec.yaml`). Bump in lockstep with each release.
-const String kAppVersion = '0.20.1-beta.2';
+const String kAppVersion = '0.20.2-beta.3';
 
 /// Current build number (matches the `version` `+N` suffix in
 /// `pubspec.yaml`). Bump whenever `kAppVersion` is bumped.
-const String kAppBuild = '18';
+const String kAppBuild = '19';
 
-/// Human-friendly version label, e.g. `0.20.1-beta.2 (build 18)`.
+/// Human-friendly version label, e.g. `0.20.2-beta.3 (build 19)`.
 const String kAppVersionLabel = '$kAppVersion (build $kAppBuild)';
 
 /// App-wide constants for Flick Player.

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -13,24 +13,24 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
 
 enum AlbumSortOption { name, artist, tracks }
 
 /// Albums screen with masonry grid of album artwork.
-class AlbumsScreen extends StatefulWidget {
+class AlbumsScreen extends ConsumerStatefulWidget {
   const AlbumsScreen({super.key});
 
   @override
-  State<AlbumsScreen> createState() => _AlbumsScreenState();
+  ConsumerState<AlbumsScreen> createState() => _AlbumsScreenState();
 }
 
-class _AlbumsScreenState extends State<AlbumsScreen> {
+class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
   final SongRepository _songRepository = SongRepository();
   final PlayerService _playerService = PlayerService();
   List<AlbumGroup> _albums = [];
   List<AlbumGroup> _sortedAlbums = [];
   bool _isLoading = true;
-  bool _isGlanceMinimized = false;
   AlbumSortOption _sortOption = AlbumSortOption.artist;
   bool _visibilitySet = false;
 
@@ -250,22 +250,25 @@ class _AlbumsScreenState extends State<AlbumsScreen> {
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
-          GestureDetector(
-            onTap: () {
-              setState(() {
-                _isGlanceMinimized = !_isGlanceMinimized;
-              });
-            },
-            child: AnimatedCrossFade(
-              firstChild: _buildGlanceCard(context, expanded: true),
-              secondChild: _buildGlanceCard(context, expanded: false),
-              crossFadeState:
-                  _isGlanceMinimized
-                      ? CrossFadeState.showSecond
-                      : CrossFadeState.showFirst,
-              duration: AppConstants.animationNormal,
+          if (!ref.watch(appPreferencesProvider).glanceCardHidden)
+            GestureDetector(
+              onTap: () {
+                ref
+                    .read(appPreferencesProvider.notifier)
+                    .setGlanceCardMinimized(
+                      !ref.read(appPreferencesProvider).glanceCardMinimized,
+                    );
+              },
+              child: AnimatedCrossFade(
+                firstChild: _buildGlanceCard(context, expanded: true),
+                secondChild: _buildGlanceCard(context, expanded: false),
+                crossFadeState:
+                    ref.watch(appPreferencesProvider).glanceCardMinimized
+                        ? CrossFadeState.showSecond
+                        : CrossFadeState.showFirst,
+                duration: AppConstants.animationNormal,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/features/artists/screens/artists_screen.dart
+++ b/lib/features/artists/screens/artists_screen.dart
@@ -12,19 +12,20 @@ import 'package:flick/features/artists/screens/artist_detail_screen.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/glass_search_bar.dart';
 
 enum ArtistSortOption { name, songs, albums }
 
-class ArtistsScreen extends StatefulWidget {
+class ArtistsScreen extends ConsumerStatefulWidget {
   const ArtistsScreen({super.key});
 
   @override
-  State<ArtistsScreen> createState() => _ArtistsScreenState();
+  ConsumerState<ArtistsScreen> createState() => _ArtistsScreenState();
 }
 
-class _ArtistsScreenState extends State<ArtistsScreen> {
+class _ArtistsScreenState extends ConsumerState<ArtistsScreen> {
   final SongRepository _songRepository = SongRepository();
   final PlayerService _playerService = PlayerService();
   final TextEditingController _searchController = TextEditingController();
@@ -33,7 +34,6 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
   List<MapEntry<String, List<Song>>> _sortedArtists = [];
   String _searchQuery = '';
   bool _isLoading = true;
-  bool _isGlanceMinimized = false;
   ArtistSortOption _sortOption = ArtistSortOption.name;
   bool _visibilitySet = false;
 
@@ -312,19 +312,26 @@ class _ArtistsScreenState extends State<ArtistsScreen> {
             ),
           ),
           const SizedBox(height: AppConstants.spacingMd),
-          GestureDetector(
-            onTap: () {
-              setState(() => _isGlanceMinimized = !_isGlanceMinimized);
-            },
-            child: AnimatedCrossFade(
-              firstChild: _buildGlanceCard(context, expanded: true),
-              secondChild: _buildGlanceCard(context, expanded: false),
-              crossFadeState: _isGlanceMinimized
-                  ? CrossFadeState.showSecond
-                  : CrossFadeState.showFirst,
-              duration: AppConstants.animationNormal,
+          if (!ref.watch(appPreferencesProvider).glanceCardHidden)
+            GestureDetector(
+              onTap: () {
+                ref
+                    .read(appPreferencesProvider.notifier)
+                    .setGlanceCardMinimized(
+                      !ref.read(appPreferencesProvider).glanceCardMinimized,
+                    );
+              },
+              child: AnimatedCrossFade(
+                firstChild: _buildGlanceCard(context, expanded: true),
+                secondChild: _buildGlanceCard(context, expanded: false),
+                crossFadeState: ref
+                        .watch(appPreferencesProvider)
+                        .glanceCardMinimized
+                    ? CrossFadeState.showSecond
+                    : CrossFadeState.showFirst,
+                duration: AppConstants.animationNormal,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -1432,12 +1432,15 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                     label: 'Set Album Art',
                     onTap: () {
                       Navigator.pop(sheetContext);
-                      unawaited(
-                        Future<void>.delayed(
-                          Duration.zero,
-                          () => AlbumArtPickerBottomSheet.show(context, activeSong),
-                        ),
-                      );
+                      Future.delayed(Duration.zero, () async {
+                        final changed = await AlbumArtPickerBottomSheet.show(
+                          context,
+                          activeSong,
+                        );
+                        if (changed && context.mounted) {
+                          ref.invalidate(songsProvider);
+                        }
+                      });
                     },
                   ),
                   if (activeSong.filePath != null &&

--- a/lib/features/settings/screens/interface_settings_screen.dart
+++ b/lib/features/settings/screens/interface_settings_screen.dart
@@ -73,6 +73,18 @@ class InterfaceSettingsScreen extends ConsumerWidget {
                 },
               ),
               const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.layoutGrid,
+                title: 'Library Glance Card',
+                subtitle: 'Show the "at a glance" summary on Artists/Albums',
+                value: !appPreferences.glanceCardHidden,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setGlanceCardHidden(!value);
+                },
+              ),
+              const SettingsDivider(),
               NavigationSetting(
                 icon: LucideIcons.navigation,
                 title: 'Bottom Bar',

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -2610,11 +2610,20 @@ class _AlbumCardState extends State<_AlbumCard>
                               child: Stack(
                                 fit: StackFit.expand,
                                 children: [
-                                  _buildArtGrid(
-                                    padded,
-                                    artworkTargetWidth,
-                                    context,
-                                  ),
+                                  if (artworks.length == 1)
+                                    _buildSingleArt(
+                                      artworks.first,
+                                      artworkTargetWidth,
+                                      context,
+                                    )
+                                  else if (artworks.isEmpty)
+                                    _buildGridPlaceholder(context)
+                                  else
+                                    _buildArtGrid(
+                                      padded,
+                                      artworkTargetWidth,
+                                      context,
+                                    ),
                                   Positioned.fill(
                                     child: DecoratedBox(
                                       decoration: BoxDecoration(
@@ -2744,6 +2753,23 @@ class _AlbumCardState extends State<_AlbumCard>
     );
   }
 
+  Widget _buildSingleArt(
+    _ArtEntry entry,
+    int targetWidth,
+    BuildContext context,
+  ) {
+    return CachedImageWidget(
+      imagePath: entry.art,
+      audioSourcePath: entry.source,
+      fit: BoxFit.cover,
+      useThumbnail: true,
+      thumbnailWidth: targetWidth,
+      thumbnailHeight: targetWidth,
+      placeholder: _buildGridPlaceholder(context),
+      errorWidget: _buildGridPlaceholder(context),
+    );
+  }
+
   Widget _buildGridPlaceholder(BuildContext context) {
     return ClipRRect(
       borderRadius: BorderRadius.all(Radius.circular(AppConstants.radiusSm)),
@@ -2777,6 +2803,13 @@ class _AlbumListTile extends StatelessWidget {
     final artPath = artSong?.albumArt;
     final sourcePath = artSong?.filePath ?? album.songs.first.filePath;
     final trackCount = album.songs.length;
+    int? albumYear;
+    for (final s in album.songs) {
+      if (s.year != null && s.year! > 0) {
+        albumYear = s.year;
+        break;
+      }
+    }
 
     return Material(
       color: Colors.transparent,
@@ -2864,6 +2897,17 @@ class _AlbumListTile extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: AppConstants.spacingSm),
+              if (albumYear != null)
+                Padding(
+                  padding: const EdgeInsets.only(right: AppConstants.spacingSm),
+                  child: Text(
+                    albumYear.toString(),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextSecondary,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ),
               Icon(
                 LucideIcons.chevronRight,
                 color: context.adaptiveTextTertiary,

--- a/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
+++ b/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
@@ -18,7 +18,7 @@ class AlbumArtPickerBottomSheet extends StatefulWidget {
 
   final Song song;
 
-  static Future<void> show(BuildContext context, Song song) async {
+  static Future<bool> show(BuildContext context, Song song) async {
     final messenger = ScaffoldMessenger.maybeOf(context);
     final result = await showModalBottomSheet<_AlbumArtSheetResult>(
       context: context,
@@ -30,8 +30,9 @@ class AlbumArtPickerBottomSheet extends StatefulWidget {
       ),
     );
 
+    final changed = result != null;
     if (!context.mounted || messenger == null || result == null) {
-      return;
+      return changed;
     }
 
     messenger
@@ -42,6 +43,7 @@ class AlbumArtPickerBottomSheet extends StatefulWidget {
           behavior: SnackBarBehavior.floating,
         ),
       );
+    return changed;
   }
 
   @override

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -119,12 +119,15 @@ class SongActionsBottomSheet extends ConsumerWidget {
             label: 'Set Album Art',
             onTap: () {
               Navigator.pop(context);
-              unawaited(
-                Future<void>.delayed(
-                  Duration.zero,
-                  () => AlbumArtPickerBottomSheet.show(rootContext, song),
-                ),
-              );
+              Future.delayed(Duration.zero, () async {
+                final changed = await AlbumArtPickerBottomSheet.show(
+                  rootContext,
+                  song,
+                );
+                if (changed && rootContext.mounted) {
+                  ref.invalidate(songsProvider);
+                }
+              });
             },
           ),
           if (song.filePath != null &&

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -44,6 +44,73 @@ class ChangelogSubsection {
 /// automatically surface the entry whose `version` equals `kAppVersion`.
 const List<ChangelogEntry> kChangelogEntries = [
   ChangelogEntry(
+    version: '0.20.2-beta.3',
+    date: '2026-06-27',
+    sections: [
+      ChangelogSection(
+        title: 'Bluetooth Codec Control',
+        bullets: [
+          '**Bluetooth Hi-Res Direct mode** — forces the highest-quality codec path for capable headphones.',
+          'Per-codec preference controls with persistence (AAC, aptX, LDAC, etc.).',
+          'Codec preferences applied on Bluetooth init and on device connect.',
+          'Device connection state tracking with codec configuration feedback.',
+          'Hi-Res Direct mode resolved before low-latency in audio route selection.',
+          'Bluetooth settings refactored with codec control, device filtering, and UI refinements.',
+          'Developer mode toggle in Bluetooth settings for advanced codec debugging.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Glance Cards & Albums',
+        bullets: [
+          'Glance card visibility toggle — show, hide, or minimize the Quick Access card on the menu screen.',
+          'Per-card hidden and minimized preferences persisted across sessions.',
+          '`AlbumsScreen` migrated to `ConsumerStatefulWidget` (Riverpod) with app preferences integration.',
+          'Single-art and empty-art edge cases handled; album year displayed on album cards.',
+          '`AlbumArtPickerBottomSheet.show()` returns change status for reactive UI updates.',
+          'Stale song provider prevented on in-place album art updates.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Streak & Milestone Polish',
+        bullets: [
+          'Animated shimmer streak number replaced with static tier-colored text for performance.',
+          'Dynamic tier colors and glow effects on the streak popup banner.',
+          'Tier-based shimmer effect on streak popup background.',
+          'Tier color and count helpers added to `MilestoneCategoryX`.',
+          'New tests for milestone tier colors and counts.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'USB Audio Fixes',
+        bullets: [
+          '**Write-only USB clocks** supported — trusts `SET_CUR` when readback is unavailable from the device.',
+          'USB permission `PendingIntent` fixed for devices that don\'t support explicit packages.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Artwork Cache Improvements',
+        bullets: [
+          'Embedded album art normalized before caching for consistent lookups.',
+          'Content-based cache keys replace path-based keys — same art from different files shares one cache entry.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Queue & Playback',
+        bullets: [
+          'Playlist restart from end when wrap-around queue is enabled.',
+          'Duplicate recently-played entry check removed — prevents missing play-count updates.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Debug & Developer',
+        bullets: [
+          'Debug logging added to audio strategy and decoder selection paths.',
+          'Feature requests tracking document added to docs.',
+        ],
+      ),
+    ],
+  ),
+  ChangelogEntry(
     version: '0.20.1-beta.2',
     date: '2026-06-24',
     sections: [

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -375,6 +375,20 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
         .setWelcomeCardDismissed(value);
   }
 
+  Future<void> setGlanceCardHidden(bool value) async {
+    if (state.glanceCardHidden == value) return;
+    state = state.copyWith(glanceCardHidden: value);
+    await ref.read(appPreferencesServiceProvider).setGlanceCardHidden(value);
+  }
+
+  Future<void> setGlanceCardMinimized(bool value) async {
+    if (state.glanceCardMinimized == value) return;
+    state = state.copyWith(glanceCardMinimized: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setGlanceCardMinimized(value);
+  }
+
   Future<void> setReplaceAlbumWithBitPerfectCapsule(bool value) async {
     if (state.replaceAlbumWithBitPerfectCapsule == value) return;
     state = state.copyWith(replaceAlbumWithBitPerfectCapsule: value);

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -488,9 +488,14 @@ final playerProvider = NotifierProvider<PlayerNotifier, PlayerState>(
 // Convenience selectors for granular rebuilds
 // ============================================================================
 
-/// Current song selector - only rebuilds when the song changes.
+/// Current song selector.
+///
+/// Watches `playerProvider` without `.select` so in-place updates that don't
+/// change `Song.id` (e.g. album-art rewrites via `syncAlbumArtPaths`) still
+/// re-emit. `Song.==` is by id, so `.select((s) => s.currentSong)` would mask
+/// those changes.
 final currentSongProvider = Provider<Song?>((ref) {
-  return ref.watch(playerProvider.select((state) => state.currentSong));
+  return ref.watch(playerProvider).currentSong;
 });
 
 /// Is playing selector.

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -50,6 +50,8 @@ class AppPreferences {
   final String leftActionButton;
   final String rightActionButton;
   final bool welcomeCardDismissed;
+  final bool glanceCardHidden;
+  final bool glanceCardMinimized;
   final bool replaceAlbumWithBitPerfectCapsule;
   final int folderGridPageSize;
   final String? lastSeenChangelogVersion;
@@ -123,6 +125,8 @@ class AppPreferences {
     this.leftActionButton = 'lyrics',
     this.rightActionButton = 'favorites',
     this.welcomeCardDismissed = false,
+    this.glanceCardHidden = false,
+    this.glanceCardMinimized = false,
     this.replaceAlbumWithBitPerfectCapsule = false,
     this.folderGridPageSize = 8,
     this.lastSeenChangelogVersion,
@@ -197,6 +201,8 @@ class AppPreferences {
     String? leftActionButton,
     String? rightActionButton,
     bool? welcomeCardDismissed,
+    bool? glanceCardHidden,
+    bool? glanceCardMinimized,
     bool? replaceAlbumWithBitPerfectCapsule,
     int? folderGridPageSize,
     String? lastSeenChangelogVersion,
@@ -288,6 +294,8 @@ class AppPreferences {
       leftActionButton: leftActionButton ?? this.leftActionButton,
       rightActionButton: rightActionButton ?? this.rightActionButton,
       welcomeCardDismissed: welcomeCardDismissed ?? this.welcomeCardDismissed,
+      glanceCardHidden: glanceCardHidden ?? this.glanceCardHidden,
+      glanceCardMinimized: glanceCardMinimized ?? this.glanceCardMinimized,
       replaceAlbumWithBitPerfectCapsule:
           replaceAlbumWithBitPerfectCapsule ??
           this.replaceAlbumWithBitPerfectCapsule,
@@ -379,6 +387,8 @@ class AppPreferencesService {
   static const _leftActionButtonKey = 'left_action_button';
   static const _rightActionButtonKey = 'right_action_button';
   static const _welcomeCardDismissedKey = 'welcome_card_dismissed';
+  static const _glanceCardHiddenKey = 'glance_card_hidden';
+  static const _glanceCardMinimizedKey = 'glance_card_minimized';
   static const _replaceAlbumWithBitPerfectCapsuleKey =
       'replace_album_with_bit_perfect_capsule';
   static const _folderGridPageSizeKey = 'folder_grid_page_size';
@@ -481,6 +491,8 @@ class AppPreferencesService {
       leftActionButton: prefs.getString(_leftActionButtonKey) ?? 'lyrics',
       rightActionButton: prefs.getString(_rightActionButtonKey) ?? 'favorites',
       welcomeCardDismissed: prefs.getBool(_welcomeCardDismissedKey) ?? false,
+      glanceCardHidden: prefs.getBool(_glanceCardHiddenKey) ?? false,
+      glanceCardMinimized: prefs.getBool(_glanceCardMinimizedKey) ?? false,
       replaceAlbumWithBitPerfectCapsule:
           prefs.getBool(_replaceAlbumWithBitPerfectCapsuleKey) ?? false,
       folderGridPageSize: prefs.getInt(_folderGridPageSizeKey) ?? 8,
@@ -956,6 +968,26 @@ class AppPreferencesService {
   Future<void> setWelcomeCardDismissed(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_welcomeCardDismissedKey, value);
+  }
+
+  Future<bool> getGlanceCardHidden() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_glanceCardHiddenKey) ?? false;
+  }
+
+  Future<void> setGlanceCardHidden(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_glanceCardHiddenKey, value);
+  }
+
+  Future<bool> getGlanceCardMinimized() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_glanceCardMinimizedKey) ?? false;
+  }
+
+  Future<void> setGlanceCardMinimized(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_glanceCardMinimizedKey, value);
   }
 
   Future<bool> getReplaceAlbumWithBitPerfectCapsule() async {


### PR DESCRIPTION
# Summary

- Add glance card hidden and minimized preferences with persistence and interface settings toggle
- Handle album art change detection and refresh songs across screens
- Mark `AlbumsScreen` to Riverpod and use app preferences
- Make `AlbumArtPickerBottomSheet` show return change status with single-art/empty-art handling
- Prevent stale song provider on in-place updates
- Prepare `0.20.2-beta.3` pre-release with changelog and release notes

# Changes

## Glance Card Preferences

- Add hidden and minimized preferences for glance card with provider/persistence
- Add toggle for glance card visibility in interface settings
- Migrate glance card state to app preferences provider
- Handle album art change and refresh songs across screens
- Handle single-art and empty-art cases in glance card
- Show album year in glance card

## Albums Screen

- Migrate `AlbumsScreen` to Riverpod and use app preferences
- Migrate glance card state from local context to shared provider

## Album Art Picker

- Make `AlbumArtPickerBottomSheet.show` return change status (`bool`)
- Handle album art change and refresh songs from song actions full player

## Performance

- Prevent stale song provider on in-place updates in player provider

## Release

- Prepare `0.20.2-beta.3` pre-release
- Add changelog entries and release notes document
- Update version constants

## Files Changed

- `lib/providers/app_preferences_provider.dart`
- `lib/providers/player_provider.dart`
- `lib/services/app_preferences_service.dart`
- `lib/features/albums/screens/albums_screen.dart`
- `lib/features/artists/screens/artists_screen.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/settings/screens/interface_settings_screen.dart`
- `lib/features/songs/screens/songs_screen.dart`
- `lib/features/songs/widgets/album_art_picker_bottom_sheet.dart`
- `lib/features/songs/widgets/song_actions_bottom_sheet.dart`
- `lib/core/constants/app_constants.dart`
- `lib/features/whats_new/data/changelog_data.dart`
- `CHANGELOG.md`
- `docs/RELEASE_0.20.2-beta.3.md`
- `FEATURE_REQUESTS.md`