### PR TITLE
 Add album stretch artwork, streak settings, album detail toggles, and responsive songs header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.20.4-beta.5 (2026-07-03)
+
+### Pitch Shifter (SoundTouch)
+- Real-time pitch shifting via SoundTouch DSP library with lock-free bypass.
+- Pitch shift semitones API with FFI bridge and notifier.
+- Pitch control bottom sheet with semitone slider; option on song actions sheet.
+- Pitch resets to 1.0× on playback stop.
+
+### Android Audio API Preference
+- Choose AAudio, OpenSL ES, or Auto for Android audio output.
+- Persisted preference with instant apply.
+- Exposed in UAC2 settings and Rust debug state.
+
+### Blurred Backgrounds Everywhere
+- `BlurredSongBackground` wraps all library screens for consistent glass look.
+- Fade-only route transition keeps background stable between screens.
+
+### Orbit Customization
+- Dedicated orbital settings screen — geometry, sizing, depth, art resolution, visual toggles.
+- `SongCard` sizing fully configurable; unused constants removed.
+
+### Album Artwork Stretch
+- Album artwork stretches to fill card — toggle in Library settings.
+
+### Lyrics Performance
+- In-memory cache with timeout; shared HTTP client.
+- Exact and fuzzy searches run in parallel — first match wins.
+
+### Streaks & Preference Controls
+- Streaks can be disabled with reset; day streak hidden when disabled.
+- "More from Artist" / "More Artists" toggles on album detail.
+- Display preferences on artist sort sheet.
+
+### Artwork Reliability
+- Only cache confirmed-existing paths; prefer embedded art for fallback.
+
+### UI Polish & Fixes
+- Engine selector: glass bottom sheet with hero gradients.
+- Responsive songs header, edge-drag guard, sort sheet margin fix.
+- Docs: audio preload scan plan, scan details revamp.
+
 ## 0.20.3-beta.4 (2026-06-30)
 
 ### Full Player Refactor & Widgets

--- a/docs/AUDIO_PRELOAD_SCAN_PLAN.md
+++ b/docs/AUDIO_PRELOAD_SCAN_PLAN.md
@@ -1,0 +1,229 @@
+# Audio Preload Scan — Phased Plan
+
+A new optional scan mode that, after the normal library scan discovers files,
+**preloads cover art + missing sparse metadata** and **decodes each song once
+to cache waveform peaks and audio-analysis metrics** (LUFS, true peak, DR, LRA,
+clipping). No PCM is retained — everything is computed in a single streaming
+decode pass and stored as small per-song summaries.
+
+Scope: the scanner (`lib/services/library_scanner_service.dart`,
+`rust/src/api/scanner.rs`), a new Rust analysis bridge, a new Isar cache entity,
+and small additions to Library Settings + the waveform seek bar consumer.
+
+**Ponytail policy**: one streaming decode pass per song, hand-rolled BS.1770
+loudness (no new crates), waveform peaks as ~240 floats, metrics as a handful
+of scalars. Peaks + metrics live in a sibling Isar entity (not columns on the
+hot `songs` row). Cover art reuses the existing `albumArtPath` flow verbatim.
+No PCM cache, no per-format decoder duplication.
+
+---
+
+## A. What "audio preload" means here
+
+| Component | Already done by existing scan | Added by this mode |
+|-----------|-------------------------------|--------------------|
+| Text tags (title/artist/album/track/disc) | yes | — |
+| Technical fields (duration/bitrate/sample rate/bit depth) | yes (Rust deep scan); sparse backfill for MediaStore/SAF | sparse backfill runs **inline** instead of detached |
+| Cover art | no — `extract_embedded_artwork` is on-demand only | **preloaded**, written to app docs dir, path stored on `albumArtPath` |
+| Waveform peaks | no — seek bar uses synthetic `Random(duration)` data | **cached** (~240 buckets/song) |
+| Loudness / dynamics analysis | no | **computed once** (LUFS, true peak, DR, LRA, clipping) |
+| PCM retention | n/a | **never** — peaks + scalars only |
+
+---
+
+## B. Trigger model and scope (decisions)
+
+- **Trigger**: both a **toggle in Library Settings** ("Preload audio data",
+  stored on `LibraryScanPreferences`) **and** a **one-off manual action**
+  ("Preload library audio") beside the existing "Rescan Library" entry in
+  `library_settings_screen.dart:1140`.
+- **Default scope**: only new/modified songs (skip when
+  `song.lastModified <= cache.computedAt`). Cheap incremental scans.
+- **Override**: the manual action exposes a **"Reprocess all" checkbox** that
+  forces `forceAll: true` (ignores `computedAt`, rebuilds the whole library
+  cache). Used to bump `version` after an algorithm change too.
+- **Toggle semantics**: when on, every normal scan fires the preload pass as a
+  detached task at the end of `_scanFolderRust` / `_scanFolderMediaStore` /
+  `_scanFolderAndroid` (same `_runDetachedScanTask` pattern already used for
+  sparse-metadata and playlist sync).
+
+---
+
+## C. Storage decision
+
+A new Isar entity `SongAudioCacheEntity` 1:1 with `SongEntity`:
+
+| Field | Type | Why |
+|-------|------|-----|
+| `songId` (PK, indexed) | Id | lookup by song; cascade-delete when the song goes |
+| `peaks` | `List<double>` (~240) | waveform seek bar; ~2 KB/song |
+| `lufs` | `double?` | integrated loudness, BS.1770 |
+| `truePeakDb` | `double?` | dBTP |
+| `dr` | `double?` | TT Dynamic Range (off-line) |
+| `lra` | `double?` | Loudness Range |
+| `clipping` | `bool` | samples pinned at ±1.0 |
+| `version` | `int` | bump = force global recompute via the override |
+| `computedAt` | `int` (ms since epoch) | skip-or-reprocess gate vs `song.lastModified` |
+
+**Why a sibling table, not columns on `songs`**: Isar loads entire objects, so
+keeping rarely-accessed blobs off the hot row keeps song lists fast. A cache
+truncate (`isar.songAudioCacheEntitys.clear()`) becomes a one-liner that
+doesn't touch metadata; schema migrations stay isolated; "reprocess all" is a
+single collection wipe + walk.
+
+**Cover art** stays on the existing `SongEntity.albumArtPath` field. Bytes are
+written to `getApplicationDocumentsDirectory()/album_art/<songId>.<ext>` — the
+same pattern already used by `album_art_service.dart:101` and
+`album_art_import_service.dart:616`. Reuses
+`SongRepository.updateAlbumArtPath` (`song_repository.dart:183`) unchanged.
+
+---
+
+## D. Rust analysis bridge (new file `rust/src/api/audio_analysis.rs`)
+
+One streaming function, one pass per file, no PCM retained:
+
+```rust
+pub struct AudioAnalysisResult {
+    pub peaks: Vec<f32>,            // length = peak_buckets, normalised 0.0..=1.0
+    pub lufs: Option<f64>,          // integrated, BS.1770
+    pub true_peak_db: Option<f64>,  // dBTP
+    pub dr: Option<f64>,            // TT DR
+    pub lra: Option<f64>,           // loudness range
+    pub clipping: bool,
+}
+
+pub fn analyze_audio_file(path: String, peak_buckets: u32) -> Option<AudioAnalysisResult>
+```
+
+### Decoder reuse
+
+| Format | Existing decoder to reuse |
+|--------|---------------------------|
+| MP3/FLAC/OGG/Opus/AIFF/WAV/ALAC/M4A | **Symphonia** (already a dep; probed in `audio_api.rs:878-893`) |
+| DSF | `dsf_meta::DsfFile` (already used in `scanner.rs:434`) |
+| DFF | `dff_meta::DffFile` (already used in `scanner.rs:479`) |
+| WavPack | existing wavpack thread (`rust/src/audio/wavpack_thread.rs`) |
+
+For DSD formats the analysis pass downsamples the 1-bit stream to PCM at
+~176.4 kHz on the fly (existing DSD pipeline does this for playback). No new
+codec code.
+
+### Single-pass computation
+
+The loop over decoded sample blocks maintains, in O(1) memory beyond the
+bucket arrays:
+
+- **Peaks**: per bucket, track `min` and `max` (or RMS — TBD in Phase 2). At
+  the end, normalise each bucket to `0.0..=1.0` against the global max. Bucket
+  boundaries are sample-count based, independent of decoder rate.
+- **LUFS / LRA**: ITU-R BS.1770 — K-weighting biquad (shelf + high-pass),
+  400 ms blocks with 75 % overlap, absolute-gating at −70 LUFS, relative gate
+  at −10 LU below the gated mean. ~150 LOC of stdlib math, no crate.
+- **True peak**: oversample ×4 via a simple sinc interpolation and take the
+  max; cheap approximation of dBTP (good enough for a metrics badge, not for
+  mastering).
+- **DR**: sliding-block (3 s) peak-to-RMS ratio, classify into DR bands.
+- **Clipping**: count samples at `|s| >= 0.9999`.
+
+### Bridge plumbing
+
+Register in `rust/src/api/mod.rs`, regenerate FRB
+(`flutter_rust_bridge_codegen generate`). The generated Dart binding lands in
+`lib/src/rust/api/audio_analysis.dart`.
+
+---
+
+## E. Confirmed gaps (what does not exist yet)
+
+| # | Gap | Severity | Location |
+|---|-----|----------|----------|
+| G1 | No offline audio decode-then-discard path; only realtime playback decoders exist. | High | new file `rust/src/api/audio_analysis.rs` |
+| G2 | No BS.1770 / DR / true-peak / LRA / clipping implementation. | High | new file `rust/src/api/audio_analysis.rs` |
+| G3 | No `SongAudioCacheEntity` Isar collection. | High | new file `lib/data/entities/song_audio_cache_entity.dart` + repo methods in `song_repository.dart` |
+| G4 | No `AudioPreloadService` (orchestrates decode + art + cache upsert, throttle, cancel). | High | new file `lib/services/audio_preload_service.dart` |
+| G5 | Scanner does not spawn the preload pass after a scan. | High | `library_scanner_service.dart` (after each `_scanFolder*`) |
+| G6 | No `preloadAudioData` toggle on `LibraryScanPreferences`. | Medium | `library_scan_preferences_service.dart:6-87` |
+| G7 | No Library Settings toggle row + no manual action sheet. | Medium | `library_settings_screen.dart:810, 1140` |
+| G8 | Waveform seek bar still renders synthetic `Random(duration)` data. | Medium | `waveform_seek_bar.dart:33, 58-65` |
+| G9 | Sparse-metadata backfill is detached-only; not reusable inline from the preload pass. | Low | `library_scanner_service.dart:486` (`_extractSparseMetadataInBackground`) |
+
+---
+
+## F. Phases
+
+### Phase 1 — Storage + bridge skeleton
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P1.1 | G3 | New `lib/data/entities/song_audio_cache_entity.dart` (Isar `@collection`), register in `database.dart`. Add `getBySongId`, `upsert`, `clearAll`, `deleteBySongIds` to a small `SongAudioCacheRepository` (or fold into `SongRepository`). |
+| P1.2 | G1 | New `rust/src/api/audio_analysis.rs` with `analyze_audio_file(path, peak_buckets)` returning **peaks only** (`lufs`/`dr`/etc. left `None`). Symphonia path for standard formats; DSD/WavPack return `None` for now (graceful skip). |
+| P1.3 | G1 | Register the module in `rust/src/api/mod.rs`, run `flutter_rust_bridge_codegen generate`. |
+| P1.4 | G4 | New `lib/services/audio_preload_service.dart` with `Stream<PreloadProgress> preloadSongs(List<SongEntity>, {bool forceAll})`. Concurrency cap = 2, honours `cancel()`, skips when cache fresh unless `forceAll`. End-to-end on one test file at this stage. |
+
+### Phase 2 — Analysis metrics
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P2.1 | G2 | Implement K-weighting biquad + 400 ms/75 % overlap gated block integration (BS.1770) → `lufs`. |
+| P2.2 | G2 | Implement LRA (same gated blocks, stats over block loudness). |
+| P2.3 | G2 | Implement true peak (×4 sinc oversample, max). |
+| P2.4 | G2 | Implement DR (3 s sliding window peak/RMS). |
+| P2.5 | G2 | Implement clipping flag (`|s| >= 0.9999` count > threshold). |
+| P2.6 | G1 | Wire DSD (DSF/DFF) and WavPack through the same streaming loop; metrics populated for those formats too. |
+
+### Phase 3 — Scanner integration
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P3.1 | G9 | Refactor the sparse-metadata chunk fetch out of `_extractSparseMetadataInBackground` so it's callable from `AudioPreloadService` (no behaviour change to current call sites). |
+| P3.2 | G5 | After each `_scanFolder*` completes, if `scanPreferences.preloadAudioData == true`, spawn `AudioPreloadService.preloadSongs(newlyAddedSongs)` via `_runDetachedScanTask`. Forward `_isCancelled`. |
+| P3.3 | G5 | Pass `forceAll: true` only from the manual "Reprocess all" path; default path passes `forceAll: false`. |
+| P3.4 | G5 | Wire cover-art preload: per song, `extractEmbeddedArtwork(path)` → write to `album_art/<songId>.<ext>` → `SongRepository.updateAlbumArtPath`. Skip silently if no embedded art. |
+
+### Phase 4 — UI
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P4.1 | G6 | Add `preloadAudioData: bool` (default `false`) to `LibraryScanPreferences` + `copyWith` + `setPreloadAudioData` (`library_scan_preferences_service.dart`). |
+| P4.2 | G7 | New toggle row "Preload audio data" beside "Deep scan" (`library_settings_screen.dart:810`), same styling. |
+| P4.3 | G7 | New menu action "Preload library audio" beside "Rescan Library" (`library_settings_screen.dart:1140`). Opens a sheet with a "Reprocess all" checkbox and an estimate (song count × ~real-time). |
+| P4.4 | G7 | Surface preload progress via the existing `_scanProgressNotifier`/`ScanProgress` plumbing; add a `phase` field (`scanning` vs `preloading`) so the UI can label "Preloading… N / M". |
+
+### Phase 5 — Waveform consumer
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P5.1 | G8 | In `waveform_seek_bar.dart`, replace `_generateWaveform()` with a lookup: read `SongAudioCacheEntity.peaks` for the current song, interpolate to `widget.barCount`. |
+| P5.2 | G8 | Fall back to the existing synthetic `Random(duration)` data only when no cache row exists. No flicker: resolve async, keep synthetic shape until the cached peaks arrive. |
+
+### Phase 6 — Self-checks (ponytail: one runnable check per non-trivial unit)
+
+| Task | Change |
+|------|--------|
+| P6.1 | Rust `#[test]`: synthesise a 1 kHz sine at known RMS, assert `peaks.len() == peak_buckets` and `lufs` within ±1 LU of the analytic value. |
+| P6.2 | Rust `#[test]`: a full-scale square wave asserts `clipping == true` and `true_peak_db ≈ 0.0`. |
+| P6.3 | Dart unit test for `AudioPreloadService`: cache-fresh song is skipped; `forceAll: true` re-processes it. |
+
+---
+
+## G. Risks & open questions
+
+- **Cost on large libraries.** 1 000 songs × ~real-time decode is many hours
+  single-threaded. Concurrency cap of 2 + the "new songs only" default keeps
+  incremental scans cheap. The manual action shows an estimate before starting.
+  Acceptable as v1.
+- **DSD decode cost.** DSF/DFF files are large and decode roughly at real time.
+  Phase 2 includes them in the metrics pass; if it proves too slow in practice,
+  the fallback is **peaks only for DSD** (still useful for the seek bar) with
+  metrics left `None`. Decide after Phase 2 benchmarking.
+- **Android SAF-only folders** (removable storage, no Rust path access). Fall
+  back to MediaMetadataRetriever-only metadata + skip peaks/art for those
+  files (art is still extractable via SAF if we add a separate code path
+  later). The preload service treats unreachable paths as a silent skip.
+- **LUFS implementation.** Hand-rolled BS.1770 keeps the dependency list flat
+  (~150 LOC, stdlib math only). Switch to a crate only if accuracy becomes a
+  problem in practice.
+- **Peak bucket resolution.** ~240 chosen to sit above the seek bar's current
+  `_cachedSampleCount = 180` (`waveform_seek_bar.dart:33`) with headroom for
+  pinch-zoom. Adjustable in one constant if zoom needs more.

--- a/docs/RELEASE_0.20.4-beta.5.md
+++ b/docs/RELEASE_0.20.4-beta.5.md
@@ -1,0 +1,113 @@
+# Flick 0.20.4-beta.5
+
+0.20.4-beta.5 ships real-time pitch shifting via SoundTouch, an Android audio API preference (AAudio/OpenSL/Auto), blurred backgrounds across all library screens, customizable orbit (menu) settings, album artwork stretch mode, lyrics performance caching, streak and preference controls, and artwork reliability fixes.
+
+## Overview
+
+This beta adds nine headline features:
+
+1. **Pitch shifter (SoundTouch)** — real-time pitch shifting via SoundTouch DSP, lock-free bypass, semitone API
+2. **Android audio API preference** — choose AAudio, OpenSL ES, or Auto for audio output
+3. **Blurred backgrounds everywhere** — consistent glass-look backgrounds on all library screens
+4. **Orbit customization** — tune the menu screen's orbit geometry, sizing, depth, art resolution
+5. **Album artwork stretch** — stretch album art to fill cards
+6. **Lyrics performance** — in-memory cache, parallel exact+fuzzy searches
+7. **Streaks & preference controls** — disable streaks, toggle album detail sections
+8. **Artwork reliability** — only cache confirmed paths, prefer embedded art
+9. **UI polish** — glass engine selector, responsive header, edge-drag guard
+
+## Highlights
+
+- **Pitch shifter**: SoundTouch, the industry-standard pitch and tempo library, is integrated into Flick's DSP chain. A lock-free bypass flag makes the pitch shifter zero-cost when set to 1.0×. The semitone API spans the full musically useful range. A pitch control bottom sheet provides a semitone slider, also accessible from the song actions sheet. Pitch resets to 1.0× when playback stops in non-Rust backends.
+- **Audio API**: You can now choose between **AAudio** (recommended, Android 8+), **OpenSL ES** (legacy), or **Auto** for Android audio output. The preference is persisted and applied instantly. It's exposed in Settings → Audio → UAC2 and in the Rust debug state JSON. An `AudioApiPreference` enum with FFI getter/setter and Dart bridge makes the preference reactive.
+- **Blurred backgrounds**: A shared `BlurredSongBackground` widget now wraps all library screens (songs, recently played, recently added, queue, favorites, playlists, folders, artists, albums) for a consistent glass-morphism look. A fade-only route transition keeps the blurred background stable while screens change.
+- **Orbit customization**: A new orbital settings screen lets you tune the menu screen's orbit — geometry parameters, card sizing, visual depth, art resolution, and general visual toggles. All parameters live in `AppPreferences` with setters and a reset option. `SongCard` sizing is now fully configurable. Unused hardcoded orbit constants were removed.
+- **Album artwork stretch**: Album artwork can now stretch to fill the entire card instead of being letterboxed. Toggle from Settings → Library → Stretch album artwork. Uses a single-image display with stretch support.
+- **Lyrics performance**: An in-memory cache with timeout reduces redundant API calls when searching the same lyrics repeatedly. A shared HTTP client prevents connection pool exhaustion. Exact and fuzzy searches run in parallel and return the first match.
+- **Streaks & preferences**: Streaks can be disabled entirely with a reset option that clears all streak data. The day streak milestone is hidden when streaks are disabled. "More from Artist" and "More Artists" sections on album detail screens can be toggled independently. Display preferences were added to the artist sort sheet.
+- **Artwork**: Only confirmed-existing artwork paths are cached, preventing phantom thumbnails from appearing when storage is unmounted. The artwork source path now prefers songs with embedded album art for fallback. The path picker matches the song that has artwork matching the album art.
+
+## What's New
+
+### Pitch Shifter (SoundTouch)
+
+- SoundTouch library integrated into DSP chain
+- Lock-free bypass flag (zero-cost at 1.0×)
+- Semitones API with FFI bridge and notifier
+- Pitch control bottom sheet with slider
+- Song actions sheet integration
+- Auto-reset to 1.0× on stop
+
+### Android Audio API Preference
+
+- AAudio / OpenSL ES / Auto selection
+- Persisted with instant apply
+- UAC2 settings and debug state exposure
+- `AudioApiPreference` enum, FFI, Dart bridge
+
+### Blurred Backgrounds Everywhere
+
+- `BlurredSongBackground` on all library screens
+- Fade-only route transition for stable backgrounds
+
+### Orbit Customization
+
+- Orbital settings screen (geometry, sizing, depth, art, visuals)
+- Configurable `SongCard` sizing
+- All parameters in `AppPreferences` with reset
+- Unused constants removed
+
+### Album Artwork Stretch
+
+- Stretch mode toggle in Library settings
+- Single-image display with stretch support
+
+### Lyrics Performance
+
+- In-memory cache with timeout
+- Shared HTTP client
+- Parallel exact + fuzzy searches
+
+### Streaks & Preference Controls
+
+- Disable streaks with reset
+- Hide day streak when disabled
+- Independent album detail section toggles
+- Artist sort sheet display preferences
+
+### Artwork Reliability
+
+- Cache only confirmed-existing paths
+- Prefer embedded art for fallback
+- Match artwork source path to album art
+
+### UI Polish & Fixes
+
+- Glass bottom sheet engine selector with hero gradients
+- Responsive songs header with Flexible labels
+- Edge-drag navigation guard
+- Sort sheet margin fix
+- Docs: scan plan, scan revamp, feature requests
+
+## Files Changed
+
+| Area | Key Paths |
+| --- | --- |
+| Pitch Shifter | `rust/vendor/soundtouch-sys/`, `rust/src/audio/pitch_shifter.rs`, `lib/features/player/widgets/pitch_control_sheet.dart` |
+| Audio API | `rust/src/audio/android_output.rs`, `rust/src/api/audio_api_preference.rs`, `lib/features/settings/screens/uac2_preferences_screen.dart` |
+| Blurred BG | `lib/widgets/common/blurred_song_background.dart`, `lib/features/**/screens/*.dart` |
+| Orbit | `lib/features/settings/screens/orbit_settings_screen.dart`, `lib/widgets/orbit_view.dart`, `lib/widgets/song_card.dart` |
+| Albums | `lib/features/albums/screens/albums_screen.dart`, `lib/features/albums/widgets/album_card.dart` |
+| Lyrics | `lib/services/lyrics_service.dart`, `lib/services/online_lyrics_service.dart` |
+| Streaks | `lib/features/milestones/`, `lib/features/settings/screens/interface_screen.dart` |
+| Artwork | `lib/services/artwork_cache_service.dart`, `lib/services/artwork_extraction_service.dart` |
+| Engine Selector | `lib/features/home/widgets/engine_selector.dart` |
+
+## Upgrading
+
+1. Pitch shifter: tap the pitch badge on the player or open the three-dot song actions → Pitch
+2. Audio API: Settings → Audio → UAC2 → Android Audio API
+3. Orbit customization: Settings → Interface → Orbit
+4. Album artwork stretch: Settings → Library → Stretch album artwork
+5. Streak settings: Settings → Interface → Streaks
+6. Blurred backgrounds are automatic on all library screens — no configuration needed

--- a/docs/SCAN_DETAILS_REVAMP_PLAN.md
+++ b/docs/SCAN_DETAILS_REVAMP_PLAN.md
@@ -1,0 +1,216 @@
+# Scan Details Revamp Plan
+
+Status: **Planned** (not yet implemented)
+Last updated: 2026-07-20
+
+## Goal
+
+Revamp the library scanning UI to expose the full scan session, not just songs-found count and current filename. Today the service computes/knows a lot that the UI never surfaces (scan engine, phase, new/modified/deleted deltas, elapsed time, folder progress, background-task state, removable-storage unavailability). This plan widens the `ScanProgress` model and redesigns both the live overlay and the post-scan summary around it.
+
+## Files touched
+
+Only two files change:
+
+- `lib/services/library_scanner_service.dart` — extend `ScanProgress`; instrument every yield
+- `lib/features/settings/screens/library_settings_screen.dart` — full redesign of overlay + complete sheet; add elapsed timer
+
+No Rust changes. No new dependencies.
+
+## Decisions (locked)
+
+| Question | Decision |
+|---|---|
+| Which details to surface | All: elapsed + rate, progress %, phase, engine, new/modified/deleted, background status, folder progress |
+| Scope | Full redesign of overlay AND complete sheet |
+| Data plumbing | Extend `ScanProgress`; service populates new fields |
+| Background tasks | Overlay stays open until foreground AND detached tasks all finish; phase row shows "Finishing metadata enrichment…" |
+| Removable unavailable | Dedicated "USB storage not connected" state in the redesigned overlay |
+| Progress visual | Both — circular ring around the vinyl AND a linear bar |
+
+---
+
+## Phase 1 — Extend `ScanProgress`
+
+Location: `lib/services/library_scanner_service.dart:18-35`.
+
+Add fields with defaults so existing call sites still compile:
+
+```dart
+class ScanProgress {
+  final int songsFound;
+  final int totalFiles;
+  final int filesProcessed;           // NEW — for progress bar (processed/total)
+  final String? currentFile;
+  final String? currentFolder;
+  final String? phase;                // NEW — 'Reading metadata', etc.
+  final String? scanEngine;           // NEW — 'Rust deep scan' | 'MediaStore' | 'SAF' | 'SAF (instant)'
+  final int newSongs;                 // NEW
+  final int modifiedSongs;            // NEW
+  final int deletedSongs;             // NEW
+  final int? foldersTotal;            // NEW — scan-all only
+  final int? foldersCompleted;        // NEW — scan-all only
+  final bool backgroundTasksRunning;  // NEW — foreground done, detached still finishing
+  final bool isComplete;
+  final bool unavailable;
+}
+```
+
+Defaults: numeric fields `0`, `backgroundTasksRunning false`, optionals `null`.
+
+---
+
+## Phase 2 — Service emits richer progress
+
+### 2a. `_ScanAccumulator` helper
+
+Avoid repeating the field list at every yield. Mutable holder the per-path methods write into; a single `toProgress({...overrides})` builds the immutable `ScanProgress`. Fields: `songsFound`, `totalFiles`, `filesProcessed`, `newSongs`, `modifiedSongs`, `deletedSongs`, plus `currentFolder`, `scanEngine`, `phase` set at method entry.
+
+### 2b. Per-path instrumentation
+
+Each scan path already has the data locally — surface it:
+
+| Path | `scanEngine` | Where counters already live |
+|---|---|---|
+| `_scanFolderRust` (`:1241`) | `'Rust deep scan'` | `processed` at `:1298` / `:1409`; existing/missing in `existingMap` / `idsToDelete` |
+| `_scanFolderMediaStore` (`:231`) | `'MediaStore'` | no incremental — batch builds, jump 0→total (accurate); new/modified from `existing != null` check at `:331` |
+| `_scanFolderAndroid` (`:877`) | `'SAF'` | `processed` at `:1210`; `existingMap` lookups |
+| `_scanFolderAndroidInstant` (`:691`) | `'SAF (instant)'` | single yield at `:742`; deltas computed from `newBatch.length` + post-pass deletions |
+
+`phase` string emitted before each major step. Canonical labels:
+`'Querying filesystem'`, `'Loading existing entries'`, `'Diffing'`, `'Reading metadata'`, `'Parsing CUE/log'`, `'Upserting songs'`, `'Syncing playlists'`, `'Syncing fingerprints'`, `'Finalizing'`.
+
+`newSongs`/`modifiedSongs`/`deletedSongs` accumulators: per batch, `existing == null` → new, else modified; deleted from `idsToDelete.length` / `urisToDelete.length` / `chunk.deletedPaths.length`.
+
+`filesProcessed`: reuse existing `processed` counters. MediaStore/instant paths jump 0→total (accurate — they batch).
+
+### 2c. Detached-task tracking
+
+Today `_runDetachedScanTask` (`:1902`) is fire-and-forget. Change to:
+
+- Keep a `List<Future<void>> _detachedTasks` on the service instance (or per-scan accumulator).
+- `_runDetachedScanTask` appends its wrapped future to the list.
+- After the foreground scan loop ends, yield `ScanProgress(isComplete: false, backgroundTasksRunning: true, phase: 'Finishing metadata enrichment', filesProcessed: totalFiles)` (ring/bar pin at 100%).
+- `await Future.wait(_detachedTasks)`, then clear the list, then yield the final `isComplete: true`.
+- Cancel still works — `_isCancelled` already gates the detached loops.
+
+This is the only behavior change users will notice: the overlay stays open until enrichment/playlist/fingerprint work drains, instead of closing the instant foreground finishes.
+
+### 2d. `scanAllFolders` folder counting
+
+Location: `:1617`. The wrapper knows `scanPlan.length` and tracks `completed` (`:1648`). Emit `foldersTotal: scanPlan.length` and `foldersCompleted: completed` on every progress forwarded through the controller.
+
+---
+
+## Phase 3 — Elapsed/rate timer (UI state)
+
+Location: `_LibrarySettingsScreenState` in `library_settings_screen.dart`.
+
+- Add `Timer? _elapsedTimer` and `final ValueNotifier<Duration> _elapsedNotifier = ValueNotifier(Duration.zero)`.
+- On scan start (alongside `_scanStopwatch.reset()`): start a `Timer.periodic(Duration(milliseconds: 200), (_) => _elapsedNotifier.value = _scanStopwatch.elapsed)`.
+- On scan end / dispose: cancel timer.
+- Rate is derived in the builder, not stored: `songsFound / max(elapsed.inSeconds, 1)`.
+- The overlay's root listens to both `_scanProgressNotifier` and `_elapsedNotifier` via `Listenable.merge`.
+
+---
+
+## Phase 4 — Redesign scanning overlay
+
+Replace `_showScanningOverlay` (`:391-570`). Full-screen glass dashboard.
+
+```
+┌─────────────────────────────┐
+│                             │
+│        ┌─────────┐          │
+│        │ vinyl   │  120px, circular progress ring around it
+│        │  42%    │          │
+│        └─────────┘          │
+│                             │
+│        Music Library        │  folder name (18, semibold)
+│      ● Reading metadata     │  phase (accent, pulsing dot)
+│                             │
+│  ▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░  │  linear progress bar
+│      210 / 500 files        │
+│                             │
+│  ┌──────┬──────┬──────┐     │
+│  │ 142  │  68  │  12  │     │  new / modified / deleted
+│  │ New  │ Mod  │ Del  │     │
+│  └──────┴──────┴──────┘     │
+│                             │
+│  ┌──────┬──────┬──────┐     │
+│  │ 1:23 │ 42/s │ Rust │     │  elapsed / rate / engine chip
+│  │Time  │Rate  │ Deep │     │
+│  └──────┴──────┴──────┘     │
+│                             │
+│    Folder 2 of 5            │  only when foldersTotal != null
+│                             │
+│       [ Cancel ]            │
+└─────────────────────────────┘
+```
+
+### Building blocks
+
+- **Progress ring around vinyl**: `CustomPainter` drawing an arc from `filesProcessed / totalFiles`. Indeterminate sweep when `totalFiles == 0`. Vinyl stays at 120px (down from 180) to leave room.
+- **Linear bar**: standard `LinearProgressIndicator` with the same fraction; `"$filesProcessed / $totalFiles files"` below.
+- **Phase row**: accent dot (small, pulsing via `AnimationController` reuse of `_vinylController` or a new 1s repeat) + `phase` text. Falls back to `'Initializing…'` when null.
+- **3-up New/Mod/Del grid**: reuse `_buildScanStat` (extract a compact variant if needed). Icons: `LucideIcons.plus`, `LucideIcons.refreshCw`, `LucideIcons.trash2`.
+- **3-up Time/Rate/Engine grid**: elapsed (`m:ss`), rate (`$N/s`), engine chip (`LucideIcons.cpu`). Engine chip is a pill, hidden when `scanEngine == null`.
+- **Folder progress**: single centered line `"Folder $foldersCompleted of $foldersTotal"`, rendered only when `foldersTotal != null && foldersTotal > 1`.
+- **Cancel button**: keep current behavior (`_scannerService.cancelScan()` + close).
+
+### State variants
+
+1. **Normal scanning**: dashboard above.
+2. **Background tasks running** (`backgroundTasksRunning == true`): same dashboard, ring + bar at 100%, phase row swaps to `"Finishing metadata enrichment…"` with a small spinner instead of the pulsing dot. New/Mod/Del counts hold at final values.
+3. **Removable unavailable** (`progress.unavailable == true`): replace the dashboard with a centered state — `LucideIcons.usb` (or `unplug`), `"USB storage not connected"`, subtitle `"$currentFolder is offline — retained songs still listed"`, single **Done** button (not Cancel). Available immediately because the service already yields `unavailable: true` at `:133-140` for unmounted removable storage.
+
+### Glass/styling
+
+Keep existing `BackdropFilter` + `AppColors.glassBackground`/`glassBorder` treatment; reuse `AppConstants.spacing*` and `radius*`. The existing drag handle and bottom-sheet framing go away (full-screen now).
+
+---
+
+## Phase 5 — Redesign scan-complete sheet
+
+Replace `_showScanCompleteBottomSheet` (`:572-652`). Pass the final `ScanProgress` + stopwatch into it.
+
+Layout:
+
+```
+        ✓  (LucideIcons.circleCheck, accent, 48)
+
+   ┌──────┬──────┬──────┐
+   │ 142  │  68  │  12  │     New / Modified / Deleted
+   │ New  │ Mod  │ Del  │
+   └──────┴──────┴──────┘
+
+   ┌──────┬──────┬──────┐
+   │ 4210 │ 1:23 │ 34/s │     Total songs / Time / Avg rate
+   │ Tot  │ Time │ Rate │
+   └──────┴──────┴──────┘
+
+   [ Rust deep scan · 5 folders ]   engine chip + folder count (scan-all only)
+
+            [ Done ]
+```
+
+- Drop the old 1×2 `_buildScanStat` row.
+- New/Mod/Del come straight from the final `ScanProgress`; Total from `progress.songsFound`; Time from stopwatch; Rate derived.
+- Engine chip + folder count line only renders when `scanEngine != null` / `foldersTotal != null`.
+- Keep `GlassBottomSheet.show`, `isDismissible`, `enableDrag`, `maxHeightRatio` pattern.
+
+---
+
+## Phase 6 — Verify
+
+- `flutter analyze lib/services/library_scanner_service.dart lib/features/settings/screens/library_settings_screen.dart`
+- Confirm scanner tests still compile: `dart test test/` if anything references `ScanProgress` (none currently do — service tests don't construct it — but re-check at impl time).
+- Manual smoke: scan one folder (Rust path on desktop), scan one folder on Android (MediaStore + SAF), rescan all folders, unmount removable storage and scan.
+
+---
+
+## Out of scope
+
+- Per-file ETA (rate is shown, but not "X seconds remaining" — files have wildly variable metadata cost; ETA would be misleading).
+- Persisting scan history to DB. Today scans are ephemeral; this plan keeps that.
+- Notification/channel updates during scan (separate surface).
+- Changing the detached task set itself (sparse metadata, sidecar, playlist sync, fingerprint sync all stay as-is).

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -1,12 +1,8 @@
 /// Current marketing version of the app (matches the `version` field in
 /// `pubspec.yaml`). Bump in lockstep with each release.
-const String kAppVersion = '0.20.3-beta.4';
-
-/// Current build number (matches the `version` `+N` suffix in
-/// `pubspec.yaml`). Bump whenever `kAppVersion` is bumped.
-const String kAppBuild = '20';
-
-/// Human-friendly version label, e.g. `0.20.3-beta.4 (build 20)`.
+const String kAppVersion = '0.20.4-beta.5';
+const String kAppBuild = '21';
+/// Human-friendly version label, e.g. `0.20.4-beta.5 (build 21)`.
 const String kAppVersionLabel = '$kAppVersion (build $kAppBuild)';
 
 /// App-wide constants for Flick Player.

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -119,7 +119,15 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     return null;
   }
 
+  // ponytail: pick the source path of the SAME song whose albumArt we'd use,
+  // so CachedImageWidget's embedded-art fallback targets the matching track.
   String? _getSourcePath(List<Song> songs) {
+    for (final song in songs) {
+      if (song.albumArt != null && song.albumArt!.isNotEmpty) {
+        final fp = song.filePath;
+        if (fp != null && fp.isNotEmpty) return fp;
+      }
+    }
     for (final song in songs) {
       if (song.filePath != null && song.filePath!.isNotEmpty) {
         return song.filePath;
@@ -917,6 +925,12 @@ class _ArtistCard extends StatelessWidget {
   }
 
   String? _getSourcePath() {
+    for (final song in songs) {
+      if (song.albumArt != null && song.albumArt!.isNotEmpty) {
+        final fp = song.filePath;
+        if (fp != null && fp.isNotEmpty) return fp;
+      }
+    }
     for (final song in songs) {
       if (song.filePath != null && song.filePath!.isNotEmpty) {
         return song.filePath;

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -16,6 +16,7 @@ import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
 
 /// Album detail screen showing songs, album info, and more from the artist.
 class AlbumDetailScreen extends ConsumerStatefulWidget {
@@ -481,7 +482,8 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
                     }, childCount: widget.songs.length),
                   ),
                 ),
-                if (_moreAlbums.isNotEmpty) ...[
+                if (_moreAlbums.isNotEmpty &&
+                    ref.watch(appPreferencesProvider).showMoreFromArtist) ...[
                   _buildSectionTitle(
                     context,
                     'More from ${widget.albumArtist}',
@@ -513,7 +515,8 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
                     ),
                   ),
                 ],
-                if (_moreArtists.isNotEmpty) ...[
+                if (_moreArtists.isNotEmpty &&
+                    ref.watch(appPreferencesProvider).showMoreArtists) ...[
                   const SliverToBoxAdapter(
                     child: SizedBox(height: AppConstants.spacingLg),
                   ),

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -116,12 +116,20 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
     return null;
   }
 
+  // ponytail: pick the source path of the SAME song whose albumArt we'd use,
+  // so CachedImageWidget's embedded-art fallback targets the matching track
+  // instead of an unrelated one. Falls back to first non-empty filePath only
+  // when no song has albumArt.
   String? _getArtworkSourcePath(List<Song> songs) {
     for (final song in songs) {
-      final filePath = song.filePath;
-      if (filePath != null && filePath.isNotEmpty) {
-        return filePath;
+      if (song.albumArt != null && song.albumArt!.isNotEmpty) {
+        final fp = song.filePath;
+        if (fp != null && fp.isNotEmpty) return fp;
       }
+    }
+    for (final song in songs) {
+      final fp = song.filePath;
+      if (fp != null && fp.isNotEmpty) return fp;
     }
     return null;
   }

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -102,10 +102,7 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
       backgroundColor: Colors.transparent,
       builder: (_) => _AlbumSortSheet(
         currentOption: _sortOption,
-        onSelected: (option) {
-          _setSortOption(option);
-          Navigator.of(context).pop();
-        },
+        onSelected: (option) => _setSortOption(option),
       ),
     );
   }
@@ -152,9 +149,9 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
       _visibilitySet = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          ProviderScope.containerOf(context)
-              .read(navBarVisibleProvider.notifier)
-              .setVisible(true);
+          ProviderScope.containerOf(
+            context,
+          ).read(navBarVisibleProvider.notifier).setVisible(true);
         }
       });
     }
@@ -197,22 +194,22 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
           Row(
             children: [
               if (Navigator.of(context).canPop()) ...[
-              Container(
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                  border: Border.all(color: AppColors.glassBorder),
-                ),
-                child: IconButton(
-                  icon: Icon(
-                    LucideIcons.arrowLeft,
-                    color: context.adaptiveTextPrimary,
-                    size: context.responsiveIcon(AppConstants.iconSizeMd),
+                Container(
+                  decoration: BoxDecoration(
+                    color: AppColors.glassBackground,
+                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                    border: Border.all(color: AppColors.glassBorder),
                   ),
-                  onPressed: () => Navigator.of(context).pop(),
+                  child: IconButton(
+                    icon: Icon(
+                      LucideIcons.arrowLeft,
+                      color: context.adaptiveTextPrimary,
+                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    ),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
                 ),
-              ),
-              const SizedBox(width: AppConstants.spacingMd),
+                const SizedBox(width: AppConstants.spacingMd),
               ],
               Expanded(
                 child: Column(
@@ -267,8 +264,8 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
                 secondChild: _buildGlanceCard(context, expanded: false),
                 crossFadeState:
                     ref.watch(appPreferencesProvider).glanceCardMinimized
-                        ? CrossFadeState.showSecond
-                        : CrossFadeState.showFirst,
+                    ? CrossFadeState.showSecond
+                    : CrossFadeState.showFirst,
                 duration: AppConstants.animationNormal,
               ),
             ),
@@ -311,9 +308,7 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
                   children: [
                     Text(
                       'Your collection at a glance',
-                      style: Theme.of(
-                        context,
-                      ).textTheme.titleMedium?.copyWith(
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: context.adaptiveTextPrimary,
                         fontWeight: FontWeight.w700,
                       ),
@@ -467,31 +462,34 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
                 right: AppConstants.spacingLg,
                 bottom: AppConstants.navBarHeight + 120,
               ),
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: context.gridColumns(
-                compact: 2,
-                phone: 2,
-                tablet: 3,
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: context.gridColumns(
+                  compact: 2,
+                  phone: 2,
+                  tablet: 3,
+                ),
+                childAspectRatio: 0.78,
+                crossAxisSpacing: AppConstants.spacingMd,
+                mainAxisSpacing: AppConstants.spacingLg,
               ),
-              childAspectRatio: 0.78,
-              crossAxisSpacing: AppConstants.spacingMd,
-              mainAxisSpacing: AppConstants.spacingLg,
-            ),
-            itemCount: _sortedAlbums.length,
-            itemBuilder: (context, index) {
-              final album = _sortedAlbums[index];
-              return _AlbumCard(
-                albumName: album.albumName,
-                albumArtist: album.albumArtist,
-                songs: album.songs,
-                albumArt: _getAlbumArt(album.songs),
-                albumArtSourcePath: _getArtworkSourcePath(album.songs),
-                onTap: () => _openAlbumDetail(album),
-              );
-            },
-            ),
+              itemCount: _sortedAlbums.length,
+              itemBuilder: (context, index) {
+                final album = _sortedAlbums[index];
+                return _AlbumCard(
+                  albumName: album.albumName,
+                  albumArtist: album.albumArtist,
+                  songs: album.songs,
+                  albumArt: _getAlbumArt(album.songs),
+                  albumArtSourcePath: _getArtworkSourcePath(album.songs),
+                  stretchArtwork: ref
+                      .watch(appPreferencesProvider)
+                      .albumsStretchArtwork,
+                  onTap: () => _openAlbumDetail(album),
+                );
+              },
             ),
           ),
+        ),
       ],
     );
   }
@@ -503,6 +501,7 @@ class _AlbumCard extends StatefulWidget {
   final List<Song> songs;
   final String? albumArt;
   final String? albumArtSourcePath;
+  final bool stretchArtwork;
   final VoidCallback onTap;
 
   const _AlbumCard({
@@ -511,6 +510,7 @@ class _AlbumCard extends StatefulWidget {
     required this.songs,
     required this.albumArt,
     required this.albumArtSourcePath,
+    required this.stretchArtwork,
     required this.onTap,
   });
 
@@ -552,7 +552,13 @@ class _AlbumCardState extends State<_AlbumCard>
     final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
     final cardWidth = context.scaleSize(AppConstants.cardWidthMd);
     final artworkTargetWidth = (cardWidth * devicePixelRatio).round();
-    final artworkTargetHeight = artworkTargetWidth;
+    // ponytail: only set thumbnailHeight when stretching — passing both
+    // cacheWidth+cacheHeight forces the decoder to a square bitmap, which
+    // distorts non-square art. Null height lets aspect ratio survive so
+    // BoxFit.cover can crop.
+    final artworkTargetHeight = widget.stretchArtwork
+        ? artworkTargetWidth
+        : null;
 
     return GestureDetector(
       onTapDown: (_) => _controller.forward(),
@@ -606,14 +612,14 @@ class _AlbumCardState extends State<_AlbumCard>
                               ),
                             ],
                           ),
-                          child: Stack(
-                            fit: StackFit.expand,
-                            children: [
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(
-                                  AppConstants.radiusLg,
-                                ),
-                                child: CachedImageWidget(
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(
+                              AppConstants.radiusLg,
+                            ),
+                            child: Stack(
+                              fit: StackFit.expand,
+                              children: [
+                                CachedImageWidget(
                                   imagePath: widget.albumArt,
                                   audioSourcePath: widget.albumArtSourcePath,
                                   fit: BoxFit.cover,
@@ -623,50 +629,52 @@ class _AlbumCardState extends State<_AlbumCard>
                                   placeholder: _buildPlaceholder(context),
                                   errorWidget: _buildPlaceholder(context),
                                 ),
-                              ),
-                              Positioned.fill(
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    gradient: LinearGradient(
-                                      begin: Alignment.topCenter,
-                                      end: Alignment.bottomCenter,
-                                      colors: [
-                                        Colors.transparent,
-                                        Colors.black.withValues(alpha: 0.1),
-                                        Colors.black.withValues(alpha: 0.45),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              Positioned(
-                                left: AppConstants.spacingSm,
-                                bottom: AppConstants.spacingSm,
-                                child: Container(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: AppConstants.spacingSm,
-                                    vertical: 6,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: Colors.black.withValues(alpha: 0.55),
-                                    borderRadius: BorderRadius.circular(999),
-                                    border: Border.all(
-                                      color: Colors.white.withValues(
-                                        alpha: 0.12,
+                                Positioned.fill(
+                                  child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                      gradient: LinearGradient(
+                                        begin: Alignment.topCenter,
+                                        end: Alignment.bottomCenter,
+                                        colors: [
+                                          Colors.transparent,
+                                          Colors.black.withValues(alpha: 0.1),
+                                          Colors.black.withValues(alpha: 0.45),
+                                        ],
                                       ),
                                     ),
                                   ),
-                                  child: Text(
-                                    '${widget.songs.length} tracks',
-                                    style: const TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 11,
-                                      fontWeight: FontWeight.w700,
+                                ),
+                                Positioned(
+                                  left: AppConstants.spacingSm,
+                                  bottom: AppConstants.spacingSm,
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: AppConstants.spacingSm,
+                                      vertical: 6,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: Colors.black.withValues(
+                                        alpha: 0.55,
+                                      ),
+                                      borderRadius: BorderRadius.circular(999),
+                                      border: Border.all(
+                                        color: Colors.white.withValues(
+                                          alpha: 0.12,
+                                        ),
+                                      ),
+                                    ),
+                                    child: Text(
+                                      '${widget.songs.length} tracks',
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.w700,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),
@@ -832,7 +840,9 @@ class _AlbumSortSheet extends StatelessWidget {
                   label,
                   style: TextStyle(
                     fontSize: 15,
-                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                    fontWeight: isSelected
+                        ? FontWeight.w600
+                        : FontWeight.normal,
                     color: isSelected
                         ? AppColors.accent
                         : context.adaptiveTextPrimary,

--- a/lib/features/artists/screens/artists_screen.dart
+++ b/lib/features/artists/screens/artists_screen.dart
@@ -721,7 +721,7 @@ class _ArtistCardState extends State<_ArtistCard>
   }
 }
 
-class _ArtistSortSheet extends StatelessWidget {
+class _ArtistSortSheet extends ConsumerWidget {
   final ArtistSortOption currentOption;
   final ValueChanged<ArtistSortOption> onSelected;
 
@@ -731,7 +731,8 @@ class _ArtistSortSheet extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final prefs = ref.watch(appPreferencesProvider);
     return SafeArea(
       top: false,
       child: Container(
@@ -754,6 +755,29 @@ class _ArtistSortSheet extends StatelessWidget {
               const SizedBox(height: 8),
               ...ArtistSortOption.values.map(
                 (option) => _buildSortTile(context, option),
+              ),
+              const SizedBox(height: 16),
+              _buildSectionHeader(context, 'DISPLAY'),
+              const SizedBox(height: 8),
+              _buildToggleTile(
+                context,
+                icon: LucideIcons.disc3,
+                label: 'More from artist',
+                subtitle: 'Show related albums on album pages',
+                value: prefs.showMoreFromArtist,
+                onChanged: ref
+                    .read(appPreferencesProvider.notifier)
+                    .setShowMoreFromArtist,
+              ),
+              _buildToggleTile(
+                context,
+                icon: LucideIcons.users,
+                label: 'More artists',
+                subtitle: 'Show other artists on album pages',
+                value: prefs.showMoreArtists,
+                onChanged: ref
+                    .read(appPreferencesProvider.notifier)
+                    .setShowMoreArtists,
               ),
             ],
           ),
@@ -866,5 +890,58 @@ class _ArtistSortSheet extends StatelessWidget {
       case ArtistSortOption.albums:
         return 'Album Count';
     }
+  }
+
+  Widget _buildToggleTile(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => onChanged(!value),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          child: Row(
+            children: [
+              Icon(icon, size: 20, color: context.adaptiveTextSecondary),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 15,
+                        color: context.adaptiveTextPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: context.adaptiveTextTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(
+                value: value,
+                activeThumbColor: AppColors.accent,
+                onChanged: onChanged,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/artists/screens/artists_screen.dart
+++ b/lib/features/artists/screens/artists_screen.dart
@@ -800,10 +800,7 @@ class _ArtistSortSheet extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () {
-          onSelected(option);
-          Navigator.of(context).pop();
-        },
+        onTap: () => onSelected(option),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
           decoration: BoxDecoration(

--- a/lib/features/folders/screens/folders_screen.dart
+++ b/lib/features/folders/screens/folders_screen.dart
@@ -2220,10 +2220,7 @@ class _FolderRootSortSheetState extends State<_FolderRootSortSheet> {
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () {
-          widget.onSelected(option);
-          Navigator.of(context).pop();
-        },
+        onTap: () => widget.onSelected(option),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
           decoration: BoxDecoration(
@@ -2382,10 +2379,7 @@ class _FolderBrowserSortSheet extends StatelessWidget {
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () {
-          onSelected(option);
-          Navigator.of(context).pop();
-        },
+        onTap: () => onSelected(option),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
           decoration: BoxDecoration(

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -2326,11 +2326,15 @@ class _HeroActionButton extends StatelessWidget {
                 color: isPrimary ? AppColors.background : Colors.white,
               ),
               const SizedBox(width: AppConstants.spacingXs),
-              Text(
-                label,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                  color: isPrimary ? AppColors.background : Colors.white,
-                  fontWeight: FontWeight.w700,
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                    color: isPrimary ? AppColors.background : Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
             ],

--- a/lib/features/milestone/screens/milestones_screen.dart
+++ b/lib/features/milestone/screens/milestones_screen.dart
@@ -26,6 +26,7 @@ class MilestonesScreen extends ConsumerStatefulWidget {
 class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
   final _service = MilestoneService();
   bool _loading = true;
+  bool _streaksEnabled = true;
   Map<MilestoneType, MilestoneRecord> _records = {};
   Map<MilestoneCategory, int> _current = const {};
 
@@ -42,9 +43,11 @@ class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
     final listenSeconds = await _service.getAccumulatedListenSeconds();
     final streak = await _service.getCurrentDayStreak();
     final artists = await _service.getUniqueArtistCount();
+    final streaksEnabled = ref.read(appPreferencesProvider).streaksEnabled;
     if (!mounted) return;
     setState(() {
       _records = {for (final r in records) r.type: r};
+      _streaksEnabled = streaksEnabled;
       _current = {
         MilestoneCategory.songs: playCount,
         MilestoneCategory.hours: listenSeconds ~/ 3600,
@@ -137,15 +140,20 @@ class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
   }
 
   Widget _buildGrid(BuildContext context) {
-    final cats = MilestoneCategory.values;
+    final cats = _streaksEnabled
+        ? MilestoneCategory.values
+        : MilestoneCategory.values
+            .where((c) => c != MilestoneCategory.dayStreak)
+            .toList();
+    final bannerSlots = _streaksEnabled ? 1 : 0;
     return ListView.builder(
       padding: const EdgeInsets.symmetric(
         horizontal: AppConstants.spacingLg,
         vertical: AppConstants.spacingMd,
       ),
-      itemCount: cats.length + 1,
+      itemCount: cats.length + bannerSlots,
       itemBuilder: (context, index) {
-        if (index == 0) {
+        if (index < bannerSlots) {
           return Padding(
             padding: const EdgeInsets.only(bottom: AppConstants.spacingMd),
             child: _StreakBanner(
@@ -154,10 +162,12 @@ class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
             ),
           );
         }
-        final cat = cats[index - 1];
+        final cat = cats[index - bannerSlots];
         return Padding(
           padding: EdgeInsets.only(
-            bottom: index - 1 < cats.length - 1 ? AppConstants.spacingMd : 0,
+            bottom: index - bannerSlots < cats.length - 1
+                ? AppConstants.spacingMd
+                : 0,
           ),
           child: _CategorySection(
             category: cat,

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -69,6 +69,10 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
   // Last drag update time for throttling
   DateTime _lastDragUpdate = DateTime.now();
 
+  // ponytail: 24dp edge zone matches Android's predictive back gesture origin
+  static const double _backGestureEdgeWidth = 24.0;
+  double _horizontalDragStartX = double.infinity;
+
   // Notifier for throttled position – only _WaveformLayer listens, so no setState needed.
   late final ValueNotifier<Duration> _throttledPositionNotifier;
   Timer? _positionThrottleTimer;
@@ -390,8 +394,19 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                   _dragOffset = 0.0;
                   _dragController.animateTo(0.0);
                 },
+                onHorizontalDragStart: (details) {
+                  _horizontalDragStartX = details.globalPosition.dx;
+                },
                 onHorizontalDragEnd: (details) {
                   if (_isVinylRotationActive) return;
+                  // Skip song navigation if drag started at screen edge so the
+                  // native Android back gesture takes priority.
+                  final screenWidth = MediaQuery.sizeOf(context).width;
+                  final nearLeftEdge = _horizontalDragStartX <= _backGestureEdgeWidth;
+                  final nearRightEdge =
+                      _horizontalDragStartX >= screenWidth - _backGestureEdgeWidth;
+                  if (nearLeftEdge || nearRightEdge) return;
+
                   if (details.primaryVelocity! < -500) {
                     // Swipe Left -> Next
                     _animateToNextSong();

--- a/lib/features/settings/screens/interface_settings_screen.dart
+++ b/lib/features/settings/screens/interface_settings_screen.dart
@@ -4,12 +4,38 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/providers/providers.dart';
+import 'package:flick/services/milestone_service.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/features/settings/screens/bottom_bar_settings_screen.dart';
 import 'package:flick/features/settings/screens/visualizer_settings_screen.dart';
 
 class InterfaceSettingsScreen extends ConsumerWidget {
   const InterfaceSettingsScreen({super.key});
+
+  Future<void> _confirmResetStreak(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reset streak data?'),
+        content: const Text(
+          'This clears your current day streak and any unlocked streak milestones. This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await MilestoneService().clearStreakData();
+    }
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -83,6 +109,25 @@ class InterfaceSettingsScreen extends ConsumerWidget {
                       .read(appPreferencesProvider.notifier)
                       .setGlanceCardHidden(!value);
                 },
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.flame,
+                title: 'Day Streaks',
+                subtitle: 'Track consecutive listening days and show the popup',
+                value: appPreferences.streaksEnabled,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setStreaksEnabled(value);
+                },
+              ),
+              const SettingsDivider(),
+              ActionButton(
+                icon: LucideIcons.trash2,
+                title: 'Reset Streak Data',
+                subtitle: 'Clear the counter and any unlocked streak milestones',
+                onTap: () => _confirmResetStreak(context),
               ),
               const SettingsDivider(),
               NavigationSetting(

--- a/lib/features/settings/screens/library_settings_screen.dart
+++ b/lib/features/settings/screens/library_settings_screen.dart
@@ -1004,6 +1004,7 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
   @override
   Widget build(BuildContext context) {
     final libraryScanPreferences = ref.watch(libraryScanPreferencesProvider);
+    final appPreferences = ref.watch(appPreferencesProvider);
 
     return SettingsScaffold(
       title: 'Library',
@@ -1161,6 +1162,24 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
                 title: 'Clear Artwork Cache',
                 subtitle: _cacheSizeLabel,
                 onTap: _isClearingCache ? null : _confirmClearArtworkCache,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Album Artwork'),
+          SettingsCard(
+            children: [
+              ToggleSetting(
+                icon: LucideIcons.crop,
+                title: 'Stretch Non-Square Art',
+                subtitle:
+                    'Off crops to fill the square; on stretches the artwork edge-to-edge',
+                value: appPreferences.albumsStretchArtwork,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setAlbumsStretchArtwork(value);
+                },
               ),
             ],
           ),

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -108,6 +108,35 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Album Detail'),
+          SettingsCard(
+            children: [
+              ToggleSetting(
+                icon: LucideIcons.disc3,
+                title: 'More from Artist',
+                subtitle: 'Show related albums on album pages',
+                value: appPreferences.showMoreFromArtist,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setShowMoreFromArtist(value);
+                },
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.users,
+                title: 'More Artists',
+                subtitle: 'Show other artists on album pages',
+                value: appPreferences.showMoreArtists,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setShowMoreArtists(value);
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
           const SettingsSectionHeader('Progress Bar'),
           SettingsCard(
             children: [

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -666,6 +666,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
                             scale: 1.0 + pinchDelta * 0.04,
                             child: _AlbumCard(
                               album: album,
+                              stretchArtwork: ref
+                                  .watch(appPreferencesProvider)
+                                  .albumsStretchArtwork,
                               onTap: () => _openAlbumDetail(album),
                             ),
                           ),
@@ -706,9 +709,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
 
   Widget _buildAlbumListView(List<AlbumGroup> albums) {
     final visibleCount = min(_visibleAlbumCount, albums.length);
-    final visibleAlbums = albums
-        .take(visibleCount)
-        .toList(growable: false);
+    final visibleAlbums = albums.take(visibleCount).toList(growable: false);
     final hasMore = visibleCount < albums.length;
 
     return ListView.builder(
@@ -741,6 +742,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
           padding: const EdgeInsets.only(bottom: AppConstants.spacingSm),
           child: _AlbumListTile(
             album: album,
+            stretchArtwork: ref
+                .watch(appPreferencesProvider)
+                .albumsStretchArtwork,
             onTap: () => _openAlbumDetail(album),
           ),
         );
@@ -1534,7 +1538,8 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
   }
 
   Future<void> _showMoreActions() async {
-    final allSelected = _selectedIds.length == _cachedDisplaySongs.length &&
+    final allSelected =
+        _selectedIds.length == _cachedDisplaySongs.length &&
         _cachedDisplaySongs.isNotEmpty;
     if (!mounted) return;
 
@@ -1575,8 +1580,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
                 shrinkWrap: true,
                 children: [
                   _selectionSheetTile(
-                    icon:
-                        allSelected ? LucideIcons.x : LucideIcons.checkCheck,
+                    icon: allSelected ? LucideIcons.x : LucideIcons.checkCheck,
                     label: allSelected ? 'Deselect all' : 'Select all',
                     onTap: () {
                       Navigator.pop(sheetContext);
@@ -1936,8 +1940,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
                       ],
                     ),
                     borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                    border:
-                        Border.all(color: AppColors.glassBorder, width: 1),
+                    border: Border.all(color: AppColors.glassBorder, width: 1),
                     boxShadow: [
                       BoxShadow(
                         color: Colors.black.withValues(alpha: 0.2),
@@ -2493,9 +2496,14 @@ class _QueueSwipeListItemState extends State<_QueueSwipeListItem> {
 
 class _AlbumCard extends StatefulWidget {
   final AlbumGroup album;
+  final bool stretchArtwork;
   final VoidCallback onTap;
 
-  const _AlbumCard({required this.album, required this.onTap});
+  const _AlbumCard({
+    required this.album,
+    required this.stretchArtwork,
+    required this.onTap,
+  });
 
   @override
   State<_AlbumCard> createState() => _AlbumCardState();
@@ -2506,7 +2514,6 @@ class _AlbumCardState extends State<_AlbumCard>
   late AnimationController _controller;
   late Animation<double> _scaleAnimation;
   late Animation<double> _tiltAnimation;
-  List<_ArtEntry> _cachedArtworks = const [];
 
   @override
   void initState() {
@@ -2523,15 +2530,6 @@ class _AlbumCardState extends State<_AlbumCard>
       begin: 0.0,
       end: 0.02,
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
-    _cachedArtworks = _computeArtworks(widget.album.songs);
-  }
-
-  @override
-  void didUpdateWidget(covariant _AlbumCard oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.album.songs, widget.album.songs)) {
-      _cachedArtworks = _computeArtworks(widget.album.songs);
-    }
   }
 
   @override
@@ -2540,27 +2538,18 @@ class _AlbumCardState extends State<_AlbumCard>
     super.dispose();
   }
 
-  static List<_ArtEntry> _computeArtworks(List<Song> songs) {
-    final seen = <String>{};
-    final result = <_ArtEntry>[];
-    for (final song in songs) {
-      final art = song.albumArt;
-      if (art != null && art.isNotEmpty && seen.add(art)) {
-        result.add(_ArtEntry(art, song.filePath));
-      }
-      if (result.length >= 4) break;
-    }
-    return result;
-  }
-
   @override
   Widget build(BuildContext context) {
     final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
-    final artworks = _cachedArtworks;
-    final padded = List<_ArtEntry>.from(artworks);
-    while (padded.length < 4) {
-      padded.add(const _ArtEntry(null, null));
+    Song? artSong;
+    for (final s in widget.album.songs) {
+      if (s.albumArt != null && s.albumArt!.isNotEmpty) {
+        artSong = s;
+        break;
+      }
     }
+    final artPath = artSong?.albumArt;
+    final sourcePath = artSong?.filePath ?? widget.album.songs.first.filePath;
 
     return GestureDetector(
       onTapDown: (_) => _controller.forward(),
@@ -2623,20 +2612,18 @@ class _AlbumCardState extends State<_AlbumCard>
                               child: Stack(
                                 fit: StackFit.expand,
                                 children: [
-                                  if (artworks.length == 1)
-                                    _buildSingleArt(
-                                      artworks.first,
-                                      artworkTargetWidth,
-                                      context,
-                                    )
-                                  else if (artworks.isEmpty)
-                                    _buildGridPlaceholder(context)
-                                  else
-                                    _buildArtGrid(
-                                      padded,
-                                      artworkTargetWidth,
-                                      context,
-                                    ),
+                                  CachedImageWidget(
+                                    imagePath: artPath,
+                                    audioSourcePath: sourcePath,
+                                    fit: BoxFit.cover,
+                                    useThumbnail: true,
+                                    thumbnailWidth: artworkTargetWidth,
+                                    thumbnailHeight: widget.stretchArtwork
+                                        ? artworkTargetWidth
+                                        : null,
+                                    placeholder: _buildPlaceholder(context),
+                                    errorWidget: _buildPlaceholder(context),
+                                  ),
                                   Positioned.fill(
                                     child: DecoratedBox(
                                       decoration: BoxDecoration(
@@ -2735,64 +2722,12 @@ class _AlbumCardState extends State<_AlbumCard>
     );
   }
 
-  Widget _buildArtGrid(
-    List<_ArtEntry> artworks,
-    int targetWidth,
-    BuildContext context,
-  ) {
-    final cellSize = targetWidth ~/ 2;
-    final cellRadius = AppConstants.radiusSm;
-    return GridView.count(
-      crossAxisCount: 2,
-      physics: const NeverScrollableScrollPhysics(),
-      children: artworks.map((entry) {
-        if (entry.art != null && entry.art!.isNotEmpty) {
-          return ClipRRect(
-            borderRadius: BorderRadius.all(Radius.circular(cellRadius)),
-            child: CachedImageWidget(
-              imagePath: entry.art,
-              audioSourcePath: entry.source,
-              fit: BoxFit.cover,
-              useThumbnail: true,
-              thumbnailWidth: cellSize,
-              thumbnailHeight: cellSize,
-              placeholder: _buildGridPlaceholder(context),
-              errorWidget: _buildGridPlaceholder(context),
-            ),
-          );
-        }
-        return _buildGridPlaceholder(context);
-      }).toList(),
-    );
-  }
-
-  Widget _buildSingleArt(
-    _ArtEntry entry,
-    int targetWidth,
-    BuildContext context,
-  ) {
-    return CachedImageWidget(
-      imagePath: entry.art,
-      audioSourcePath: entry.source,
-      fit: BoxFit.cover,
-      useThumbnail: true,
-      thumbnailWidth: targetWidth,
-      thumbnailHeight: targetWidth,
-      placeholder: _buildGridPlaceholder(context),
-      errorWidget: _buildGridPlaceholder(context),
-    );
-  }
-
-  Widget _buildGridPlaceholder(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.all(Radius.circular(AppConstants.radiusSm)),
-      child: Container(
-        color: AppColors.surfaceLight,
-        child: const Icon(
-          LucideIcons.music,
-          color: AppColors.textTertiary,
-          size: 18,
-        ),
+  Widget _buildPlaceholder(BuildContext context) {
+    return Center(
+      child: Icon(
+        LucideIcons.disc,
+        size: context.responsiveIcon(AppConstants.containerSizeSm),
+        color: context.adaptiveTextTertiary.withValues(alpha: 0.5),
       ),
     );
   }
@@ -2800,9 +2735,14 @@ class _AlbumCardState extends State<_AlbumCard>
 
 class _AlbumListTile extends StatelessWidget {
   final AlbumGroup album;
+  final bool stretchArtwork;
   final VoidCallback onTap;
 
-  const _AlbumListTile({required this.album, required this.onTap});
+  const _AlbumListTile({
+    required this.album,
+    required this.stretchArtwork,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -2862,7 +2802,7 @@ class _AlbumListTile extends StatelessWidget {
                     fit: BoxFit.cover,
                     useThumbnail: true,
                     thumbnailWidth: 104,
-                    thumbnailHeight: 104,
+                    thumbnailHeight: stretchArtwork ? 104 : null,
                     placeholder: const ColoredBox(
                       color: AppColors.surface,
                       child: Icon(
@@ -2932,13 +2872,6 @@ class _AlbumListTile extends StatelessWidget {
       ),
     );
   }
-}
-
-class _ArtEntry {
-  final String? art;
-  final String? source;
-
-  const _ArtEntry(this.art, this.source);
 }
 
 class _AlbumFilterSheet extends StatefulWidget {

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -1869,6 +1869,9 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
     final currentFilter =
         songsAsync.value?.fileTypeFilter ?? SongFileTypeFilter.all;
     final isAlbumMode = currentSort == SongSortOption.album;
+    final buttonGap = context.isCompact
+        ? AppConstants.spacingXxs
+        : AppConstants.spacingSm;
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -1878,27 +1881,29 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Your Library',
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: context.adaptiveTextPrimary,
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Your Library',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: context.adaptiveTextPrimary,
+                  ),
                 ),
-              ),
-              const SizedBox(height: AppConstants.spacingXxs),
-              Text(
-                '$songCount songs',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.adaptiveTextSecondary,
+                const SizedBox(height: AppConstants.spacingXxs),
+                Text(
+                  '$songCount songs',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: context.adaptiveTextSecondary,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
-
           Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
               if (isAlbumMode) ...[
                 _buildHeaderIconButton(
@@ -1908,7 +1913,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
                       : LucideIcons.list,
                   onTap: () => _setAlbumViewMode(!_albumIsListView),
                 ),
-                const SizedBox(width: AppConstants.spacingSm),
+                SizedBox(width: buttonGap),
                 _buildHeaderIconButton(
                   context: context,
                   icon: LucideIcons.listFilter,
@@ -1920,68 +1925,43 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
                   icon: LucideIcons.checkCheck,
                   onTap: () => _enterSelectionMode(null),
                 ),
-              const SizedBox(width: AppConstants.spacingSm),
+              SizedBox(width: buttonGap),
               _buildHeaderIconButton(
                 context: context,
                 icon: LucideIcons.shuffle,
                 onTap: () => _shufflePlayFromLibrary(songsAsync),
               ),
-              const SizedBox(width: AppConstants.spacingSm),
+              SizedBox(width: buttonGap),
               TutorialTargetAnchor(
                 target: TutorialTarget.songsSortButton,
-                child: Container(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topLeft,
-                      end: Alignment.bottomRight,
-                      colors: [
-                        AppColors.surfaceLight.withValues(alpha: 0.75),
-                        AppColors.surface.withValues(alpha: 0.85),
-                      ],
-                    ),
-                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-                    border: Border.all(color: AppColors.glassBorder, width: 1),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.2),
-                        blurRadius: 12,
-                        spreadRadius: 1,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                  ),
-                  child: IconButton(
-                    onPressed: () {
-                      SortFilterBottomSheet.show(
-                        context,
-                        currentSort: currentSort,
-                        currentFilter: currentFilter,
-                        onSortChanged: (option) {
-                          ref
-                              .read(songsProvider.notifier)
-                              .setSortOption(option);
-                          setState(() {
-                            _selectedIndex = 0;
-                            _lastSyncedSong = null;
-                          });
-                        },
-                        onFilterChanged: (filter) {
-                          ref
-                              .read(songsProvider.notifier)
-                              .setFileTypeFilter(filter);
-                          setState(() {
-                            _selectedIndex = 0;
-                            _lastSyncedSong = null;
-                          });
-                        },
-                      );
-                    },
-                    icon: Icon(
-                      Icons.sort_rounded,
-                      color: context.adaptiveTextSecondary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
-                    ),
-                  ),
+                child: _buildHeaderIconButton(
+                  context: context,
+                  icon: Icons.sort_rounded,
+                  onTap: () {
+                    SortFilterBottomSheet.show(
+                      context,
+                      currentSort: currentSort,
+                      currentFilter: currentFilter,
+                      onSortChanged: (option) {
+                        ref
+                            .read(songsProvider.notifier)
+                            .setSortOption(option);
+                        setState(() {
+                          _selectedIndex = 0;
+                          _lastSyncedSong = null;
+                        });
+                      },
+                      onFilterChanged: (filter) {
+                        ref
+                            .read(songsProvider.notifier)
+                            .setFileTypeFilter(filter);
+                        setState(() {
+                          _selectedIndex = 0;
+                          _lastSyncedSong = null;
+                        });
+                      },
+                    );
+                  },
                 ),
               ),
             ],
@@ -2059,6 +2039,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
     required IconData icon,
     required VoidCallback onTap,
   }) {
+    final isCompact = context.isCompact;
     return Container(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -2082,6 +2063,15 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
       ),
       child: IconButton(
         onPressed: onTap,
+        visualDensity: isCompact
+            ? VisualDensity.compact
+            : VisualDensity.standard,
+        constraints: isCompact
+            ? const BoxConstraints(minWidth: 36, minHeight: 36)
+            : const BoxConstraints(minWidth: 44, minHeight: 44),
+        padding: isCompact
+            ? const EdgeInsets.all(4)
+            : const EdgeInsets.all(8),
         icon: Icon(
           icon,
           color: context.adaptiveTextSecondary,

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -44,6 +44,92 @@ class ChangelogSubsection {
 /// automatically surface the entry whose `version` equals `kAppVersion`.
 const List<ChangelogEntry> kChangelogEntries = [
   ChangelogEntry(
+    version: '0.20.4-beta.5',
+    date: '2026-07-03',
+    sections: [
+      ChangelogSection(
+        title: 'Pitch Shifter (SoundTouch)',
+        bullets: [
+          'Real-time pitch shifting via the **SoundTouch** audio processing library, integrated into the DSP chain.',
+          'Lock-free bypass flag — zero-cost when pitch is at 1.0×.',
+          'Pitch shift semitones API with FFI bridge and notifier.',
+          'Pitch control bottom sheet with semitone slider.',
+          'Pitch control option added to the song actions sheet.',
+          'Pitch resets automatically to 1.0× when playback stops.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Android Audio API Preference',
+        bullets: [
+          'Choose your Android audio API: **AAudio** (recommended, Android 8+), **OpenSL ES** (legacy), or **Auto**.',
+          'Preference persisted across sessions with instant apply on change.',
+          'Exposed in UAC2 settings and Rust debug state.',
+          '`AudioApiPreference` enum with FFI getter/setter and Dart bridge.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Blurred Backgrounds Everywhere',
+        bullets: [
+          '`BlurredSongBackground` widget wraps all library screens for a consistent glass look.',
+          'Fade-only route transition keeps the background stable between screens.',
+          'Applied to songs, recently played, recently added, queue, favorites, playlists, folders, artists, and albums.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Orbit Customization',
+        bullets: [
+          'Dedicated orbital settings screen — tune geometry, sizing, depth, art resolution, and visual toggles.',
+          'Orbit parameters live in `AppPreferences` with setters and reset.',
+          '`SongCard` sizing is now fully configurable.',
+          'Orbit config passed into `OrbitView` as widget fields; unused constants removed.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Album Artwork Stretch',
+        bullets: [
+          'Album artwork can now stretch to fill the card — toggle from Library settings.',
+          'Single-image album display with stretch support.',
+          '`albumsStretchArtwork` preference.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Lyrics Performance',
+        bullets: [
+          'In-memory cache with timeout reduces redundant API calls on repeated lyrics searches.',
+          'Shared HTTP client prevents connection pool exhaustion.',
+          'Exact and fuzzy lyrics searches now run in parallel — first match wins.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Streaks & Preference Controls',
+        bullets: [
+          'Streaks can be disabled entirely with a reset option — clears all streak data.',
+          'Day streak milestone hidden when streaks are disabled.',
+          '"More from Artist" and "More Artists" sections on album detail screens can be toggled independently.',
+          'Display preferences added to artist sort sheet.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Artwork Reliability',
+        bullets: [
+          'Only cache confirmed-existing artwork paths — prevents phantom thumbnails.',
+          'Prefer songs with embedded album art for source path fallback.',
+          'Artwork source path picks the song whose art matches the album art.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'UI Polish & Fixes',
+        bullets: [
+          'Engine selector refactored to use glass bottom sheet with hero gradient styling.',
+          'Songs screen header now responsive with `Flexible` labels.',
+          'Drag near screen edge no longer accidentally triggers song navigation.',
+          'Sort sheet dismiss margin fixed; redundant `Navigator.pop` calls removed.',
+          'Docs: audio preload scan plan, scan details revamp, audio analysis feature requests.',
+        ],
+      ),
+    ],
+  ),
+  ChangelogEntry(
     version: '0.20.3-beta.4',
     date: '2026-06-30',
     sections: [

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -397,6 +397,12 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
         .setReplaceAlbumWithBitPerfectCapsule(value);
   }
 
+  Future<void> setAlbumsStretchArtwork(bool value) async {
+    if (state.albumsStretchArtwork == value) return;
+    state = state.copyWith(albumsStretchArtwork: value);
+    await ref.read(appPreferencesServiceProvider).setAlbumsStretchArtwork(value);
+  }
+
   Future<void> setFolderGridPageSize(int value) async {
     if (state.folderGridPageSize == value) return;
     state = state.copyWith(folderGridPageSize: value);

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -625,6 +625,24 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setOrbitShowGlow(value);
   }
 
+  Future<void> setStreaksEnabled(bool value) async {
+    if (state.streaksEnabled == value) return;
+    state = state.copyWith(streaksEnabled: value);
+    await ref.read(appPreferencesServiceProvider).setStreaksEnabled(value);
+  }
+
+  Future<void> setShowMoreFromArtist(bool value) async {
+    if (state.showMoreFromArtist == value) return;
+    state = state.copyWith(showMoreFromArtist: value);
+    await ref.read(appPreferencesServiceProvider).setShowMoreFromArtist(value);
+  }
+
+  Future<void> setShowMoreArtists(bool value) async {
+    if (state.showMoreArtists == value) return;
+    state = state.copyWith(showMoreArtists: value);
+    await ref.read(appPreferencesServiceProvider).setShowMoreArtists(value);
+  }
+
   Future<void> resetOrbitSettings() async {
     state = state.copyWith(
       orbitRadiusRatio: 1.0,

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -87,6 +87,9 @@ class AppPreferences {
   final double orbitArtResolutionMultiplier;
   final bool orbitShowPath;
   final bool orbitShowGlow;
+  final bool streaksEnabled;
+  final bool showMoreFromArtist;
+  final bool showMoreArtists;
 
   const AppPreferences({
     this.animationsEnabled = true,
@@ -175,6 +178,9 @@ class AppPreferences {
     this.orbitArtResolutionMultiplier = 2.0,
     this.orbitShowPath = true,
     this.orbitShowGlow = true,
+    this.streaksEnabled = true,
+    this.showMoreFromArtist = true,
+    this.showMoreArtists = true,
   });
 
   AppPreferences copyWith({
@@ -264,6 +270,9 @@ class AppPreferences {
     double? orbitArtResolutionMultiplier,
     bool? orbitShowPath,
     bool? orbitShowGlow,
+    bool? streaksEnabled,
+    bool? showMoreFromArtist,
+    bool? showMoreArtists,
   }) {
     return AppPreferences(
       animationsEnabled: animationsEnabled ?? this.animationsEnabled,
@@ -388,6 +397,9 @@ class AppPreferences {
           orbitArtResolutionMultiplier ?? this.orbitArtResolutionMultiplier,
       orbitShowPath: orbitShowPath ?? this.orbitShowPath,
       orbitShowGlow: orbitShowGlow ?? this.orbitShowGlow,
+      streaksEnabled: streaksEnabled ?? this.streaksEnabled,
+      showMoreFromArtist: showMoreFromArtist ?? this.showMoreFromArtist,
+      showMoreArtists: showMoreArtists ?? this.showMoreArtists,
     );
   }
 }
@@ -485,6 +497,9 @@ class AppPreferencesService {
       'orbit_art_resolution_multiplier';
   static const _orbitShowPathKey = 'orbit_show_path';
   static const _orbitShowGlowKey = 'orbit_show_glow';
+  static const _streaksEnabledKey = 'streaks_enabled';
+  static const _showMoreFromArtistKey = 'album_show_more_from_artist';
+  static const _showMoreArtistsKey = 'album_show_more_artists';
   static const _shuffleModeKey = 'playback_shuffle_mode';
   static const _loopModeKey = 'playback_loop_mode';
   static const _advanceListOrderKey = 'playback_advance_list_order';
@@ -612,6 +627,9 @@ class AppPreferencesService {
           prefs.getDouble(_orbitArtResolutionMultiplierKey) ?? 2.0,
       orbitShowPath: prefs.getBool(_orbitShowPathKey) ?? true,
       orbitShowGlow: prefs.getBool(_orbitShowGlowKey) ?? true,
+      streaksEnabled: prefs.getBool(_streaksEnabledKey) ?? true,
+      showMoreFromArtist: prefs.getBool(_showMoreFromArtistKey) ?? true,
+      showMoreArtists: prefs.getBool(_showMoreArtistsKey) ?? true,
     );
   }
 
@@ -1407,6 +1425,36 @@ class AppPreferencesService {
   Future<void> setOrbitShowGlow(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_orbitShowGlowKey, value);
+  }
+
+  Future<bool> getStreaksEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_streaksEnabledKey) ?? true;
+  }
+
+  Future<void> setStreaksEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_streaksEnabledKey, value);
+  }
+
+  Future<bool> getShowMoreFromArtist() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_showMoreFromArtistKey) ?? true;
+  }
+
+  Future<void> setShowMoreFromArtist(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showMoreFromArtistKey, value);
+  }
+
+  Future<bool> getShowMoreArtists() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_showMoreArtistsKey) ?? true;
+  }
+
+  Future<void> setShowMoreArtists(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showMoreArtistsKey, value);
   }
 
   Future<void> clearOrbitSettings() async {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -53,6 +53,7 @@ class AppPreferences {
   final bool glanceCardHidden;
   final bool glanceCardMinimized;
   final bool replaceAlbumWithBitPerfectCapsule;
+  final bool albumsStretchArtwork;
   final int folderGridPageSize;
   final String? lastSeenChangelogVersion;
   final bool bottomBarAutoCollapseEnabled;
@@ -140,6 +141,7 @@ class AppPreferences {
     this.glanceCardHidden = false,
     this.glanceCardMinimized = false,
     this.replaceAlbumWithBitPerfectCapsule = false,
+    this.albumsStretchArtwork = false,
     this.folderGridPageSize = 8,
     this.lastSeenChangelogVersion,
     this.bottomBarAutoCollapseEnabled = false,
@@ -228,6 +230,7 @@ class AppPreferences {
     bool? glanceCardHidden,
     bool? glanceCardMinimized,
     bool? replaceAlbumWithBitPerfectCapsule,
+    bool? albumsStretchArtwork,
     int? folderGridPageSize,
     String? lastSeenChangelogVersion,
     bool? bottomBarAutoCollapseEnabled,
@@ -335,6 +338,8 @@ class AppPreferences {
       replaceAlbumWithBitPerfectCapsule:
           replaceAlbumWithBitPerfectCapsule ??
           this.replaceAlbumWithBitPerfectCapsule,
+      albumsStretchArtwork:
+          albumsStretchArtwork ?? this.albumsStretchArtwork,
       folderGridPageSize: folderGridPageSize ?? this.folderGridPageSize,
       lastSeenChangelogVersion:
           lastSeenChangelogVersion ?? this.lastSeenChangelogVersion,
@@ -441,6 +446,7 @@ class AppPreferencesService {
   static const _glanceCardMinimizedKey = 'glance_card_minimized';
   static const _replaceAlbumWithBitPerfectCapsuleKey =
       'replace_album_with_bit_perfect_capsule';
+  static const _albumsStretchArtworkKey = 'albums_stretch_artwork';
   static const _folderGridPageSizeKey = 'folder_grid_page_size';
   static const _lastSeenChangelogVersionKey = 'last_seen_changelog_version';
   static const _bottomBarAutoCollapseEnabledKey =
@@ -558,6 +564,8 @@ class AppPreferencesService {
       glanceCardMinimized: prefs.getBool(_glanceCardMinimizedKey) ?? false,
       replaceAlbumWithBitPerfectCapsule:
           prefs.getBool(_replaceAlbumWithBitPerfectCapsuleKey) ?? false,
+      albumsStretchArtwork:
+          prefs.getBool(_albumsStretchArtworkKey) ?? false,
       folderGridPageSize: prefs.getInt(_folderGridPageSizeKey) ?? 8,
       lastSeenChangelogVersion: prefs.getString(_lastSeenChangelogVersionKey),
       bottomBarAutoCollapseEnabled:
@@ -1075,6 +1083,16 @@ class AppPreferencesService {
   Future<void> setReplaceAlbumWithBitPerfectCapsule(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_replaceAlbumWithBitPerfectCapsuleKey, value);
+  }
+
+  Future<bool> getAlbumsStretchArtwork() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_albumsStretchArtworkKey) ?? false;
+  }
+
+  Future<void> setAlbumsStretchArtwork(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_albumsStretchArtworkKey, value);
   }
 
   Future<int> getFolderGridPageSize() async {

--- a/lib/services/milestone_service.dart
+++ b/lib/services/milestone_service.dart
@@ -404,6 +404,19 @@ class MilestoneService {
     await prefs.setInt(_streakPopupSnoozedUntilKey, _dayKey(DateTime.now()));
   }
 
+  /// Clears all streak-related state: counter, last-active day, popup snooze,
+  /// and any shown streak milestones. Used when the user disables streaks.
+  Future<void> clearStreakData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_streakCurrentKey);
+    await prefs.remove(_streakLastActiveDayKey);
+    await prefs.remove(_streakPopupSnoozedUntilKey);
+    final shown = await getShownMilestones();
+    final filtered = shown.where((r) => r.type.category != MilestoneCategory.dayStreak).toList();
+    final raw = jsonEncode(filtered.map((r) => r.toJson()).toList());
+    await prefs.setString(_shownMilestonesKey, raw);
+  }
+
   Future<List<MilestoneRecord>> getShownMilestones() async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_shownMilestonesKey);

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -4628,6 +4628,11 @@ class PlayerService {
       );
       if (_usingRustBackend) {
         await _rustAudioService.setPitchShiftSemitones(0.0);
+      } else {
+        final player = _justAudioPlayer;
+        if (player != null) {
+          await player.setPitch(1.0);
+        }
       }
       return;
     }
@@ -4635,7 +4640,12 @@ class PlayerService {
     if (_usingRustBackend) {
       await _rustAudioService.setPitchShiftSemitones(clamped);
     } else {
-      debugPrint('[PITCH] NOT routed: not using Rust backend (just_audio has no pitch support)');
+      final player = _justAudioPlayer;
+      if (player != null) {
+        // ponytail: just_audio setPitch takes a frequency ratio (1.0 = no shift).
+        final ratio = math.pow(2, clamped / 12).toDouble();
+        await player.setPitch(ratio);
+      }
     }
   }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2123,6 +2123,7 @@ class PlayerService {
   /// streak tier. Called once at startup after the milestone notifier is
   /// wired so the celebration dialog can still fire.
   Future<void> recordActivityDayAndCheckMilestones() async {
+    if (!await _appPreferencesService.getStreaksEnabled()) return;
     final streak = await _milestoneService.recordActivityDay();
     final milestone = await _milestoneService.checkMilestones();
     if (milestone != null) {

--- a/lib/widgets/common/cached_image_widget.dart
+++ b/lib/widgets/common/cached_image_widget.dart
@@ -100,7 +100,11 @@ void pauseArtworkExtraction(bool paused) {
 }
 
 class _CachedImageWidgetState extends State<CachedImageWidget> {
-  static final Map<String, bool> _pathExistsCache = {};
+  // ponytail: cache only confirmed-existing paths to keep fast-scroll stat()
+  // O(1). Misses are NOT cached so async extraction can populate the path
+  // later — caching false would permanently hide art whose file appears
+  // after the first check.
+  static final Set<String> _knownExistingPaths = {};
 
   String? _resolvedImagePath;
   bool _hasPendingResolve = false;
@@ -209,14 +213,16 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
       return path;
     }
 
-    // ponytail: memoize stat() so repeated existence checks during fast scroll
-    // stay O(1); first encounter per path still does one disk hit. Stale entries
-    // are safe — Image.file's errorBuilder handles a since-deleted file.
-    final exists = _pathExistsCache.putIfAbsent(
-      path,
-      () => File(path).existsSync(),
-    );
-    return exists ? path : null;
+    if (_knownExistingPaths.contains(path)) {
+      return path;
+    }
+
+    if (File(path).existsSync()) {
+      _knownExistingPaths.add(path);
+      return path;
+    }
+
+    return null;
   }
 
   Widget _buildFileImage(String imagePath) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.20.3-beta.4+21
+version: 0.20.4-beta.5+21
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
# Summary

- Add album artwork stretch preference with single-image refactor and library settings toggle
- Add streak enable/disable, clear, and reset preferences with conditional milestone hiding
- Add "More from Artist" and "More Artists" section toggles to album detail settings
- Add display preferences to artist sort sheet
- Refactor songs screen header for responsive layout and spacing
- Only cache confirmed-existing paths in artwork lookup for performance
- Remove redundant `Navigator.pop` calls and avoid song navigation on edge drag
- Reset pitch to 1.0 when stopping in non-Rust backend
- Prepare `0.20.4-beta.5` pre-release

# Changes

## Album Artwork

- Add `albumsStretchArtwork` preference with provider/service
- Add album artwork stretch setting to library settings screen
- Refactor album artwork to single image with stretch support
- Prefer song with embedded album art for artwork source path fallback

## Streak System

- Add streak and album preferences fields to app preferences service
- Add mutators for streak and show-more preferences
- Add streak settings and reset option to interface screen
- Clear streak data when user disables streaks
- Conditionally hide day streak milestone when streaks are disabled

## Album Detail

- Add album detail settings section for "More from Artist" and "More Artists" toggles (29 lines)
- Conditionally hide sections based on display preferences
- Pick artwork source path matching song with album art

## Artist Sort

- Add display preferences to artist sort sheet (81 lines rewritten)

## UI

- Refactor songs screen header for responsive layout and spacing (136 lines changed)
- Wrap label text in `Flexible` to prevent overflow

## Performance

- Only cache confirmed-existing paths in artwork lookup

## Navigation

- Remove redundant `Navigator.pop` calls before `onSelected` across folders and artists screens
- Avoid song navigation when drag starts near screen edge in full player screen

## Pitch Fix

- Reset pitch to 1.0 when stopping in non-Rust backend

## Release & Docs

- Prepare `0.20.4-beta.5` pre-release with changelog and release notes
- Add audio preload scan plan and scan details revamp plan docs

## Files Changed

- `pubspec.yaml`
- `lib/core/constants/app_constants.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/player_service.dart`
- `lib/services/milestone_service.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/features/albums/screens/album_detail_screen.dart`
- `lib/features/artists/screens/artists_screen.dart`
- `lib/features/folders/screens/folders_screen.dart`
- `lib/features/songs/screens/songs_screen.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/settings/screens/interface_settings_screen.dart`
- `lib/features/settings/screens/ui_customization_settings_screen.dart`
- `lib/features/settings/screens/library_settings_screen.dart`
- `lib/features/milestone/screens/milestones_screen.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/widgets/common/cached_image_widget.dart`
- `lib/features/whats_new/data/changelog_data.dart`
- `CHANGELOG.md`
- `docs/RELEASE_0.20.4-beta.5.md`
- `docs/AUDIO_PRELOAD_SCAN_PLAN.md`
- `docs/SCAN_DETAILS_REVAMP_PLAN.md`