### PR TITLE
Add Apple Music-style animated album art, USB DAC disconnect handling, and engine restart notice

### DIFF
--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -15,6 +15,8 @@ import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
+import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
 import 'package:flick/providers/navigation_provider.dart';
 import 'package:flick/providers/app_preferences_provider.dart';
 
@@ -560,31 +562,43 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
     );
   }
 
+  Widget _buildArtLayer(BuildContext context) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final animated = prefs.animatedAlbumArt && prefs.animationsEnabled;
+    final fallback = Container(
+      color: AppColors.surface,
+      child: Icon(
+        LucideIcons.disc,
+        size: 80,
+        color: context.adaptiveTextTertiary,
+      ),
+    );
+    if (!animated) {
+      return CachedImageWidget(
+        imagePath: widget.albumArt,
+        audioSourcePath: widget.albumArtSourcePath,
+        fit: BoxFit.cover,
+        placeholder: fallback,
+        errorWidget: fallback,
+      );
+    }
+    return ScrollFadeWrapper(
+      scrollController: _scrollController,
+      child: AnimatedAlbumArt(
+        imagePath: widget.albumArt,
+        audioSourcePath: widget.albumArtSourcePath,
+        dominantColor: _albumColor,
+        placeholder: fallback,
+        errorWidget: fallback,
+      ),
+    );
+  }
+
   Widget _buildAppBarBackground(BuildContext context, Color fadeTo) {
     return Stack(
       fit: StackFit.expand,
       children: [
-        CachedImageWidget(
-          imagePath: widget.albumArt,
-          audioSourcePath: widget.albumArtSourcePath,
-          fit: BoxFit.cover,
-          placeholder: Container(
-            color: AppColors.surface,
-            child: Icon(
-              LucideIcons.disc,
-              size: 80,
-              color: context.adaptiveTextTertiary,
-            ),
-          ),
-          errorWidget: Container(
-            color: AppColors.surface,
-            child: Icon(
-              LucideIcons.disc,
-              size: 80,
-              color: context.adaptiveTextTertiary,
-            ),
-          ),
-        ),
+        _buildArtLayer(context),
         Container(
           decoration: BoxDecoration(
             gradient: LinearGradient(

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -17,8 +17,11 @@ import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
+import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
 
 /// Artist detail screen showing songs, albums, and most played tracks.
 class ArtistDetailScreen extends ConsumerStatefulWidget {
@@ -604,6 +607,38 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     );
   }
 
+  Widget _buildArtLayer(BuildContext context) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final animated = prefs.animatedAlbumArt && prefs.animationsEnabled;
+    final fallback = Container(
+      color: AppColors.surface,
+      child: Icon(
+        LucideIcons.user,
+        size: 80,
+        color: context.adaptiveTextTertiary,
+      ),
+    );
+    if (!animated) {
+      return CachedImageWidget(
+        imagePath: _artistArt,
+        audioSourcePath: _artistArtSourcePath,
+        fit: BoxFit.cover,
+        placeholder: fallback,
+        errorWidget: fallback,
+      );
+    }
+    return ScrollFadeWrapper(
+      scrollController: _scrollController,
+      child: AnimatedAlbumArt(
+        imagePath: _artistArt,
+        audioSourcePath: _artistArtSourcePath,
+        dominantColor: _artistColor,
+        placeholder: fallback,
+        errorWidget: fallback,
+      ),
+    );
+  }
+
   Widget _buildAppBarBackground(
     BuildContext context,
     Color fadeTo,
@@ -612,27 +647,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     return Stack(
       fit: StackFit.expand,
       children: [
-        CachedImageWidget(
-          imagePath: _artistArt,
-          audioSourcePath: _artistArtSourcePath,
-          fit: BoxFit.cover,
-          placeholder: Container(
-            color: AppColors.surface,
-            child: Icon(
-              LucideIcons.user,
-              size: 80,
-              color: context.adaptiveTextTertiary,
-            ),
-          ),
-          errorWidget: Container(
-            color: AppColors.surface,
-            child: Icon(
-              LucideIcons.user,
-              size: 80,
-              color: context.adaptiveTextTertiary,
-            ),
-          ),
-        ),
+        _buildArtLayer(context),
         Container(
           decoration: BoxDecoration(
             gradient: LinearGradient(

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -17,7 +17,6 @@ import 'package:flick/features/artists/screens/artist_detail_screen.dart';
 import 'package:flick/features/artists/screens/artists_screen.dart';
 import 'package:flick/features/favorites/screens/favorites_screen.dart';
 import 'package:flick/features/folders/screens/folders_screen.dart';
-import 'package:flick/features/menu/screens/restarting_screen.dart';
 import 'package:flick/features/playlists/screens/playlist_detail_screen.dart';
 import 'package:flick/features/playlists/screens/playlists_screen.dart';
 import 'package:flick/features/queue/screens/queue_screen.dart';
@@ -33,6 +32,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/engine_restart_notice.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
 
 /// Music-home menu screen inspired by streaming app landing pages.
@@ -47,7 +47,7 @@ class MenuScreen extends ConsumerStatefulWidget {
 }
 
 class _MenuScreenState extends ConsumerState<MenuScreen>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   final RecentlyPlayedRepository _recentlyPlayedRepository =
       RecentlyPlayedRepository();
   final PlayerService _playerService = PlayerService();
@@ -63,6 +63,9 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   late final AnimationController _welcomeCardController;
   late final Animation<double> _welcomeCardFade;
   late final Animation<Offset> _welcomeCardSlide;
+  late final AnimationController _updateNoticeController;
+  late final Animation<double> _updateNoticeFade;
+  late final Animation<Offset> _updateNoticeSlide;
 
   @override
   void initState() {
@@ -85,6 +88,24 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
       ),
     );
     _welcomeCardController.forward();
+    _updateNoticeController = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
+    _updateNoticeFade = CurvedAnimation(
+      parent: _updateNoticeController,
+      curve: Curves.easeOutCubic,
+    );
+    _updateNoticeSlide = Tween<Offset>(
+      begin: const Offset(0, -0.15),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _updateNoticeController,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+    _updateNoticeController.forward();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadHistoryData();
       _watchHistory();
@@ -94,6 +115,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   @override
   void dispose() {
     _welcomeCardController.dispose();
+    _updateNoticeController.dispose();
     _historySubscription?.cancel();
     super.dispose();
   }
@@ -436,87 +458,6 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
     );
   }
 
-  Widget _buildRestartNotice(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(AppConstants.spacingMd),
-      decoration: BoxDecoration(
-        color: AppColors.accent.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppColors.accent.withValues(alpha: 0.30)),
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.16),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Icon(
-              LucideIcons.refreshCcw,
-              color: context.adaptiveTextPrimary,
-              size: 17,
-            ),
-          ),
-          const SizedBox(width: AppConstants.spacingMd),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Restart required',
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    color: context.adaptiveTextPrimary,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: AppConstants.spacingXxs),
-                Text(
-                  'Your new audio engine is ready. Restart Flick to apply it.',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.adaptiveTextSecondary,
-                    height: 1.35,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(width: AppConstants.spacingSm),
-          FilledButton(
-            onPressed: _showRestartingScreen,
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.accent,
-              foregroundColor: AppColors.background,
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingMd,
-                vertical: AppConstants.spacingSm,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-            child: const Text('Restart'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showRestartingScreen() {
-    Navigator.of(context).push(
-      PageRouteBuilder(
-        opaque: true,
-        transitionDuration: const Duration(milliseconds: 300),
-        reverseTransitionDuration: Duration.zero,
-        pageBuilder: (_, _, _) => const RestartingScreen(),
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return FadeTransition(opacity: animation, child: child);
-        },
-      ),
-    );
-  }
-
   Future<void> _showEnginePickerSheet(
     BuildContext context,
     AudioEnginePreference current,
@@ -783,7 +724,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                               AppConstants.spacingLg,
                               AppConstants.spacingMd,
                             ),
-                            child: _buildRestartNotice(context),
+                            child: const EngineRestartNotice(),
                           ),
                         ),
                       ),
@@ -793,14 +734,20 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                           duration: AppConstants.animationNormal,
                           curve: Curves.easeInOut,
                           alignment: Alignment.topCenter,
-                          child: Padding(
-                            padding: const EdgeInsets.fromLTRB(
-                              AppConstants.spacingLg,
-                              0,
-                              AppConstants.spacingLg,
-                              AppConstants.spacingLg,
+                          child: FadeTransition(
+                            opacity: _updateNoticeFade,
+                            child: SlideTransition(
+                              position: _updateNoticeSlide,
+                              child: Padding(
+                                padding: const EdgeInsets.fromLTRB(
+                                  AppConstants.spacingLg,
+                                  0,
+                                  AppConstants.spacingLg,
+                                  AppConstants.spacingMd,
+                                ),
+                                child: _buildUpdateNotice(context),
+                              ),
                             ),
-                            child: _buildUpdateNotice(context),
                           ),
                         ),
                       ),
@@ -1209,103 +1156,103 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
 
   Widget _buildUpdateNotice(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(AppConstants.spacingLg),
-      decoration: BoxDecoration(
-        color: AppColors.surface.withValues(alpha: 0.72),
-        borderRadius: BorderRadius.circular(28),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.18),
-            blurRadius: 22,
-            offset: const Offset(0, 14),
-          ),
-        ],
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingMd,
+        vertical: AppConstants.spacingSm,
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      decoration: BoxDecoration(
+        // ponytail: fixed warm amber gradient to signal "update" without alarm.
+        // Independent of album art. Change hue here if branding shifts.
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF3A2A14), Color(0xFF1F160A)],
+        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+      ),
+      child: Row(
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                width: 44,
-                height: 44,
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(14),
-                ),
-                child: const Icon(
-                  LucideIcons.badgeAlert,
-                  color: Colors.white,
-                  size: 20,
-                ),
-              ),
-              const SizedBox(width: AppConstants.spacingMd),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Update Available',
-                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        color: Colors.white,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const SizedBox(height: AppConstants.spacingXxs),
-                    Text(
-                      'A newer Flick build is live on the Play Store.',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Colors.white.withValues(alpha: 0.82),
-                        height: 1.45,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              IconButton(
-                onPressed: () {
-                  setState(() => _showUpdateNotice = false);
-                  ScaffoldMessenger.of(context)
-                    ..removeCurrentSnackBar()
-                    ..showSnackBar(
-                      SnackBar(
-                        content: const Text(
-                          'Update notice hidden.',
-                        ),
-                        behavior: SnackBarBehavior.floating,
-                        duration: const Duration(seconds: 4),
-                        action: SnackBarAction(
-                          label: 'Undo',
-                          onPressed: () =>
-                              setState(() => _showUpdateNotice = true),
-                        ),
-                      ),
-                    );
-                },
-                icon: const Icon(
-                  LucideIcons.x,
-                  size: 18,
-                  color: Colors.white70,
-                ),
-                visualDensity: VisualDensity.compact,
-              ),
-            ],
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Icon(
+              LucideIcons.badgeAlert,
+              color: Colors.white,
+              size: 16,
+            ),
           ),
-          const SizedBox(height: AppConstants.spacingMd),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Update Available',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingXxs),
+                Text(
+                  'A newer Flick build is on the Play Store.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.8),
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
           FilledButton.icon(
             onPressed: _openPlayStoreListing,
-            icon: const Icon(LucideIcons.externalLink, size: 18),
+            icon: const Icon(LucideIcons.externalLink, size: 14),
             label: const Text('Update'),
             style: FilledButton.styleFrom(
               backgroundColor: Colors.white,
               foregroundColor: const Color(0xFF0F1720),
+              visualDensity: VisualDensity.compact,
               padding: const EdgeInsets.symmetric(
-                horizontal: AppConstants.spacingLg,
-                vertical: AppConstants.spacingMd,
+                horizontal: AppConstants.spacingMd,
+                vertical: AppConstants.spacingXs,
               ),
+              textStyle: Theme.of(
+                context,
+              ).textTheme.labelLarge?.copyWith(fontSize: 13),
             ),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() => _showUpdateNotice = false);
+              ScaffoldMessenger.of(context)
+                ..removeCurrentSnackBar()
+                ..showSnackBar(
+                  SnackBar(
+                    content: const Text(
+                      'Update notice hidden.',
+                    ),
+                    behavior: SnackBarBehavior.floating,
+                    duration: const Duration(seconds: 4),
+                    action: SnackBarAction(
+                      label: 'Undo',
+                      onPressed: () =>
+                          setState(() => _showUpdateNotice = true),
+                    ),
+                  ),
+                );
+            },
+            icon: const Icon(
+              LucideIcons.x,
+              size: 18,
+              color: Colors.white70,
+            ),
+            visualDensity: VisualDensity.compact,
           ),
         ],
       ),

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -17,6 +17,7 @@ import 'package:flick/features/artists/screens/artist_detail_screen.dart';
 import 'package:flick/features/artists/screens/artists_screen.dart';
 import 'package:flick/features/favorites/screens/favorites_screen.dart';
 import 'package:flick/features/folders/screens/folders_screen.dart';
+import 'package:flick/features/menu/screens/restarting_screen.dart';
 import 'package:flick/features/playlists/screens/playlist_detail_screen.dart';
 import 'package:flick/features/playlists/screens/playlists_screen.dart';
 import 'package:flick/features/queue/screens/queue_screen.dart';
@@ -56,6 +57,7 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
   Map<ListeningRecapPeriod, ListeningRecap> _recaps = const {};
   bool _isHistoryLoading = true;
   bool _showUpdateNotice = true;
+  bool _pendingEngineRestart = false;
   Color? _heroDominantColor;
   String? _heroColorArtPath;
   late final AnimationController _welcomeCardController;
@@ -434,6 +436,87 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
     );
   }
 
+  Widget _buildRestartNotice(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: AppColors.accent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.30)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.16),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              LucideIcons.refreshCcw,
+              color: context.adaptiveTextPrimary,
+              size: 17,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Restart required',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingXxs),
+                Text(
+                  'Your new audio engine is ready. Restart Flick to apply it.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextSecondary,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          FilledButton(
+            onPressed: _showRestartingScreen,
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.accent,
+              foregroundColor: AppColors.background,
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppConstants.spacingMd,
+                vertical: AppConstants.spacingSm,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: const Text('Restart'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showRestartingScreen() {
+    Navigator.of(context).push(
+      PageRouteBuilder(
+        opaque: true,
+        transitionDuration: const Duration(milliseconds: 300),
+        reverseTransitionDuration: Duration.zero,
+        pageBuilder: (_, _, _) => const RestartingScreen(),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          return FadeTransition(opacity: animation, child: child);
+        },
+      ),
+    );
+  }
+
   Future<void> _showEnginePickerSheet(
     BuildContext context,
     AudioEnginePreference current,
@@ -602,15 +685,8 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
 
     if (dialogContext.mounted) Navigator.of(dialogContext).pop();
 
-    if (context.mounted) {
-      final messenger = ScaffoldMessenger.of(context);
-      messenger.removeCurrentSnackBar();
-      messenger.showSnackBar(
-        const SnackBar(
-          content: Text('Restart the app to apply playback changes.'),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+    if (mounted) {
+      setState(() => _pendingEngineRestart = true);
     }
   }
 
@@ -691,6 +767,24 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                                       ),
                                     )
                                   : const SizedBox.shrink(),
+                        ),
+                      ),
+                    if (_pendingEngineRestart &&
+                        appPreferences.showEngineSelector)
+                      SliverToBoxAdapter(
+                        child: AnimatedSize(
+                          duration: AppConstants.animationNormal,
+                          curve: Curves.easeInOut,
+                          alignment: Alignment.topCenter,
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(
+                              AppConstants.spacingLg,
+                              0,
+                              AppConstants.spacingLg,
+                              AppConstants.spacingMd,
+                            ),
+                            child: _buildRestartNotice(context),
+                          ),
                         ),
                       ),
                     if (updateState.updateAvailable && _showUpdateNotice)

--- a/lib/features/menu/screens/restarting_screen.dart
+++ b/lib/features/menu/screens/restarting_screen.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:restart_app/restart_app.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/services/player_service.dart';
+
+const _restartMessages = <String>[
+  'Applying new audio engine…',
+  'Reinitializing playback…',
+  'Finishing up…',
+];
+
+/// Full-screen overlay shown while Flick restarts to apply a new audio engine.
+///
+/// Uses [Restart.restartApp] which schedules an AlarmManager relaunch and
+/// then kills the process — the only way to truly restart on Android.
+class RestartingScreen extends StatefulWidget {
+  const RestartingScreen({super.key});
+
+  @override
+  State<RestartingScreen> createState() => _RestartingScreenState();
+}
+
+class _RestartingScreenState extends State<RestartingScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _fadeController;
+  late final Animation<double> _fade;
+  late final Timer _exitTimer;
+  late final Timer _messageTimer;
+  int _messageIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _fadeController = AnimationController(
+      duration: const Duration(milliseconds: 350),
+      vsync: this,
+    )..forward();
+    _fade = CurvedAnimation(
+      parent: _fadeController,
+      curve: Curves.easeOutCubic,
+    );
+    _messageTimer = Timer.periodic(const Duration(milliseconds: 850), (_) {
+      if (!mounted) return;
+      setState(() {
+        _messageIndex = (_messageIndex + 1) % _restartMessages.length;
+      });
+    });
+    _exitTimer = Timer(const Duration(milliseconds: 2700), () async {
+      // Silence playback now, then hard-kill the process. The default
+      // platformDefault mode only calls finishAffinity(), which leaves the
+      // foreground audio service + native engine alive (song keeps playing and
+      // a second instance opens). forceKill runs Runtime.exit(0) — a real
+      // process kill, so the relaunch starts a single fresh instance.
+      unawaited(PlayerService().pause());
+      await Restart.restartApp(forceKill: true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _messageTimer.cancel();
+    _exitTimer.cancel();
+    _fadeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: AppColors.background,
+        body: SafeArea(
+          child: FadeTransition(
+            opacity: _fade,
+            child: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  SizedBox(
+                    width: 84,
+                    height: 84,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        const SizedBox(
+                          width: 84,
+                          height: 84,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.6,
+                            color: AppColors.accent,
+                          ),
+                        ),
+                        Icon(
+                          LucideIcons.refreshCcw,
+                          color: AppColors.accent,
+                          size: 30,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: AppConstants.spacingLg),
+                  Text(
+                    'Restarting Flick',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: AppConstants.spacingXs),
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    child: Text(
+                      _restartMessages[_messageIndex],
+                      key: ValueKey(_messageIndex),
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Colors.white.withValues(alpha: 0.7),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -19,7 +19,10 @@ import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/providers/playlist_provider.dart';
 import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
+import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
 
 class PlaylistDetailScreen extends ConsumerStatefulWidget {
   final Playlist playlist;
@@ -629,40 +632,41 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
   }
 
   Widget _buildCollageBackground() {
+    final fallback = Container(
+      color: AppColors.surface,
+      child: Icon(
+        LucideIcons.listMusic,
+        size: 80,
+        color: context.adaptiveTextTertiary,
+      ),
+    );
     if (_songs.isEmpty) {
-      return Container(
-        color: AppColors.surface,
-        child: Icon(
-          LucideIcons.listMusic,
-          size: 80,
-          color: context.adaptiveTextTertiary,
-        ),
-      );
+      return fallback;
     }
 
     final firstArt = _getArt(_songs);
     final firstSource = _getSourcePath(_songs);
     if (firstArt != null) {
+      final prefs = ref.watch(appPreferencesProvider);
+      final animated = prefs.animatedAlbumArt && prefs.animationsEnabled;
+      if (animated) {
+        return ScrollFadeWrapper(
+          scrollController: _scrollController,
+          child: AnimatedAlbumArt(
+            imagePath: firstArt,
+            audioSourcePath: firstSource,
+            dominantColor: _playlistColor,
+            placeholder: fallback,
+            errorWidget: fallback,
+          ),
+        );
+      }
       return CachedImageWidget(
         imagePath: firstArt,
         audioSourcePath: firstSource,
         fit: BoxFit.cover,
-        placeholder: Container(
-          color: AppColors.surface,
-          child: Icon(
-            LucideIcons.listMusic,
-            size: 80,
-            color: context.adaptiveTextTertiary,
-          ),
-        ),
-        errorWidget: Container(
-          color: AppColors.surface,
-          child: Icon(
-            LucideIcons.listMusic,
-            size: 80,
-            color: context.adaptiveTextTertiary,
-          ),
-        ),
+        placeholder: fallback,
+        errorWidget: fallback,
       );
     }
 

--- a/lib/features/settings/screens/bluetooth_settings_screen.dart
+++ b/lib/features/settings/screens/bluetooth_settings_screen.dart
@@ -266,6 +266,17 @@ class _BluetoothSettingsScreenState
                     .read(appPreferencesProvider.notifier)
                     .setResumeOnBluetoothReconnect(v),
               ),
+              ToggleSetting(
+                icon: LucideIcons.usb,
+                title: 'Pause on USB DAC Detach',
+                subtitle: appPrefs.pauseOnUsbDacDisconnect
+                    ? 'Playback pauses when a USB DAC is physically unplugged'
+                    : 'Playback continues when a USB DAC is unplugged',
+                value: appPrefs.pauseOnUsbDacDisconnect,
+                onChanged: (v) => ref
+                    .read(appPreferencesProvider.notifier)
+                    .setPauseOnUsbDacDisconnect(v),
+              ),
             ]),
           ),
           const SizedBox(height: AppConstants.spacingLg),

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -14,6 +14,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/src/rust/api/audio_api.dart' as rust_audio;
 import 'package:flick/src/rust/audio/engine.dart' show AudioApiPreference;
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/engine_restart_notice.dart';
 import 'package:flick/widgets/uac2/uac2_volume_control.dart';
 import 'package:flick/features/settings/screens/logs_screen.dart';
 import 'package:flick/features/player/widgets/ambient_background.dart';
@@ -27,6 +28,8 @@ class Uac2PreferencesScreen extends ConsumerStatefulWidget {
 }
 
 class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
+  bool _pendingEngineRestart = false;
+
   @override
   Widget build(BuildContext context) {
                     final preferencesService = ref.watch(uac2PreferencesServiceProvider);
@@ -72,6 +75,10 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
                         child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          if (_pendingEngineRestart) ...[
+                            const EngineRestartNotice(),
+                            const SizedBox(height: AppConstants.spacingLg),
+                          ],
                           _buildSectionHeader(context, 'Audio Format'),
                           _buildFormatPreferences(
                             context,
@@ -716,7 +723,7 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
                         }
                         if ((engineChanged || wasBitPerfectEnabled) &&
                             context.mounted) {
-                          _showRestartRequiredToast(context);
+                          setState(() => _pendingEngineRestart = true);
                         }
                       },
               ),
@@ -751,7 +758,7 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
                   }
                   if ((engineChanged || wasBitPerfectEnabled) &&
                       context.mounted) {
-                    _showRestartRequiredToast(context);
+                    setState(() => _pendingEngineRestart = true);
                   }
                 },
               ),
@@ -773,7 +780,7 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
                     Navigator.of(dialogContext).pop();
                   }
                   if (changed && context.mounted) {
-                    _showRestartRequiredToast(context);
+                    setState(() => _pendingEngineRestart = true);
                   }
                 },
               ),

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -16,6 +16,7 @@ import 'package:flick/src/rust/audio/engine.dart' show AudioApiPreference;
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/uac2/uac2_volume_control.dart';
 import 'package:flick/features/settings/screens/logs_screen.dart';
+import 'package:flick/features/player/widgets/ambient_background.dart';
 
 class Uac2PreferencesScreen extends ConsumerStatefulWidget {
   const Uac2PreferencesScreen({super.key});
@@ -41,76 +42,89 @@ class _Uac2PreferencesScreenState extends ConsumerState<Uac2PreferencesScreen> {
                     final diagnostics = ref.watch(audioOutputDiagnosticsProvider);
                     final killIsochronousUsbOnQuitAsync = ref.watch(killIsochronousUsbOnQuitProvider);
                     final dsdOutputModeAsync = ref.watch(dsdOutputModeProvider);
+                    final currentSong = ref.watch(currentSongProvider);
 
     return DisplayModeWrapper(
       child: Scaffold(
-        backgroundColor: AppColors.background,
-        body: SafeArea(
-          bottom: false,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildHeader(context),
-              const SizedBox(height: AppConstants.spacingMd),
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingMd,
-                  ),
-                    child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _buildSectionHeader(context, 'Audio Format'),
-                      _buildFormatPreferences(
-                        context,
-                        preferencesService,
-                        formatPrefAsync,
-                        preferredFormatAsync,
-                        audioFormatAsync,
-                      ),
-                      const SizedBox(height: AppConstants.spacingLg),
-                      _buildSectionHeader(context, 'Experimental'),
-                      _buildExperimentalWarning(context),
-                      _buildDsdOptions(
-                        context,
-                        preferencesService,
-                        dsdOutputModeAsync,
-                      ),
-                      const SizedBox(height: AppConstants.spacingSm),
-                      _build432HzTuningTile(
-                        context,
-                        preferencesService,
-                        tuning432HzAsync,
-                      ),
-                      const SizedBox(height: AppConstants.spacingLg),
-                      _buildSectionHeader(context, 'Advanced'),
-                      _buildAdvancedOptions(
-                        context,
-                        preferencesService,
-                        audioEngineAsync,
-                        androidAudioApiAsync,
-                        developerModeAsync,
-                        bitPerfectAsync,
-                        dapBitPerfectAsync,
-                        killIsochronousUsbOnQuitAsync,
-                        diagnostics,
-                      ),
-                      if (audioEngineAsync.when(
-                        data: (e) => e == AudioEnginePreference.isochronousUsb,
-                        loading: () => false,
-                        error: (_, _) => false,
-                      )) ...[
-                        const SizedBox(height: AppConstants.spacingLg),
-                        _buildSectionHeader(context, 'Volume'),
-                        const Uac2VolumeControl(),
-                      ],
-                      const SizedBox(height: AppConstants.navBarHeight + 120),
-                    ],
-                  ),
-                ),
+        backgroundColor: Colors.transparent,
+        body: Stack(
+          children: [
+            Container(
+              decoration: const BoxDecoration(
+                gradient: AppColors.backgroundGradient,
               ),
-            ],
-          ),
+            ),
+            Positioned.fill(
+              child: AmbientBackground(song: currentSong),
+            ),
+            SafeArea(
+              bottom: false,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeader(context),
+                  const SizedBox(height: AppConstants.spacingMd),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.spacingMd,
+                      ),
+                        child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildSectionHeader(context, 'Audio Format'),
+                          _buildFormatPreferences(
+                            context,
+                            preferencesService,
+                            formatPrefAsync,
+                            preferredFormatAsync,
+                            audioFormatAsync,
+                          ),
+                          const SizedBox(height: AppConstants.spacingLg),
+                          _buildSectionHeader(context, 'Experimental'),
+                          _buildExperimentalWarning(context),
+                          _buildDsdOptions(
+                            context,
+                            preferencesService,
+                            dsdOutputModeAsync,
+                          ),
+                          const SizedBox(height: AppConstants.spacingSm),
+                          _build432HzTuningTile(
+                            context,
+                            preferencesService,
+                            tuning432HzAsync,
+                          ),
+                          const SizedBox(height: AppConstants.spacingLg),
+                          _buildSectionHeader(context, 'Advanced'),
+                          _buildAdvancedOptions(
+                            context,
+                            preferencesService,
+                            audioEngineAsync,
+                            androidAudioApiAsync,
+                            developerModeAsync,
+                            bitPerfectAsync,
+                            dapBitPerfectAsync,
+                            killIsochronousUsbOnQuitAsync,
+                            diagnostics,
+                          ),
+                          if (audioEngineAsync.when(
+                            data: (e) => e == AudioEnginePreference.isochronousUsb,
+                            loading: () => false,
+                            error: (_, _) => false,
+                          )) ...[
+                            const SizedBox(height: AppConstants.spacingLg),
+                            _buildSectionHeader(context, 'Volume'),
+                            const Uac2VolumeControl(),
+                          ],
+                          const SizedBox(height: AppConstants.navBarHeight + 120),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/settings/screens/uac2_settings_screen.dart
+++ b/lib/features/settings/screens/uac2_settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/features/settings/screens/uac2_preferences_screen.dart';
 import 'package:flick/widgets/uac2/uac2_volume_control.dart';
 import 'package:flick/widgets/uac2/uac2_hotplug_monitor.dart';
+import 'package:flick/features/player/widgets/ambient_background.dart';
 
 
 class Uac2SettingsScreen extends ConsumerStatefulWidget {
@@ -28,68 +29,81 @@ class _Uac2SettingsScreenState extends ConsumerState<Uac2SettingsScreen> {
     final devicesAsync = ref.watch(uac2DevicesProvider);
     final selectedDevice = ref.watch(selectedUac2DeviceProvider);
     final deviceStatus = ref.watch(uac2DeviceStatusProvider);
+    final currentSong = ref.watch(currentSongProvider);
 
     return DisplayModeWrapper(
       child: Scaffold(
-        backgroundColor: AppColors.background,
-        body: SafeArea(
-          bottom: false,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildHeader(context),
-              const SizedBox(height: AppConstants.spacingMd),
-              Expanded(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppConstants.spacingMd,
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (!isAvailable) _buildUnavailableCard(context),
-                      if (isAvailable) ...[
-                        const Uac2HotplugMonitor(),
-                        _buildSectionHeader(context, 'USB Audio Devices'),
-                        devicesAsync.when(
-                          data: (devices) => _buildDevicesList(
-                            context,
-                            devices,
-                            selectedDevice,
-                            deviceStatus,
-                          ),
-                          loading: () => _buildLoadingCard(context),
-                          error: (error, _) => _buildErrorCard(context, error),
-                        ),
-                        if (selectedDevice != null) ...[
-                          const SizedBox(height: AppConstants.spacingLg),
-                          _buildSectionHeader(context, 'Device Information'),
-                          _buildDeviceInfoCard(context, selectedDevice),
-                          const SizedBox(height: AppConstants.spacingLg),
-                          _buildSectionHeader(context, 'Capabilities'),
-                          _buildCapabilitiesCard(context, selectedDevice),
-                        ],
-                        if (deviceStatus != null) ...[
-                          const SizedBox(height: AppConstants.spacingLg),
-                          _buildSectionHeader(context, 'Status'),
-                          _buildStatusCard(context, deviceStatus),
-                        ],
-                        if (deviceStatus != null &&
-                            deviceStatus.state != Uac2State.idle &&
-                            deviceStatus.hasVolumeControl) ...[
-                          const SizedBox(height: AppConstants.spacingLg),
-                          _buildSectionHeader(context, 'Volume Control'),
-                          const Uac2VolumeControl(),
-                        ],
-
-                      ],
-                      const SizedBox(height: AppConstants.navBarHeight + 120),
-                    ],
-                  ),
-                ),
+        backgroundColor: Colors.transparent,
+        body: Stack(
+          children: [
+            Container(
+              decoration: const BoxDecoration(
+                gradient: AppColors.backgroundGradient,
               ),
-            ],
-          ),
+            ),
+            Positioned.fill(
+              child: AmbientBackground(song: currentSong),
+            ),
+            SafeArea(
+              bottom: false,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeader(context),
+                  const SizedBox(height: AppConstants.spacingMd),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppConstants.spacingMd,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (!isAvailable) _buildUnavailableCard(context),
+                          if (isAvailable) ...[
+                            const Uac2HotplugMonitor(),
+                            _buildSectionHeader(context, 'USB Audio Devices'),
+                            devicesAsync.when(
+                              data: (devices) => _buildDevicesList(
+                                context,
+                                devices,
+                                selectedDevice,
+                                deviceStatus,
+                              ),
+                              loading: () => _buildLoadingCard(context),
+                              error: (error, _) => _buildErrorCard(context, error),
+                            ),
+                            if (selectedDevice != null) ...[
+                              const SizedBox(height: AppConstants.spacingLg),
+                              _buildSectionHeader(context, 'Device Information'),
+                              _buildDeviceInfoCard(context, selectedDevice),
+                              const SizedBox(height: AppConstants.spacingLg),
+                              _buildSectionHeader(context, 'Capabilities'),
+                              _buildCapabilitiesCard(context, selectedDevice),
+                            ],
+                            if (deviceStatus != null) ...[
+                              const SizedBox(height: AppConstants.spacingLg),
+                              _buildSectionHeader(context, 'Status'),
+                              _buildStatusCard(context, deviceStatus),
+                            ],
+                            if (deviceStatus != null &&
+                                deviceStatus.state != Uac2State.idle &&
+                                deviceStatus.hasVolumeControl) ...[
+                              const SizedBox(height: AppConstants.spacingLg),
+                              _buildSectionHeader(context, 'Volume Control'),
+                              const Uac2VolumeControl(),
+                            ],
+
+                          ],
+                          const SizedBox(height: AppConstants.navBarHeight + 120),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -134,6 +134,19 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                       .setShowMoreArtists(value);
                 },
               ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.sparkles,
+                title: 'Animated Album Art',
+                subtitle:
+                    'Pan/zoom, ambient glow and smooth fade on album, artist and playlist heroes',
+                value: appPreferences.animatedAlbumArt,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setAnimatedAlbumArt(value);
+                },
+              ),
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -403,6 +403,12 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setAlbumsStretchArtwork(value);
   }
 
+  Future<void> setAnimatedAlbumArt(bool value) async {
+    if (state.animatedAlbumArt == value) return;
+    state = state.copyWith(animatedAlbumArt: value);
+    await ref.read(appPreferencesServiceProvider).setAnimatedAlbumArt(value);
+  }
+
   Future<void> setFolderGridPageSize(int value) async {
     if (state.folderGridPageSize == value) return;
     state = state.copyWith(folderGridPageSize: value);
@@ -453,6 +459,14 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref
         .read(appPreferencesServiceProvider)
         .setPauseOnBluetoothDisconnect(value);
+  }
+
+  Future<void> setPauseOnUsbDacDisconnect(bool value) async {
+    if (state.pauseOnUsbDacDisconnect == value) return;
+    state = state.copyWith(pauseOnUsbDacDisconnect: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setPauseOnUsbDacDisconnect(value);
   }
 
   Future<void> setResumeOnBluetoothReconnect(bool value) async {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -54,6 +54,7 @@ class AppPreferences {
   final bool glanceCardMinimized;
   final bool replaceAlbumWithBitPerfectCapsule;
   final bool albumsStretchArtwork;
+  final bool animatedAlbumArt;
   final int folderGridPageSize;
   final String? lastSeenChangelogVersion;
   final bool bottomBarAutoCollapseEnabled;
@@ -62,6 +63,7 @@ class AppPreferences {
   final bool keepPlayingOnQuit;
   final bool pauseOnBluetoothDisconnect;
   final bool resumeOnBluetoothReconnect;
+  final bool pauseOnUsbDacDisconnect;
   final String preferredBluetoothDevice;
   final int btPreferredCodec;
   final String btLdacBitrate;
@@ -145,6 +147,7 @@ class AppPreferences {
     this.glanceCardMinimized = false,
     this.replaceAlbumWithBitPerfectCapsule = false,
     this.albumsStretchArtwork = false,
+    this.animatedAlbumArt = true,
     this.folderGridPageSize = 8,
     this.lastSeenChangelogVersion,
     this.bottomBarAutoCollapseEnabled = false,
@@ -153,6 +156,7 @@ class AppPreferences {
     this.keepPlayingOnQuit = false,
     this.pauseOnBluetoothDisconnect = true,
     this.resumeOnBluetoothReconnect = false,
+    this.pauseOnUsbDacDisconnect = true,
     this.preferredBluetoothDevice = '',
     this.btPreferredCodec = -1,
     this.btLdacBitrate = 'adaptive',
@@ -237,6 +241,7 @@ class AppPreferences {
     bool? glanceCardMinimized,
     bool? replaceAlbumWithBitPerfectCapsule,
     bool? albumsStretchArtwork,
+    bool? animatedAlbumArt,
     int? folderGridPageSize,
     String? lastSeenChangelogVersion,
     bool? bottomBarAutoCollapseEnabled,
@@ -245,6 +250,7 @@ class AppPreferences {
     bool? keepPlayingOnQuit,
     bool? pauseOnBluetoothDisconnect,
     bool? resumeOnBluetoothReconnect,
+    bool? pauseOnUsbDacDisconnect,
     String? preferredBluetoothDevice,
     int? btPreferredCodec,
     String? btLdacBitrate,
@@ -349,6 +355,7 @@ class AppPreferences {
           this.replaceAlbumWithBitPerfectCapsule,
       albumsStretchArtwork:
           albumsStretchArtwork ?? this.albumsStretchArtwork,
+      animatedAlbumArt: animatedAlbumArt ?? this.animatedAlbumArt,
       folderGridPageSize: folderGridPageSize ?? this.folderGridPageSize,
       lastSeenChangelogVersion:
           lastSeenChangelogVersion ?? this.lastSeenChangelogVersion,
@@ -363,6 +370,8 @@ class AppPreferences {
           pauseOnBluetoothDisconnect ?? this.pauseOnBluetoothDisconnect,
       resumeOnBluetoothReconnect:
           resumeOnBluetoothReconnect ?? this.resumeOnBluetoothReconnect,
+      pauseOnUsbDacDisconnect:
+          pauseOnUsbDacDisconnect ?? this.pauseOnUsbDacDisconnect,
       preferredBluetoothDevice:
           preferredBluetoothDevice ?? this.preferredBluetoothDevice,
       btPreferredCodec: btPreferredCodec ?? this.btPreferredCodec,
@@ -459,6 +468,7 @@ class AppPreferencesService {
   static const _replaceAlbumWithBitPerfectCapsuleKey =
       'replace_album_with_bit_perfect_capsule';
   static const _albumsStretchArtworkKey = 'albums_stretch_artwork';
+  static const _animatedAlbumArtKey = 'album_animated_art';
   static const _folderGridPageSizeKey = 'folder_grid_page_size';
   static const _lastSeenChangelogVersionKey = 'last_seen_changelog_version';
   static const _bottomBarAutoCollapseEnabledKey =
@@ -471,6 +481,7 @@ class AppPreferencesService {
       'app_pause_on_bluetooth_disconnect';
   static const _resumeOnBluetoothReconnectKey =
       'app_resume_on_bluetooth_reconnect';
+  static const _pauseOnUsbDacDisconnectKey = 'app_pause_on_usb_dac_disconnect';
   static const _preferredBluetoothDeviceKey = 'app_preferred_bluetooth_device';
   static const _btPreferredCodecKey = 'app_bt_preferred_codec';
   static const _btLdacBitrateKey = 'app_bt_ldac_bitrate';
@@ -581,6 +592,7 @@ class AppPreferencesService {
           prefs.getBool(_replaceAlbumWithBitPerfectCapsuleKey) ?? false,
       albumsStretchArtwork:
           prefs.getBool(_albumsStretchArtworkKey) ?? false,
+      animatedAlbumArt: prefs.getBool(_animatedAlbumArtKey) ?? true,
       folderGridPageSize: prefs.getInt(_folderGridPageSizeKey) ?? 8,
       lastSeenChangelogVersion: prefs.getString(_lastSeenChangelogVersionKey),
       bottomBarAutoCollapseEnabled:
@@ -594,6 +606,8 @@ class AppPreferencesService {
           prefs.getBool(_pauseOnBluetoothDisconnectKey) ?? true,
       resumeOnBluetoothReconnect:
           prefs.getBool(_resumeOnBluetoothReconnectKey) ?? false,
+      pauseOnUsbDacDisconnect:
+          prefs.getBool(_pauseOnUsbDacDisconnectKey) ?? true,
       preferredBluetoothDevice:
           prefs.getString(_preferredBluetoothDeviceKey) ?? '',
       btPreferredCodec: prefs.getInt(_btPreferredCodecKey) ?? -1,
@@ -1113,6 +1127,16 @@ class AppPreferencesService {
     await prefs.setBool(_albumsStretchArtworkKey, value);
   }
 
+  Future<bool> getAnimatedAlbumArt() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_animatedAlbumArtKey) ?? true;
+  }
+
+  Future<void> setAnimatedAlbumArt(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_animatedAlbumArtKey, value);
+  }
+
   Future<int> getFolderGridPageSize() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getInt(_folderGridPageSizeKey) ?? 8;
@@ -1225,6 +1249,16 @@ class AppPreferencesService {
   Future<void> setPauseOnBluetoothDisconnect(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_pauseOnBluetoothDisconnectKey, value);
+  }
+
+  Future<bool> getPauseOnUsbDacDisconnect() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_pauseOnUsbDacDisconnectKey) ?? true;
+  }
+
+  Future<void> setPauseOnUsbDacDisconnect(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pauseOnUsbDacDisconnectKey, value);
   }
 
   Future<bool> getResumeOnBluetoothReconnect() async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -357,6 +357,7 @@ class PlayerService {
   VoidCallback? _rustDurationListener;
   StreamSubscription<AudioInterruptionEvent>? _audioFocusSubscription;
   StreamSubscription<Map<Object?, Object?>>? _bluetoothDeviceEventSubscription;
+  StreamSubscription<void>? _usbDacDetachSubscription;
   DateTime? _bluetoothDisconnectedAt;
   static const Duration _bluetoothReconnectWindow = Duration(seconds: 30);
   bool _audioInitialized = false;
@@ -553,6 +554,7 @@ class PlayerService {
     unawaited(_loadCrossfadePreferences());
     unawaited(_loadFloatingPlayerPreference());
     _initBluetoothReconnectHandling();
+    _initUsbDacDisconnectHandling();
     unawaited(_applyBluetoothCodecPrefs());
   }
 
@@ -569,6 +571,14 @@ class PlayerService {
             _maybeResumeOnBluetoothReconnect();
           }
         });
+  }
+
+  void _initUsbDacDisconnectHandling() {
+    _usbDacDetachSubscription = _uac2Service.deviceDetachedEvents.listen((_) async {
+      if (!isPlayingNotifier.value) return;
+      final enabled = await _appPreferencesService.getPauseOnUsbDacDisconnect();
+      if (enabled) pause();
+    });
   }
 
   /// Push the user's codec preference to the active A2DP device when codec
@@ -4797,6 +4807,7 @@ class PlayerService {
     _stopHwVolumeHealthTimer();
     unawaited(_audioFocusSubscription?.cancel());
     unawaited(_bluetoothDeviceEventSubscription?.cancel());
+    unawaited(_usbDacDetachSubscription?.cancel());
     cancelSleepTimer();
     _notificationService.hideNotification();
     _floatingPlayerService.hide();

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -183,6 +183,9 @@ class Uac2Service {
   }
   Uac2DeviceStatus? _currentDeviceStatus;
   final List<ValueChanged<Uac2DeviceStatus?>> _statusListeners = [];
+  final StreamController<void> _deviceDetachedController =
+      StreamController<void>.broadcast();
+  Stream<void> get deviceDetachedEvents => _deviceDetachedController.stream;
   bool _androidChannelConfigured = false;
   Future<void>? _initializeInFlight;
   Uac2AudioFormat? _lastKnownFormat;
@@ -277,7 +280,10 @@ class Uac2Service {
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
         case 'onDeviceAttached':
+          _scheduleAndroidRouteRefresh();
+          return;
         case 'onDeviceDetached':
+          _deviceDetachedController.add(null);
           _scheduleAndroidRouteRefresh();
           return;
         case 'onVolumeChanged':

--- a/lib/widgets/common/animated_album_art.dart
+++ b/lib/widgets/common/animated_album_art.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import 'package:flick/widgets/common/cached_image_widget.dart';
+
+/// Apple Music-style hero art: slow Ken Burns pan/zoom with a soft
+/// pulsing glow derived from the art's dominant color.
+class AnimatedAlbumArt extends StatefulWidget {
+  final String? imagePath;
+  final String? audioSourcePath;
+  final Color? dominantColor;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const AnimatedAlbumArt({
+    super.key,
+    this.imagePath,
+    this.audioSourcePath,
+    this.dominantColor,
+    this.placeholder,
+    this.errorWidget,
+  });
+
+  @override
+  State<AnimatedAlbumArt> createState() => _AnimatedAlbumArtState();
+}
+
+class _AnimatedAlbumArtState extends State<AnimatedAlbumArt>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 18),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final image = CachedImageWidget(
+      imagePath: widget.imagePath,
+      audioSourcePath: widget.audioSourcePath,
+      fit: BoxFit.cover,
+      placeholder: widget.placeholder,
+      errorWidget: widget.errorWidget,
+    );
+    return ClipRect(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          final t = Curves.easeInOut.transform(_controller.value);
+          final glow = widget.dominantColor;
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              Transform.scale(
+                scale: 1.0 + 0.12 * t,
+                child: FractionalTranslation(
+                  translation: Offset(0.03 * t, -0.02 * t),
+                  child: child,
+                ),
+              ),
+              if (glow != null)
+                IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: RadialGradient(
+                        radius: 1.2,
+                        colors: [
+                          glow.withValues(alpha: 0.0),
+                          glow.withValues(alpha: 0.12 + 0.18 * t),
+                        ],
+                        stops: const [0.55, 1.0],
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+        child: image,
+      ),
+    );
+  }
+}

--- a/lib/widgets/common/engine_restart_notice.dart
+++ b/lib/widgets/common/engine_restart_notice.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/features/menu/screens/restarting_screen.dart';
+
+/// Inline "restart required" prompt shown after the audio engine is changed.
+///
+/// Self-contained: tapping Restart pushes [RestartingScreen], which hard-kills
+/// and relaunches the app so the new engine takes effect.
+class EngineRestartNotice extends StatelessWidget {
+  const EngineRestartNotice({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: AppColors.accent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.30)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.16),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              LucideIcons.refreshCcw,
+              color: context.adaptiveTextPrimary,
+              size: 17,
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Restart required',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: AppConstants.spacingXxs),
+                Text(
+                  'Your new audio engine is ready. Restart Flick to apply it.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextSecondary,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppConstants.spacingSm),
+          FilledButton(
+            onPressed: () => Navigator.of(context).push(
+              PageRouteBuilder(
+                opaque: true,
+                transitionDuration: const Duration(milliseconds: 300),
+                reverseTransitionDuration: Duration.zero,
+                pageBuilder: (_, _, _) => const RestartingScreen(),
+                transitionsBuilder: (context, animation, _, child) {
+                  return FadeTransition(opacity: animation, child: child);
+                },
+              ),
+            ),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.accent,
+              foregroundColor: AppColors.background,
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppConstants.spacingMd,
+                vertical: AppConstants.spacingSm,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: const Text('Restart'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/common/scroll_fade_wrapper.dart
+++ b/lib/widgets/common/scroll_fade_wrapper.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+/// Fades [child] out as the scroll offset grows, so heroes dissolve
+/// instead of being clipped by the pinned app bar.
+class ScrollFadeWrapper extends StatefulWidget {
+  final ScrollController scrollController;
+  final double fadeDistance;
+  final Widget child;
+
+  const ScrollFadeWrapper({
+    super.key,
+    required this.scrollController,
+    this.fadeDistance = 196,
+    required this.child,
+  });
+
+  @override
+  State<ScrollFadeWrapper> createState() => _ScrollFadeWrapperState();
+}
+
+class _ScrollFadeWrapperState extends State<ScrollFadeWrapper> {
+  // ponytail: ValueNotifier so only the Opacity node rebuilds per scroll
+  // frame; switch to RenderProxyBox if this ever shows up in profiles.
+  final ValueNotifier<double> _opacity = ValueNotifier(1.0);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    _opacity.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!widget.scrollController.hasClients) return;
+    final t = (widget.scrollController.offset / widget.fadeDistance).clamp(
+      0.0,
+      1.0,
+    );
+    final v = 1.0 - t;
+    if ((v - _opacity.value).abs() > 0.01) _opacity.value = v;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<double>(
+      valueListenable: _opacity,
+      builder: (_, value, child) => Opacity(opacity: value, child: child),
+      child: widget.child,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1087,6 +1087,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  restart_app:
+    dependency: "direct main"
+    description:
+      name: restart_app
+      sha256: "400dd401b77b599e2defef55fd4c22af3ff80af48616a82f01c2a07070e3e368"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.3"
   rive:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   permission_handler: ^12.0.1
   rive: ^0.14.0
   riverpod_annotation: ^4.0.0
+  restart_app: ^1.2.1
   rust_lib_flick_player:
     path: rust_builder
   shared_preferences: ^2.2.2

--- a/test/animated_hero_test.dart
+++ b/test/animated_hero_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/widgets/common/animated_album_art.dart';
+import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
+
+void main() {
+  testWidgets('ScrollFadeWrapper fades child as scroll offset grows', (
+    tester,
+  ) async {
+    final controller = ScrollController();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Stack(
+            children: [
+              ListView(
+                controller: controller,
+                children: const [SizedBox(height: 2000)],
+              ),
+              ScrollFadeWrapper(
+                scrollController: controller,
+                fadeDistance: 100,
+                child: const Text('hero'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    Opacity opacity = tester.widget(find.byType(Opacity));
+    expect(opacity.opacity, 1.0);
+
+    controller.jumpTo(50);
+    await tester.pump();
+    opacity = tester.widget(find.byType(Opacity));
+    expect(opacity.opacity, 0.5);
+
+    controller.jumpTo(200);
+    await tester.pump();
+    opacity = tester.widget(find.byType(Opacity));
+    expect(opacity.opacity, 0.0);
+  });
+
+  testWidgets('AnimatedAlbumArt builds and ticks without error', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: AnimatedAlbumArt(dominantColor: Colors.red)),
+      ),
+    );
+    expect(find.byType(AnimatedAlbumArt), findsOneWidget);
+    await tester.pump(const Duration(seconds: 1));
+  });
+}


### PR DESCRIPTION
# Summary

- Add Apple Music-style animated album art widget with scroll fade wrapper applied to album, artist, and playlist detail screens
- Add USB DAC disconnect detection with pause playback on device detach
- Add inline engine restart notice widget and full-screen restart overlay
- Add animated album art and USB DAC disconnect pause preferences with UI customization toggles
- Add ambient background with gradient to UAC2 preferences and settings screens
- Add tests for `ScrollFadeWrapper` and `AnimatedAlbumArt`

# Changes

## Animated Album Art

- Add animated album art widget (93 lines) with floating animation
- Add `ScrollFadeWrapper` (57 lines) for fading hero components behind pinned app bar
- Add animated album art preference with provider/service
- Add animated album art toggle to UI customization settings
- Integrate animated album art into album, artist, and playlist detail screens

## USB DAC Disconnect

- Add device detached event stream for UI notifications
- Add USB DAC disconnect pause playback in player service
- Add USB DAC detach pause toggle to Bluetooth settings
- Add USB DAC disconnect pause preferences with provider/service

## Engine Restart Notice

- Add inline `EngineRestartNotice` widget (93 lines) with persist dismiss and animation
- Add full-screen restart overlay with animated progress UI (133 lines)
- Add `restart_app` dependency
- Replace toast with inline `EngineRestartNotice` for pending restart
- Extract restart notice to shared widget, restyle update notice

## UAC2 Settings

- Replace UAC2 settings background with gradient and ambient artwork
- Add ambient background with gradient to UAC2 preferences screen

## Tests

- Add tests (56 lines) for `ScrollFadeWrapper` and `AnimatedAlbumArt`

## Files Changed

- `pubspec.yaml`
- `pubspec.lock`
- `lib/services/app_preferences_service.dart`
- `lib/services/player_service.dart`
- `lib/services/uac2_service.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/widgets/common/animated_album_art.dart`
- `lib/widgets/common/scroll_fade_wrapper.dart`
- `lib/widgets/common/engine_restart_notice.dart`
- `lib/features/albums/screens/album_detail_screen.dart`
- `lib/features/artists/screens/artist_detail_screen.dart`
- `lib/features/playlists/screens/playlist_detail_screen.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/features/menu/screens/restarting_screen.dart`
- `lib/features/settings/screens/ui_customization_settings_screen.dart`
- `lib/features/settings/screens/bluetooth_settings_screen.dart`
- `lib/features/settings/screens/uac2_settings_screen.dart`
- `lib/features/settings/screens/uac2_preferences_screen.dart`
- `test/animated_hero_test.dart`