### PR TITLE
Add orbital settings screen with configurable geometry, sizing, and visual toggles

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -57,15 +57,6 @@ class AppConstants {
   static const double glassBlurSigmaLight = 10.0;
   static const double glassBlurSigmaStrong = 20.0;
 
-  // Orbit scroll settings
-  static const double orbitRadiusRatio = 1.0; // Large radius for gentle arc
-  static const double orbitCenterOffsetRatio = -0.5; // Center off-screen left
-  static const int orbitVisibleItems = 5; // Fewer items for more spacing
-  static const double orbitItemSpacing = 0.28; // Tighter space between songs
-  static const double orbitSelectedScale = 1.25;
-  static const double orbitAdjacentScale = 0.55;
-  static const double orbitDistantScale = 0.35;
-
   // Navigation bar
   static const double navBarHeight = 80.0;
   static const double navBarIconSize = 28.0;

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -32,6 +32,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/glass_bottom_sheet.dart';
 
 /// Music-home menu screen inspired by streaming app landing pages.
 class MenuScreen extends ConsumerStatefulWidget {
@@ -54,7 +55,6 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   List<RecentlyPlayedEntry> _recentEntries = const [];
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = const {};
   bool _isHistoryLoading = true;
-  bool _showEngineCard = true;
   bool _showUpdateNotice = true;
   Color? _heroDominantColor;
   String? _heroColorArtPath;
@@ -359,205 +359,148 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
 
   Widget _buildEngineSelector(
     BuildContext context,
-    AudioEnginePreference engine,
-  ) {
-    final (title, subtitle, icon) = switch (engine) {
+    AudioEnginePreference engine, {
+    Color? dominantColor,
+  }) {
+    final (title, icon) = switch (engine) {
       AudioEnginePreference.exoPlayer => (
         'Standard Engine',
-        'Default Android player. Plays everything reliably — the safest pick for everyday listening.',
         LucideIcons.smartphone,
       ),
       AudioEnginePreference.rustOboe => (
         'High Quality Engine',
-        'Cleaner audio with smoother playback. Our recommended choice for daily listening.',
         LucideIcons.audioLines,
       ),
       AudioEnginePreference.isochronousUsb => (
         'Bit-perfect (USB DAC)',
-        'Studio-grade output for external DACs and headphone amps. Bypasses all processing for pure, untouched sound.',
         LucideIcons.usb,
       ),
     };
 
-    return Container(
-      padding: const EdgeInsets.all(AppConstants.spacingLg),
-      decoration: BoxDecoration(
-        color: AppColors.surface.withValues(alpha: 0.72),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: AppColors.glassBorder),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackgroundStrong,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Icon(icon, color: context.adaptiveTextPrimary, size: 18),
-              ),
-              const SizedBox(width: AppConstants.spacingMd),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: context.adaptiveTextPrimary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const SizedBox(height: AppConstants.spacingXxs),
-                    Text(
-                      subtitle,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: context.adaptiveTextTertiary,
-                        height: 1.35,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              IconButton(
-                onPressed: () {
-                  setState(() => _showEngineCard = false);
-                  ScaffoldMessenger.of(context)
-                    ..removeCurrentSnackBar()
-                    ..showSnackBar(
-                      SnackBar(
-                        content: const Text(
-                          'Engine selector hidden. Re-enable in Settings > UI Customization > Engine Selector.',
-                        ),
-                        behavior: SnackBarBehavior.floating,
-                        duration: const Duration(seconds: 4),
-                        action: SnackBarAction(
-                          label: 'Undo',
-                          onPressed: () => setState(() => _showEngineCard = true),
-                        ),
-                      ),
-                    );
-                },
-                icon: Icon(
-                  LucideIcons.x,
-                  size: 18,
-                  color: context.adaptiveTextTertiary,
-                ),
-                visualDensity: VisualDensity.compact,
-              ),
-            ],
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => _showEnginePickerSheet(context, engine),
+        borderRadius: BorderRadius.circular(16),
+        child: Ink(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: _heroGradientColors(dominantColor),
+              stops: const [0.0, 0.56, 1.0],
+            ),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
           ),
-          const SizedBox(height: AppConstants.spacingMd),
-          SizedBox(
-            width: double.infinity,
-            child: OutlinedButton(
-              onPressed: () => _showEnginePickerDialog(context, engine),
-              style: OutlinedButton.styleFrom(
-                side: BorderSide(color: AppColors.glassBorder),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppConstants.spacingMd,
+              vertical: AppConstants.spacingSm,
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Icon(icon, color: Colors.white, size: 16),
                 ),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppConstants.spacingMd,
-                  vertical: AppConstants.spacingSm,
+                const SizedBox(width: AppConstants.spacingMd),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
                 ),
-                backgroundColor: AppColors.glassBackgroundStrong,
-              ),
-              child: Text(
-                'Change engine',
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: context.adaptiveTextPrimary,
+                Icon(
+                  LucideIcons.chevronDown,
+                  size: 18,
+                  color: Colors.white.withValues(alpha: 0.7),
                 ),
-              ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }
 
-  Future<void> _showEnginePickerDialog(
+  Future<void> _showEnginePickerSheet(
     BuildContext context,
     AudioEnginePreference current,
   ) async {
     final service = ref.read(uac2PreferencesServiceProvider);
 
-    await showDialog<void>(
+    await GlassBottomSheet.show<void>(
       context: context,
-      builder: (dialogContext) {
-        return AlertDialog(
-          backgroundColor: AppColors.surface,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+      title: 'Choose Audio Engine',
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'The audio engine determines how your music is played back. Each option balances reliability, quality, and compatibility differently.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+              height: 1.45,
+            ),
           ),
-          title: Text(
-            'Choose Audio Engine',
-            style: TextStyle(color: context.adaptiveTextPrimary),
+          const SizedBox(height: AppConstants.spacingMd),
+          _buildEngineOption(
+            context,
+            title: 'Standard',
+            subtitle:
+                'Default Android player — plays everything reliably. The safest choice for most listeners.',
+            icon: LucideIcons.smartphone,
+            selected: current == AudioEnginePreference.exoPlayer,
+            onTap: () => _selectEngine(
+              context,
+              service,
+              AudioEnginePreference.exoPlayer,
+              current,
+            ),
           ),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'The audio engine determines how your music is played back. Each option balances reliability, quality, and compatibility differently.',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.adaptiveTextTertiary,
-                  height: 1.45,
-                ),
-              ),
-              const SizedBox(height: AppConstants.spacingMd),
-              _buildEngineOption(
-                dialogContext,
-                title: 'Standard',
-                subtitle:
-                    'Default Android player — plays everything reliably. The safest choice for most listeners.',
-                icon: LucideIcons.smartphone,
-                selected: current == AudioEnginePreference.exoPlayer,
-                onTap: () => _selectEngine(
-                  dialogContext,
-                  service,
-                  AudioEnginePreference.exoPlayer,
-                  current,
-                ),
-              ),
-              const SizedBox(height: AppConstants.spacingSm),
-              _buildEngineOption(
-                dialogContext,
-                title: 'High Quality',
-                subtitle:
-                    'Our Rust-powered engine. Cleaner sound and smoother playback — recommended for daily listening.',
-                icon: LucideIcons.audioLines,
-                selected: current == AudioEnginePreference.rustOboe,
-                onTap: () => _selectEngine(
-                  dialogContext,
-                  service,
-                  AudioEnginePreference.rustOboe,
-                  current,
-                ),
-              ),
-              const SizedBox(height: AppConstants.spacingSm),
-              _buildEngineOption(
-                dialogContext,
-                title: 'Bit-perfect (USB DAC)',
-                subtitle:
-                    'Studio-grade output for external DACs and headphone amps. Bypasses Android\'s audio processing for pure sound.',
-                icon: LucideIcons.usb,
-                selected: current == AudioEnginePreference.isochronousUsb,
-                onTap: () => _selectEngine(
-                  dialogContext,
-                  service,
-                  AudioEnginePreference.isochronousUsb,
-                  current,
-                ),
-              ),
-            ],
+          const SizedBox(height: AppConstants.spacingSm),
+          _buildEngineOption(
+            context,
+            title: 'High Quality',
+            subtitle:
+                'Our Rust-powered engine. Cleaner sound and smoother playback — recommended for daily listening.',
+            icon: LucideIcons.audioLines,
+            selected: current == AudioEnginePreference.rustOboe,
+            onTap: () => _selectEngine(
+              context,
+              service,
+              AudioEnginePreference.rustOboe,
+              current,
+            ),
           ),
-        );
-      },
+          const SizedBox(height: AppConstants.spacingSm),
+          _buildEngineOption(
+            context,
+            title: 'Bit-perfect (USB DAC)',
+            subtitle:
+                'Studio-grade output for external DACs and headphone amps. Bypasses Android\'s audio processing for pure sound.',
+            icon: LucideIcons.usb,
+            selected: current == AudioEnginePreference.isochronousUsb,
+            onTap: () => _selectEngine(
+              context,
+              service,
+              AudioEnginePreference.isochronousUsb,
+              current,
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -732,8 +675,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                           curve: Curves.easeInOut,
                           alignment: Alignment.topCenter,
                           child:
-                              _showEngineCard &&
-                                      appPreferences.showEngineSelector &&
+                              appPreferences.showEngineSelector &&
                                       enginePreferenceAsync.hasValue
                                   ? Padding(
                                       padding: const EdgeInsets.fromLTRB(
@@ -745,6 +687,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                                       child: _buildEngineSelector(
                                         context,
                                         enginePreferenceAsync.value!,
+                                        dominantColor: _heroDominantColor,
                                       ),
                                     )
                                   : const SizedBox.shrink(),
@@ -1896,6 +1839,32 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   }
 }
 
+const List<Color> _heroGradientFallback = [
+  Color(0xFF194B68),
+  Color(0xFF0C1624),
+  Color(0xFF1D2A19),
+];
+
+List<Color> _heroGradientColors(Color? dominant) {
+  final dc = dominant;
+  if (dc == null) return _heroGradientFallback;
+
+  final darkened = Color.lerp(dc, const Color(0xFF000000), 0.55)!;
+  final darker = Color.lerp(dc, const Color(0xFF000000), 0.68)!;
+  final shifted = Color.lerp(
+    Color.fromARGB(
+      255,
+      (dc.g * 255.0).round().clamp(0, 255),
+      (dc.b * 255.0).round().clamp(0, 255),
+      (dc.r * 255.0).round().clamp(0, 255),
+    ),
+    const Color(0xFF000000),
+    0.60,
+  )!;
+
+  return [darkened, darker, shifted];
+}
+
 class _HeroCardWithBlobs extends StatefulWidget {
   final Color? dominantColor;
   final Song? featuredSong;
@@ -1924,12 +1893,6 @@ class _HeroCardWithBlobs extends StatefulWidget {
 class _HeroCardWithBlobsState extends State<_HeroCardWithBlobs>
     with SingleTickerProviderStateMixin {
   late final AnimationController _blobController;
-
-  static const _defaultGradientColors = [
-    Color(0xFF194B68),
-    Color(0xFF0C1624),
-    Color(0xFF1D2A19),
-  ];
 
   static const _defaultBlobColors = [
     Color(0xFF61B8FF),
@@ -1962,25 +1925,8 @@ class _HeroCardWithBlobsState extends State<_HeroCardWithBlobs>
     super.dispose();
   }
 
-  List<Color> _adaptiveGradientColors() {
-    final dc = widget.dominantColor;
-    if (dc == null) return _defaultGradientColors;
-
-    final darkened = Color.lerp(dc, const Color(0xFF000000), 0.55)!;
-    final darker = Color.lerp(dc, const Color(0xFF000000), 0.68)!;
-    final shifted = Color.lerp(
-      Color.fromARGB(
-        255,
-        (dc.g * 255.0).round().clamp(0, 255),
-        (dc.b * 255.0).round().clamp(0, 255),
-        (dc.r * 255.0).round().clamp(0, 255),
-      ),
-      const Color(0xFF000000),
-      0.60,
-    )!;
-
-    return [darkened, darker, shifted];
-  }
+  List<Color> _adaptiveGradientColors() =>
+      _heroGradientColors(widget.dominantColor);
 
   List<Color> _adaptiveBlobColors() {
     final dc = widget.dominantColor;

--- a/lib/features/settings/screens/orbit_settings_screen.dart
+++ b/lib/features/settings/screens/orbit_settings_screen.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+import 'package:flick/features/settings/widgets/settings_widgets.dart';
+
+class OrbitSettingsScreen extends ConsumerWidget {
+  const OrbitSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final notifier = ref.read(appPreferencesProvider.notifier);
+
+    return SettingsScaffold(
+      title: 'Customize Orbital',
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SettingsSectionHeader('Geometry'),
+          SettingsCard(
+            children: [
+              SliderSetting(
+                icon: LucideIcons.radius,
+                title: 'Curvature',
+                subtitle: 'Curve of the orbit arc — higher is gentler',
+                value: prefs.orbitRadiusRatio,
+                displayValue: prefs.orbitRadiusRatio.toStringAsFixed(2),
+                min: 0.5,
+                max: 2.0,
+                divisions: 30,
+                onChanged: notifier.setOrbitRadiusRatio,
+              ),
+              const SettingsDivider(),
+              SliderSetting(
+                icon: LucideIcons.moveVertical,
+                title: 'Vertical Position',
+                subtitle: 'Where the focal song sits vertically',
+                value: prefs.orbitCenterYRatio,
+                displayValue: '${(prefs.orbitCenterYRatio * 100).round()}%',
+                min: 0.30,
+                max: 0.60,
+                divisions: 30,
+                onChanged: notifier.setOrbitCenterYRatio,
+              ),
+              const SettingsDivider(),
+              SliderSetting(
+                icon: LucideIcons.moveHorizontal,
+                title: 'Horizontal Reach',
+                subtitle: 'How far the arc opens from the left edge',
+                value: prefs.orbitCenterOffsetRatio,
+                displayValue: prefs.orbitCenterOffsetRatio.toStringAsFixed(2),
+                min: -1.0,
+                max: 0.0,
+                divisions: 20,
+                onChanged: notifier.setOrbitCenterOffsetRatio,
+              ),
+              const SettingsDivider(),
+              SliderSetting(
+                icon: LucideIcons.ruler,
+                title: 'Item Spacing',
+                subtitle: 'Distance between songs along the arc',
+                value: prefs.orbitItemSpacing,
+                displayValue: prefs.orbitItemSpacing.toStringAsFixed(2),
+                min: 0.15,
+                max: 0.50,
+                divisions: 35,
+                onChanged: notifier.setOrbitItemSpacing,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Sizing'),
+          SettingsCard(
+            children: [
+              SliderSetting(
+                icon: LucideIcons.expand,
+                title: 'Card Size',
+                subtitle: 'Base album-art size for each song card',
+                value: prefs.orbitCardArtSize,
+                displayValue: '${prefs.orbitCardArtSize.round()}px',
+                min: 48,
+                max: 120,
+                divisions: 72,
+                onChanged: notifier.setOrbitCardArtSize,
+              ),
+              const SettingsDivider(),
+              SliderSetting(
+                icon: LucideIcons.arrowLeftRight,
+                title: 'Card Width',
+                subtitle: 'How wide each card spans across the screen',
+                value: prefs.orbitCardWidthRatio,
+                displayValue: '${(prefs.orbitCardWidthRatio * 100).round()}%',
+                min: 0.5,
+                max: 0.85,
+                divisions: 35,
+                onChanged: notifier.setOrbitCardWidthRatio,
+              ),
+              const SettingsDivider(),
+              _VisibleItemsRow(
+                value: prefs.orbitVisibleItems,
+                onChanged: notifier.setOrbitVisibleItems,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Depth'),
+          SettingsCard(
+            children: [
+              SliderSetting(
+                icon: LucideIcons.maximize,
+                title: 'Selected Size',
+                subtitle: 'Scale of the centered, focused song card',
+                value: prefs.orbitSelectedScale,
+                displayValue: prefs.orbitSelectedScale.toStringAsFixed(2),
+                min: 1.0,
+                max: 1.8,
+                divisions: 16,
+                onChanged: notifier.setOrbitSelectedScale,
+              ),
+              const SettingsDivider(),
+              SliderSetting(
+                icon: LucideIcons.chevronsDown,
+                title: 'Depth',
+                subtitle: 'How much side cards shrink away from center',
+                value: prefs.orbitDepth,
+                displayValue: '${(prefs.orbitDepth * 100).round()}%',
+                min: 0.0,
+                max: 1.0,
+                divisions: 20,
+                onChanged: notifier.setOrbitDepth,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Art Resolution'),
+          SettingsCard(
+            children: [
+              SelectionSetting(
+                icon: LucideIcons.imageMinus,
+                title: 'Low',
+                subtitle: 'Pixelated — lightest on memory',
+                selected: prefs.orbitArtResolutionMultiplier == 1.0,
+                onTap: () => notifier.setOrbitArtResolutionMultiplier(1.0),
+              ),
+              const SettingsDivider(),
+              SelectionSetting(
+                icon: LucideIcons.image,
+                title: 'Medium',
+                subtitle: 'Soft detail, balanced',
+                selected: prefs.orbitArtResolutionMultiplier == 1.5,
+                onTap: () => notifier.setOrbitArtResolutionMultiplier(1.5),
+              ),
+              const SettingsDivider(),
+              SelectionSetting(
+                icon: LucideIcons.aperture,
+                title: 'High',
+                subtitle: 'Sharp (recommended)',
+                selected: prefs.orbitArtResolutionMultiplier == 2.0,
+                onTap: () => notifier.setOrbitArtResolutionMultiplier(2.0),
+              ),
+              const SettingsDivider(),
+              SelectionSetting(
+                icon: LucideIcons.sparkles,
+                title: 'Ultra',
+                subtitle: 'Crispest — heavier during fast scrolling',
+                selected: prefs.orbitArtResolutionMultiplier == 3.0,
+                onTap: () => notifier.setOrbitArtResolutionMultiplier(3.0),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Visuals'),
+          SettingsCard(
+            children: [
+              ToggleSetting(
+                icon: LucideIcons.spline,
+                title: 'Show Orbit Path',
+                subtitle: 'Draw the curved arc behind the songs',
+                value: prefs.orbitShowPath,
+                onChanged: notifier.setOrbitShowPath,
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.circle,
+                title: 'Show Glow',
+                subtitle: 'Soft highlight behind the selected song',
+                value: prefs.orbitShowGlow,
+                onChanged: notifier.setOrbitShowGlow,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          SettingsCard(
+            children: [
+              NavigationSetting(
+                icon: LucideIcons.refreshCw,
+                title: 'Reset to Defaults',
+                subtitle: 'Restore the original orbital layout',
+                onTap: () {
+                  notifier.resetOrbitSettings();
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Orbital settings reset'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SizedBox(height: AppConstants.navBarHeight + 40),
+        ],
+      ),
+    );
+  }
+}
+
+class _VisibleItemsRow extends StatelessWidget {
+  const _VisibleItemsRow({required this.value, required this.onChanged});
+
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  static const _options = [3, 5, 7, 9];
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppConstants.spacingLg,
+        AppConstants.spacingMd,
+        AppConstants.spacingMd,
+        AppConstants.spacingSm,
+      ),
+      child: Wrap(
+        spacing: AppConstants.spacingSm,
+        children: _options.map((count) {
+          final selected = count == value;
+          return ChoiceChip(
+            label: Text('$count'),
+            selected: selected,
+            onSelected: selected ? null : (_) => onChanged(count),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/screens/playback_display_settings_screen.dart
+++ b/lib/features/settings/screens/playback_display_settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flick/models/song_view_mode.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
+import 'package:flick/features/settings/screens/orbit_settings_screen.dart';
 
 class PlaybackDisplaySettingsScreen extends ConsumerWidget {
   const PlaybackDisplaySettingsScreen({super.key});
@@ -84,6 +85,21 @@ class PlaybackDisplaySettingsScreen extends ConsumerWidget {
                       .setMode(SongViewMode.list);
                 },
               ),
+              if (songsViewMode == SongViewMode.orbit) ...[
+                const SettingsDivider(),
+                NavigationSetting(
+                  icon: LucideIcons.slidersHorizontal,
+                  title: 'Customize Orbital',
+                  subtitle: 'Curvature, sizing, depth, and visuals',
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const OrbitSettingsScreen(),
+                      ),
+                    );
+                  },
+                ),
+              ],
               const SettingsDivider(),
               ToggleSetting(
                 icon: LucideIcons.panelBottom,

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -423,6 +423,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
   }
 
   Widget _buildOrbitView(List<Song> songs, bool swipeActionsEnabled) {
+    final orbit = ref.watch(appPreferencesProvider);
     return GestureDetector(
       onLongPress: () {
         if (_selectionMode) return;
@@ -441,6 +442,18 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
         swipeActionsEnabled: swipeActionsEnabled && !_selectionMode,
         isSelectionMode: _selectionMode,
         selectedIds: _selectedIds,
+        radiusRatio: orbit.orbitRadiusRatio,
+        centerOffsetRatio: orbit.orbitCenterOffsetRatio,
+        centerYRatio: orbit.orbitCenterYRatio,
+        itemSpacing: orbit.orbitItemSpacing,
+        selectedScale: orbit.orbitSelectedScale,
+        depth: orbit.orbitDepth,
+        visibleItems: orbit.orbitVisibleItems,
+        cardArtSize: orbit.orbitCardArtSize,
+        cardWidthRatio: orbit.orbitCardWidthRatio,
+        artResolutionMultiplier: orbit.orbitArtResolutionMultiplier,
+        showPath: orbit.orbitShowPath,
+        showGlow: orbit.orbitShowGlow,
         onSelectedIndexChanged: (index) {
           if (!mounted) return;
           _showFastIndexOverlay();

--- a/lib/features/songs/widgets/orbit_scroll.dart
+++ b/lib/features/songs/widgets/orbit_scroll.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flick/core/theme/app_colors.dart';
-import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/features/songs/widgets/song_card.dart';
@@ -59,6 +58,19 @@ class OrbitScroll extends StatefulWidget {
   /// Controller for external jump-to-index actions.
   final OrbitScrollController? controller;
 
+  final double radiusRatio;
+  final double centerOffsetRatio;
+  final double centerYRatio;
+  final double itemSpacing;
+  final double selectedScale;
+  final double depth;
+  final int visibleItems;
+  final double cardArtSize;
+  final double cardWidthRatio;
+  final double artResolutionMultiplier;
+  final bool showPath;
+  final bool showGlow;
+
   const OrbitScroll({
     super.key,
     required this.songs,
@@ -71,6 +83,18 @@ class OrbitScroll extends StatefulWidget {
     this.isSelectionMode = false,
     this.selectedIds = const {},
     this.controller,
+    this.radiusRatio = 1.0,
+    this.centerOffsetRatio = -0.5,
+    this.centerYRatio = 0.42,
+    this.itemSpacing = 0.28,
+    this.selectedScale = 1.25,
+    this.depth = 0.75,
+    this.visibleItems = 5,
+    this.cardArtSize = 64.0,
+    this.cardWidthRatio = 0.68,
+    this.artResolutionMultiplier = 2.0,
+    this.showPath = true,
+    this.showGlow = true,
   });
 
   @override
@@ -97,14 +121,17 @@ class _OrbitScrollState extends State<OrbitScroll>
   final Map<int, _ItemTransform> _transformCache = {};
   static const int _maxCacheSize = 120;
 
-  static final List<int> _orderedIndices = (() {
-    final visibleRange = AppConstants.orbitVisibleItems ~/ 2;
+  // ponytail: recompute each build (~9 ints). Was a static final keyed on
+  // AppConstants.orbitVisibleItems; now derives from widget.visibleItems so the
+  // user-tunable count takes effect. Upgrade to a memo if this ever shows in a profile.
+  List<int> get _orderedIndices {
+    final visibleRange = widget.visibleItems ~/ 2;
     return List.generate(
           visibleRange * 2 + 1,
           (i) => i - visibleRange,
         )
       ..sort((a, b) => b.abs().compareTo(a.abs()));
-  })();
+  }
 
   @override
   void initState() {
@@ -125,6 +152,21 @@ class _OrbitScrollState extends State<OrbitScroll>
     if (oldWidget.controller != widget.controller) {
       oldWidget.controller?._detach();
       widget.controller?._attach(_jumpToIndex);
+    }
+    // ponytail: invalidate transform/position caches when geometry changes.
+    // Caches are keyed by relative index only, so any layout-affecting pref
+    // (spacing, scales, depth, sizes) must flush them or stale transforms render.
+    if (oldWidget.itemSpacing != widget.itemSpacing ||
+        oldWidget.selectedScale != widget.selectedScale ||
+        oldWidget.depth != widget.depth ||
+        oldWidget.visibleItems != widget.visibleItems ||
+        oldWidget.radiusRatio != widget.radiusRatio ||
+        oldWidget.centerOffsetRatio != widget.centerOffsetRatio ||
+        oldWidget.centerYRatio != widget.centerYRatio ||
+        oldWidget.cardArtSize != widget.cardArtSize ||
+        oldWidget.cardWidthRatio != widget.cardWidthRatio) {
+      _transformCache.clear();
+      _positionCache.clear();
     }
     if (widget.selectedIndex != oldWidget.selectedIndex) {
       _lastReportedIndex = widget.selectedIndex;
@@ -336,10 +378,9 @@ class _OrbitScrollState extends State<OrbitScroll>
     final size = MediaQuery.of(context).size;
 
     // Calculate orbit parameters
-    final orbitRadius = size.width * AppConstants.orbitRadiusRatio;
-    final orbitCenterX = size.width * AppConstants.orbitCenterOffsetRatio;
-    final orbitCenterY =
-        size.height * 0.42; // Higher on screen for better visibility
+    final orbitRadius = size.width * widget.radiusRatio;
+    final orbitCenterX = size.width * widget.centerOffsetRatio;
+    final orbitCenterY = size.height * widget.centerYRatio;
 
     return GestureDetector(
       onVerticalDragStart: _onVerticalDragStart,
@@ -354,10 +395,12 @@ class _OrbitScrollState extends State<OrbitScroll>
           clipBehavior: Clip.none,
           children: [
             // Background glow
-            _buildSelectionGlow(orbitCenterX, orbitCenterY, orbitRadius),
+            if (widget.showGlow)
+              _buildSelectionGlow(orbitCenterX, orbitCenterY, orbitRadius),
 
             // Path
-            _buildOrbitPath(orbitCenterX, orbitCenterY, orbitRadius),
+            if (widget.showPath)
+              _buildOrbitPath(orbitCenterX, orbitCenterY, orbitRadius),
 
             // Songs — only rebuilds when scroll offset changes
             ValueListenableBuilder<double>(
@@ -420,6 +463,12 @@ class _OrbitScrollState extends State<OrbitScroll>
 
     final centerIndex = _scrollOffset.value.round();
 
+    // ponytail: adjacent/distant shrink derived from one Depth slider.
+    // adjacent = 1 - 0.6*depth, distant = 1 - 0.8*depth. At default depth 0.75
+    // this reproduces the old 0.55/0.35. Split into two sliders if finer control is needed.
+    final adjacentScale = 1.0 - 0.6 * widget.depth;
+    final distantScale = 1.0 - 0.8 * widget.depth;
+
     for (final relativeIndex in _orderedIndices) {
       final actualIndex = centerIndex + relativeIndex;
 
@@ -436,15 +485,15 @@ class _OrbitScrollState extends State<OrbitScroll>
 
         double scale;
         if (distanceFromCenter < 1.0) {
-          scale = AppConstants.orbitSelectedScale -
-              (AppConstants.orbitSelectedScale - AppConstants.orbitAdjacentScale) *
+          scale = widget.selectedScale -
+              (widget.selectedScale - adjacentScale) *
                   distanceFromCenter;
         } else if (distanceFromCenter < 2.0) {
-          scale = AppConstants.orbitAdjacentScale -
-              (AppConstants.orbitAdjacentScale - AppConstants.orbitDistantScale) *
+          scale = adjacentScale -
+              (adjacentScale - distantScale) *
                   (distanceFromCenter - 1.0);
         } else {
-          scale = AppConstants.orbitDistantScale -
+          scale = distantScale -
               (distanceFromCenter - 2.0) * 0.12;
         }
         scale = scale.clamp(0.0, 1.25);
@@ -478,6 +527,10 @@ class _OrbitScrollState extends State<OrbitScroll>
               swipeActionsEnabled: widget.swipeActionsEnabled,
               isSelectionMode: widget.isSelectionMode,
               isMultiSelected: widget.selectedIds.contains(widget.songs[actualIndex].id),
+              artSizeBase: widget.cardArtSize,
+              artSizeLarge: widget.cardArtSize * 1.5625,
+              cardWidthRatio: widget.cardWidthRatio,
+              artResolutionMultiplier: widget.artResolutionMultiplier,
               onTap: () {
                 AppHaptics.tap();
                 _animateTo(actualIndex.toDouble());
@@ -514,7 +567,7 @@ class _OrbitScrollState extends State<OrbitScroll>
     adjustedIndex +=
         relativeIndex.sign * splitAmount * math.min(relativeIndex.abs(), 1.0);
 
-    final angle = adjustedIndex * AppConstants.orbitItemSpacing;
+    final angle = adjustedIndex * widget.itemSpacing;
     final x = centerX + radius * math.cos(angle);
     final y = centerY + radius * math.sin(angle);
 

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -40,6 +40,18 @@ class SongCard extends StatefulWidget {
   /// Whether this song is selected in multiselect mode.
   final bool isMultiSelected;
 
+  /// Base album-art size for non-selected cards (overrides default).
+  final double artSizeBase;
+
+  /// Album-art size for the selected card (overrides default).
+  final double artSizeLarge;
+
+  /// Card width as a fraction of screen width (overrides default).
+  final double cardWidthRatio;
+
+  /// Decode-resolution multiplier applied to art size (higher = sharper, heavier).
+  final double artResolutionMultiplier;
+
   const SongCard({
     super.key,
     required this.song,
@@ -52,6 +64,10 @@ class SongCard extends StatefulWidget {
     this.swipeActionsEnabled = false,
     this.isSelectionMode = false,
     this.isMultiSelected = false,
+    this.artSizeBase = AppConstants.songCardArtSize,
+    this.artSizeLarge = AppConstants.songCardArtSizeLarge,
+    this.cardWidthRatio = 0.68,
+    this.artResolutionMultiplier = 2.0,
   });
 
   @override
@@ -62,16 +78,13 @@ class _SongCardState extends State<SongCard> {
   double _dragDx = 0;
   bool _queuedFlash = false;
   bool _favoriteFlash = false;
-  double? _cachedCardWidth;
 
   @override
   Widget build(BuildContext context) {
-    final artSize = widget.isSelected
-        ? AppConstants.songCardArtSizeLarge
-        : AppConstants.songCardArtSize;
+    final artSize =
+        widget.isSelected ? widget.artSizeLarge : widget.artSizeBase;
 
-    _cachedCardWidth ??= MediaQuery.of(context).size.width * 0.68;
-    final cardWidth = _cachedCardWidth!;
+    final cardWidth = MediaQuery.of(context).size.width * widget.cardWidthRatio;
     const cardHeight = 130.0;
 
     final isSwiping = _dragDx.abs() > 0.001;
@@ -348,9 +361,10 @@ class _SongCardState extends State<SongCard> {
     BoxFit fit = BoxFit.cover,
     required double artSize,
   }) {
-    // ponytail: cap decode at 2x artSize. Selected card used to decode full-res,
-    // OOM'ing during fast orbit fling. Soft on >2x DPR — scale by devicePixelRatio if it shows.
-    final decodeDim = (artSize * 2).toInt();
+    // ponytail: cap decode at artSize * multiplier. Selected card used to decode
+    // full-res, OOM'ing during fast orbit fling. Multiplier is now user-tunable;
+    // default 2x stays soft on >2x DPR — scale up if it shows.
+    final decodeDim = (artSize * widget.artResolutionMultiplier).toInt();
 
     return CachedImageWidget(
       imagePath: path,

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -540,6 +540,102 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     state = state.copyWith(visualizerEnabled: value);
     await ref.read(appPreferencesServiceProvider).setVisualizerEnabled(value);
   }
+
+  Future<void> setOrbitRadiusRatio(double value) async {
+    if (state.orbitRadiusRatio == value) return;
+    state = state.copyWith(orbitRadiusRatio: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitRadiusRatio(value);
+  }
+
+  Future<void> setOrbitCenterOffsetRatio(double value) async {
+    if (state.orbitCenterOffsetRatio == value) return;
+    state = state.copyWith(orbitCenterOffsetRatio: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setOrbitCenterOffsetRatio(value);
+  }
+
+  Future<void> setOrbitCenterYRatio(double value) async {
+    if (state.orbitCenterYRatio == value) return;
+    state = state.copyWith(orbitCenterYRatio: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitCenterYRatio(value);
+  }
+
+  Future<void> setOrbitItemSpacing(double value) async {
+    if (state.orbitItemSpacing == value) return;
+    state = state.copyWith(orbitItemSpacing: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitItemSpacing(value);
+  }
+
+  Future<void> setOrbitSelectedScale(double value) async {
+    if (state.orbitSelectedScale == value) return;
+    state = state.copyWith(orbitSelectedScale: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitSelectedScale(value);
+  }
+
+  Future<void> setOrbitDepth(double value) async {
+    if (state.orbitDepth == value) return;
+    state = state.copyWith(orbitDepth: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitDepth(value);
+  }
+
+  Future<void> setOrbitVisibleItems(int value) async {
+    if (state.orbitVisibleItems == value) return;
+    state = state.copyWith(orbitVisibleItems: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitVisibleItems(value);
+  }
+
+  Future<void> setOrbitCardArtSize(double value) async {
+    if (state.orbitCardArtSize == value) return;
+    state = state.copyWith(orbitCardArtSize: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitCardArtSize(value);
+  }
+
+  Future<void> setOrbitCardWidthRatio(double value) async {
+    if (state.orbitCardWidthRatio == value) return;
+    state = state.copyWith(orbitCardWidthRatio: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setOrbitCardWidthRatio(value);
+  }
+
+  Future<void> setOrbitArtResolutionMultiplier(double value) async {
+    if (state.orbitArtResolutionMultiplier == value) return;
+    state = state.copyWith(orbitArtResolutionMultiplier: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setOrbitArtResolutionMultiplier(value);
+  }
+
+  Future<void> setOrbitShowPath(bool value) async {
+    if (state.orbitShowPath == value) return;
+    state = state.copyWith(orbitShowPath: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitShowPath(value);
+  }
+
+  Future<void> setOrbitShowGlow(bool value) async {
+    if (state.orbitShowGlow == value) return;
+    state = state.copyWith(orbitShowGlow: value);
+    await ref.read(appPreferencesServiceProvider).setOrbitShowGlow(value);
+  }
+
+  Future<void> resetOrbitSettings() async {
+    state = state.copyWith(
+      orbitRadiusRatio: 1.0,
+      orbitCenterOffsetRatio: -0.5,
+      orbitCenterYRatio: 0.42,
+      orbitItemSpacing: 0.28,
+      orbitSelectedScale: 1.25,
+      orbitDepth: 0.75,
+      orbitVisibleItems: 5,
+      orbitCardArtSize: 64.0,
+      orbitCardWidthRatio: 0.68,
+      orbitArtResolutionMultiplier: 2.0,
+      orbitShowPath: true,
+      orbitShowGlow: true,
+    );
+    await ref.read(appPreferencesServiceProvider).clearOrbitSettings();
+  }
 }
 
 final appPreferencesProvider =

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -74,6 +74,18 @@ class AppPreferences {
   final String searchPlaybackMode; // 'results', 'library', or 'queue'
   final String refreshRateMode; // 'high', 'standard', 'adaptive'
   final bool visualizerEnabled;
+  final double orbitRadiusRatio;
+  final double orbitCenterOffsetRatio;
+  final double orbitCenterYRatio;
+  final double orbitItemSpacing;
+  final double orbitSelectedScale;
+  final double orbitDepth;
+  final int orbitVisibleItems;
+  final double orbitCardArtSize;
+  final double orbitCardWidthRatio;
+  final double orbitArtResolutionMultiplier;
+  final bool orbitShowPath;
+  final bool orbitShowGlow;
 
   const AppPreferences({
     this.animationsEnabled = true,
@@ -149,6 +161,18 @@ class AppPreferences {
     this.searchPlaybackMode = 'results',
     this.refreshRateMode = 'high',
     this.visualizerEnabled = true,
+    this.orbitRadiusRatio = 1.0,
+    this.orbitCenterOffsetRatio = -0.5,
+    this.orbitCenterYRatio = 0.42,
+    this.orbitItemSpacing = 0.28,
+    this.orbitSelectedScale = 1.25,
+    this.orbitDepth = 0.75,
+    this.orbitVisibleItems = 5,
+    this.orbitCardArtSize = 64.0,
+    this.orbitCardWidthRatio = 0.68,
+    this.orbitArtResolutionMultiplier = 2.0,
+    this.orbitShowPath = true,
+    this.orbitShowGlow = true,
   });
 
   AppPreferences copyWith({
@@ -225,6 +249,18 @@ class AppPreferences {
     String? searchPlaybackMode,
     String? refreshRateMode,
     bool? visualizerEnabled,
+    double? orbitRadiusRatio,
+    double? orbitCenterOffsetRatio,
+    double? orbitCenterYRatio,
+    double? orbitItemSpacing,
+    double? orbitSelectedScale,
+    double? orbitDepth,
+    int? orbitVisibleItems,
+    double? orbitCardArtSize,
+    double? orbitCardWidthRatio,
+    double? orbitArtResolutionMultiplier,
+    bool? orbitShowPath,
+    bool? orbitShowGlow,
   }) {
     return AppPreferences(
       animationsEnabled: animationsEnabled ?? this.animationsEnabled,
@@ -333,6 +369,20 @@ class AppPreferences {
           searchPlaybackMode ?? this.searchPlaybackMode,
       refreshRateMode: refreshRateMode ?? this.refreshRateMode,
       visualizerEnabled: visualizerEnabled ?? this.visualizerEnabled,
+      orbitRadiusRatio: orbitRadiusRatio ?? this.orbitRadiusRatio,
+      orbitCenterOffsetRatio:
+          orbitCenterOffsetRatio ?? this.orbitCenterOffsetRatio,
+      orbitCenterYRatio: orbitCenterYRatio ?? this.orbitCenterYRatio,
+      orbitItemSpacing: orbitItemSpacing ?? this.orbitItemSpacing,
+      orbitSelectedScale: orbitSelectedScale ?? this.orbitSelectedScale,
+      orbitDepth: orbitDepth ?? this.orbitDepth,
+      orbitVisibleItems: orbitVisibleItems ?? this.orbitVisibleItems,
+      orbitCardArtSize: orbitCardArtSize ?? this.orbitCardArtSize,
+      orbitCardWidthRatio: orbitCardWidthRatio ?? this.orbitCardWidthRatio,
+      orbitArtResolutionMultiplier:
+          orbitArtResolutionMultiplier ?? this.orbitArtResolutionMultiplier,
+      orbitShowPath: orbitShowPath ?? this.orbitShowPath,
+      orbitShowGlow: orbitShowGlow ?? this.orbitShowGlow,
     );
   }
 }
@@ -416,6 +466,19 @@ class AppPreferencesService {
   static const _searchPlaybackModeKey = 'app_search_playback_mode';
   static const _refreshRateModeKey = 'app_refresh_rate_mode';
   static const _visualizerEnabledKey = 'visualizer_enabled';
+  static const _orbitRadiusRatioKey = 'orbit_radius_ratio';
+  static const _orbitCenterOffsetRatioKey = 'orbit_center_offset_ratio';
+  static const _orbitCenterYRatioKey = 'orbit_center_y_ratio';
+  static const _orbitItemSpacingKey = 'orbit_item_spacing';
+  static const _orbitSelectedScaleKey = 'orbit_selected_scale';
+  static const _orbitDepthKey = 'orbit_depth';
+  static const _orbitVisibleItemsKey = 'orbit_visible_items';
+  static const _orbitCardArtSizeKey = 'orbit_card_art_size';
+  static const _orbitCardWidthRatioKey = 'orbit_card_width_ratio';
+  static const _orbitArtResolutionMultiplierKey =
+      'orbit_art_resolution_multiplier';
+  static const _orbitShowPathKey = 'orbit_show_path';
+  static const _orbitShowGlowKey = 'orbit_show_glow';
   static const _shuffleModeKey = 'playback_shuffle_mode';
   static const _loopModeKey = 'playback_loop_mode';
   static const _advanceListOrderKey = 'playback_advance_list_order';
@@ -527,6 +590,20 @@ class AppPreferencesService {
           prefs.getString(_searchPlaybackModeKey) ?? 'results',
       refreshRateMode: prefs.getString(_refreshRateModeKey) ?? 'high',
       visualizerEnabled: prefs.getBool(_visualizerEnabledKey) ?? true,
+      orbitRadiusRatio: prefs.getDouble(_orbitRadiusRatioKey) ?? 1.0,
+      orbitCenterOffsetRatio:
+          prefs.getDouble(_orbitCenterOffsetRatioKey) ?? -0.5,
+      orbitCenterYRatio: prefs.getDouble(_orbitCenterYRatioKey) ?? 0.42,
+      orbitItemSpacing: prefs.getDouble(_orbitItemSpacingKey) ?? 0.28,
+      orbitSelectedScale: prefs.getDouble(_orbitSelectedScaleKey) ?? 1.25,
+      orbitDepth: prefs.getDouble(_orbitDepthKey) ?? 0.75,
+      orbitVisibleItems: prefs.getInt(_orbitVisibleItemsKey) ?? 5,
+      orbitCardArtSize: prefs.getDouble(_orbitCardArtSizeKey) ?? 64.0,
+      orbitCardWidthRatio: prefs.getDouble(_orbitCardWidthRatioKey) ?? 0.68,
+      orbitArtResolutionMultiplier:
+          prefs.getDouble(_orbitArtResolutionMultiplierKey) ?? 2.0,
+      orbitShowPath: prefs.getBool(_orbitShowPathKey) ?? true,
+      orbitShowGlow: prefs.getBool(_orbitShowGlowKey) ?? true,
     );
   }
 
@@ -1252,5 +1329,81 @@ class AppPreferencesService {
   Future<void> setVisualizerEnabled(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_visualizerEnabledKey, value);
+  }
+
+  Future<void> setOrbitRadiusRatio(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitRadiusRatioKey, value);
+  }
+
+  Future<void> setOrbitCenterOffsetRatio(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitCenterOffsetRatioKey, value);
+  }
+
+  Future<void> setOrbitCenterYRatio(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitCenterYRatioKey, value);
+  }
+
+  Future<void> setOrbitItemSpacing(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitItemSpacingKey, value);
+  }
+
+  Future<void> setOrbitSelectedScale(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitSelectedScaleKey, value);
+  }
+
+  Future<void> setOrbitDepth(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitDepthKey, value);
+  }
+
+  Future<void> setOrbitVisibleItems(int value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_orbitVisibleItemsKey, value);
+  }
+
+  Future<void> setOrbitCardArtSize(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitCardArtSizeKey, value);
+  }
+
+  Future<void> setOrbitCardWidthRatio(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitCardWidthRatioKey, value);
+  }
+
+  Future<void> setOrbitArtResolutionMultiplier(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_orbitArtResolutionMultiplierKey, value);
+  }
+
+  Future<void> setOrbitShowPath(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_orbitShowPathKey, value);
+  }
+
+  Future<void> setOrbitShowGlow(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_orbitShowGlowKey, value);
+  }
+
+  Future<void> clearOrbitSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_orbitRadiusRatioKey);
+    await prefs.remove(_orbitCenterOffsetRatioKey);
+    await prefs.remove(_orbitCenterYRatioKey);
+    await prefs.remove(_orbitItemSpacingKey);
+    await prefs.remove(_orbitSelectedScaleKey);
+    await prefs.remove(_orbitDepthKey);
+    await prefs.remove(_orbitVisibleItemsKey);
+    await prefs.remove(_orbitCardArtSizeKey);
+    await prefs.remove(_orbitCardWidthRatioKey);
+    await prefs.remove(_orbitArtResolutionMultiplierKey);
+    await prefs.remove(_orbitShowPathKey);
+    await prefs.remove(_orbitShowGlowKey);
   }
 }


### PR DESCRIPTION
# Summary

- Add orbit visualizer settings screen with geometry, sizing, depth, art resolution, and visual toggles
- Add orbit preference service (153 lines) and provider (96 lines) with setters and reset method
- Expose orbit parameters as widget fields and remove constant dependency
- Add customizable sizing parameters to `SongCard` widget
- Pass orbit configuration through songs screen to `OrbitView`
- Remove unused orbit scroll constants

# Changes

## Orbit Settings

- Add orbital settings screen (251 lines) with full configuration for geometry, sizing, depth, art resolution, and visual toggles
- Add orbit visualizer settings to `AppPreferences` (153 lines)
- Add orbit preference setter and reset method to provider (96 lines)
- Add orbit customization settings navigation entry to playback display settings

## Orbit Widgets

- Expose orbit parameters as widget fields in `OrbitScroll`
- Pass orbit configuration into `OrbitView` widget
- Remove dependency on hardcoded app constants
- Add customizable sizing parameters to `SongCard` widget
- Pass orbit configuration from songs screen into `OrbitView`

## Cleanup

- Remove unused orbit scroll constants from `app_constants`

## Files Changed

- `lib/features/settings/screens/orbit_settings_screen.dart`
- `lib/features/settings/screens/playback_display_settings_screen.dart`
- `lib/features/songs/screens/songs_screen.dart`
- `lib/features/songs/widgets/song_card.dart`
- `lib/features/songs/widgets/orbit_scroll.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/services/app_preferences_service.dart`
- `lib/core/constants/app_constants.dart`