### PR TITLE
Improve widget sync resiliency and artwork extraction performance during scroll

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://opencode.ai/config.json",
   "plugin": [
     ".opencode/plugins/graphify.js"
   ]

--- a/android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt
@@ -21,6 +21,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import androidx.core.app.NotificationCompat
 import androidx.media.app.NotificationCompat as MediaNotificationCompat
+import com.mossapps.flick.widgets.WidgetPrefs
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodChannel
 
@@ -250,6 +251,14 @@ class MusicNotificationService : Service() {
     }
 
     private fun shutdownForTaskRemoval() {
+        // Playback dies with the process; mirror that on home-screen widgets so the
+        // play/pause icon can't stay stuck on "playing" after the app is killed.
+        try {
+            WidgetPrefs.get(this).edit().putBoolean(WidgetPrefs.KEY_IS_PLAYING, false).apply()
+            WidgetPrefs.updateAllWidgets(this)
+        } catch (_: Exception) {
+        }
+
         try {
             if (isForegroundServiceStarted) {
                 stopForeground(STOP_FOREGROUND_REMOVE)

--- a/android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt
@@ -1,5 +1,8 @@
 package com.mossapps.flick.widgets
 
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import com.mossapps.flick.R
@@ -30,6 +33,22 @@ internal object WidgetPrefs {
 
     fun get(context: Context): SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    // ponytail: rebuild all three home widgets from current prefs; used when the
+    // app process is about to die so the play/pause state can't drift stale.
+    fun updateAllWidgets(context: Context) {
+        val mgr = AppWidgetManager.getInstance(context)
+        listOf(
+            MiniPlayerWidgetProvider::class.java,
+            FlagshipWidgetProvider::class.java,
+            CompactWidgetProvider::class.java,
+        ).forEach { cls ->
+            val ids = mgr.getAppWidgetIds(ComponentName(context, cls))
+            if (ids.isNotEmpty()) {
+                cls.getDeclaredConstructor().newInstance().onUpdate(context, mgr, ids)
+            }
+        }
+    }
 
     fun getBgOpacityAlpha(context: Context): Int {
         val level = get(context).getInt(KEY_BG_OPACITY, 3)

--- a/lib/features/songs/widgets/orbit_scroll.dart
+++ b/lib/features/songs/widgets/orbit_scroll.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -8,6 +9,7 @@ import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/features/songs/widgets/song_card.dart';
+import 'package:flick/widgets/common/cached_image_widget.dart';
 
 class OrbitScrollController {
   void Function(int index, bool animate)? _jumpToIndex;
@@ -84,6 +86,9 @@ class _OrbitScrollState extends State<OrbitScroll>
 
   // Track if we're actively scrolling to reduce visible range when idle
   bool _isScrolling = false;
+
+  // Debounce timer that flushes deferred artwork extraction after a fling settles.
+  Timer? _artworkGateTimer;
   DateTime _lastScrollTime = DateTime.now();
   int _lastReportedIndex = 0;
 
@@ -135,6 +140,8 @@ class _OrbitScrollState extends State<OrbitScroll>
     widget.controller?._detach();
     _controller.dispose();
     _scrollOffset.dispose();
+    _artworkGateTimer?.cancel();
+    pauseArtworkExtraction(false);
     super.dispose();
   }
 
@@ -164,6 +171,7 @@ class _OrbitScrollState extends State<OrbitScroll>
       final newOffset = _controller.value;
       if ((newOffset - _scrollOffset.value).abs() > 0.001) {
         _scrollOffset.value = newOffset;
+        _markScrollActive();
         if (!_isScrolling) {
           setState(() {
             _isScrolling = true;
@@ -184,6 +192,14 @@ class _OrbitScrollState extends State<OrbitScroll>
   }
 
   // --- Gesture Handling ---
+
+  void _markScrollActive() {
+    pauseArtworkExtraction(true);
+    _artworkGateTimer?.cancel();
+    _artworkGateTimer = Timer(const Duration(milliseconds: 150), () {
+      pauseArtworkExtraction(false);
+    });
+  }
 
   void _onVerticalDragStart(DragStartDetails details) {
     _controller.stop();

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -348,7 +348,9 @@ class _SongCardState extends State<SongCard> {
     BoxFit fit = BoxFit.cover,
     required double artSize,
   }) {
-    final isThumbnail = artSize <= AppConstants.songCardArtSize;
+    // ponytail: cap decode at 2x artSize. Selected card used to decode full-res,
+    // OOM'ing during fast orbit fling. Soft on >2x DPR — scale by devicePixelRatio if it shows.
+    final decodeDim = (artSize * 2).toInt();
 
     return CachedImageWidget(
       imagePath: path,
@@ -356,13 +358,9 @@ class _SongCardState extends State<SongCard> {
       fit: fit,
       placeholder: _buildPlaceholderArt(),
       errorWidget: _buildPlaceholderArt(),
-      useThumbnail: isThumbnail,
-      thumbnailWidth: isThumbnail
-          ? (AppConstants.songCardArtSize * 2).toInt()
-          : null,
-      thumbnailHeight: isThumbnail
-          ? (AppConstants.songCardArtSize * 2).toInt()
-          : null,
+      useThumbnail: true,
+      thumbnailWidth: decodeDim,
+      thumbnailHeight: decodeDim,
     );
   }
 

--- a/lib/widgets/common/cached_image_widget.dart
+++ b/lib/widgets/common/cached_image_widget.dart
@@ -82,8 +82,28 @@ class CachedImageWidget extends StatefulWidget {
   State<CachedImageWidget> createState() => _CachedImageWidgetState();
 }
 
+// ponytail: gate heavy first-time artwork extraction during fast orbit fling;
+// batch deferred work and flush on settle.
+bool _artworkExtractionPaused = false;
+final List<VoidCallback> _pendingArtworkResolvers = <VoidCallback>[];
+
+void pauseArtworkExtraction(bool paused) {
+  if (paused == _artworkExtractionPaused) return;
+  _artworkExtractionPaused = paused;
+  if (!paused) {
+    final resolvers = List<VoidCallback>.of(_pendingArtworkResolvers);
+    _pendingArtworkResolvers.clear();
+    for (final r in resolvers) {
+      r();
+    }
+  }
+}
+
 class _CachedImageWidgetState extends State<CachedImageWidget> {
+  static final Map<String, bool> _pathExistsCache = {};
+
   String? _resolvedImagePath;
+  bool _hasPendingResolve = false;
 
   @override
   void initState() {
@@ -143,6 +163,11 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
       return;
     }
 
+    if (_artworkExtractionPaused) {
+      _enqueueDeferredResolution(audioSourcePath);
+      return;
+    }
+
     final resolvedPath = await AlbumArtService.instance.resolveArtworkPath(
       existingPath: widget.imagePath,
       audioSourcePath: audioSourcePath,
@@ -160,6 +185,21 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
     }
   }
 
+  void _enqueueDeferredResolution(String audioSourcePath) {
+    if (_hasPendingResolve) return;
+    _hasPendingResolve = true;
+    final imagePath = widget.imagePath;
+    _pendingArtworkResolvers.add(() {
+      _hasPendingResolve = false;
+      if (!mounted ||
+          widget.audioSourcePath != audioSourcePath ||
+          widget.imagePath != imagePath) {
+        return;
+      }
+      _resolveEmbeddedArtwork();
+    });
+  }
+
   String? _usablePath(String? path) {
     if (path == null || path.isEmpty) {
       return null;
@@ -169,7 +209,14 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
       return path;
     }
 
-    return File(path).existsSync() ? path : null;
+    // ponytail: memoize stat() so repeated existence checks during fast scroll
+    // stay O(1); first encounter per path still does one disk hit. Stale entries
+    // are safe — Image.file's errorBuilder handles a since-deleted file.
+    final exists = _pathExistsCache.putIfAbsent(
+      path,
+      () => File(path).existsSync(),
+    );
+    return exists ? path : null;
   }
 
   Widget _buildFileImage(String imagePath) {


### PR DESCRIPTION
# Summary

- Sync widget playback state when service is killed by re-initializing from `MusicNotificationService`
- Add `updateAllWidgets` helper to `WidgetPrefs` for batch widget updates
- Pause artwork extraction during scroll with debouncing and memoize path existence checks
- Always decode artwork at 2× size to prevent OOM on fling

# Changes

## Widget Sync

- Sync widget playback state when service is killed by re-initializing from `MusicNotificationService`
- Add `updateAllWidgets` helper method to `WidgetPrefs` for batch widget updates

## Artwork Extraction Performance

- Pause artwork extraction during scroll events with debounce
- Memoize path existence checks to avoid redundant filesystem access
- Always decode artwork at 2× art size to prevent OOM on fling
- Add debounced artwork extraction pause to orbit scroll

## Files Changed

- `lib/widgets/common/cached_image_widget.dart`
- `lib/features/songs/widgets/song_card.dart`
- `lib/features/songs/widgets/orbit_scroll.dart`
- `android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt`
- `android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt`