### PR TITLE
Replace speed buttons and sleep timer presets with sliders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,24 @@
 - Responsive songs header, edge-drag guard, sort sheet margin fix.
 - Docs: audio preload scan plan, scan details revamp.
 
+### Animated Album Art & Scroll Fade
+- Apple Music-style animated album art on album, artist, and playlist detail screens.
+- `ScrollFadeWrapper` fades hero artwork behind the pinned app bar on scroll.
+- Album art layer extracted into `AnimatedAlbumArt` with scroll-aware fade.
+- Toggle in Settings → Interface → UI Customization.
+- Tests for `ScrollFadeWrapper` and `AnimatedAlbumArt`.
+
+### Engine Restart Overlay
+- Full-screen restart overlay with animated gradient progress.
+- Inline `EngineRestartNotice` widget replaces snackbar/toast prompts.
+- Shared restart notice restyled alongside update notice.
+
+### USB DAC Disconnect & UAC2 Redesign
+- USB DAC disconnect pauses playback automatically.
+- `DeviceDetachedEvent` stream for UI notifications.
+- Pause-on-disconnect toggle in Settings → Audio → Bluetooth.
+- UAC2 settings screen redesigned with gradient background and ambient artwork.
+
 ## 0.20.3-beta.4 (2026-06-30)
 
 ### Full Player Refactor & Widgets

--- a/docs/RELEASE_0.20.4-beta.5.md
+++ b/docs/RELEASE_0.20.4-beta.5.md
@@ -1,10 +1,10 @@
 # Flick 0.20.4-beta.5
 
-0.20.4-beta.5 ships real-time pitch shifting via SoundTouch, an Android audio API preference (AAudio/OpenSL/Auto), blurred backgrounds across all library screens, customizable orbit (menu) settings, album artwork stretch mode, lyrics performance caching, streak and preference controls, and artwork reliability fixes.
+0.20.4-beta.5 ships real-time pitch shifting via SoundTouch, an Android audio API preference (AAudio/OpenSL/Auto), blurred backgrounds across all library screens, customizable orbit settings, album artwork stretch mode, lyrics performance caching, streak controls, artwork reliability fixes, Apple Music-style animated album art with scroll fade, an engine restart overlay, USB DAC disconnect handling, and a redesigned UAC2 settings screen.
 
 ## Overview
 
-This beta adds nine headline features:
+This beta adds twelve headline features:
 
 1. **Pitch shifter (SoundTouch)** — real-time pitch shifting via SoundTouch DSP, lock-free bypass, semitone API
 2. **Android audio API preference** — choose AAudio, OpenSL ES, or Auto for audio output
@@ -14,7 +14,10 @@ This beta adds nine headline features:
 6. **Lyrics performance** — in-memory cache, parallel exact+fuzzy searches
 7. **Streaks & preference controls** — disable streaks, toggle album detail sections
 8. **Artwork reliability** — only cache confirmed paths, prefer embedded art
-9. **UI polish** — glass engine selector, responsive header, edge-drag guard
+9. **Animated album art & scroll fade** — Apple Music-style animated art on detail screens with scroll-aware hero fade
+10. **Engine restart overlay** — full-screen animated restart flow replaces snackbar prompts
+11. **USB DAC disconnect** — automatic pause on DAC removal with preference toggle
+12. **UAC2 settings redesign** — gradient background with ambient album artwork
 
 ## Highlights
 
@@ -26,6 +29,10 @@ This beta adds nine headline features:
 - **Lyrics performance**: An in-memory cache with timeout reduces redundant API calls when searching the same lyrics repeatedly. A shared HTTP client prevents connection pool exhaustion. Exact and fuzzy searches run in parallel and return the first match.
 - **Streaks & preferences**: Streaks can be disabled entirely with a reset option that clears all streak data. The day streak milestone is hidden when streaks are disabled. "More from Artist" and "More Artists" sections on album detail screens can be toggled independently. Display preferences were added to the artist sort sheet.
 - **Artwork**: Only confirmed-existing artwork paths are cached, preventing phantom thumbnails from appearing when storage is unmounted. The artwork source path now prefers songs with embedded album art for fallback. The path picker matches the song that has artwork matching the album art.
+- **Animated album art**: Album, artist, and playlist detail screens now feature Apple Music-style animated album artwork. A `ScrollFadeWrapper` fades the hero artwork behind the pinned app bar as you scroll down. The album art layer was extracted into an `AnimatedAlbumArt` variant with scroll-aware fade. Toggle the animation from Settings → Interface → UI Customization. Tests cover both the `ScrollFadeWrapper` and `AnimatedAlbumArt` widgets.
+- **Engine restart**: A full-screen restart overlay with animated gradient progress replaces the old snackbar and toast prompts. An inline `EngineRestartNotice` widget appears when UAC2 settings require an engine restart. The restart and update notices share a consistent restyled widget.
+- **USB DAC disconnect**: When a USB DAC is unplugged, playback now pauses automatically. A `DeviceDetachedEvent` stream notifies the UI of DAC removal events. Pause-on-disconnect can be toggled from Settings → Audio → Bluetooth.
+- **UAC2 redesign**: The UAC2 settings screen got a gradient background with ambient album artwork. The UAC2 preferences screen background was refreshed with the same gradient styling.
 
 ## What's New
 
@@ -89,6 +96,28 @@ This beta adds nine headline features:
 - Sort sheet margin fix
 - Docs: scan plan, scan revamp, feature requests
 
+### Animated Album Art & Scroll Fade
+
+- Apple Music-style animated album art on album, artist, and playlist detail screens
+- `ScrollFadeWrapper` fades hero artwork behind the pinned app bar
+- `AnimatedAlbumArt` variant with scroll-aware fade
+- Toggle in Settings → Interface → UI Customization
+- Tests for `ScrollFadeWrapper` and `AnimatedAlbumArt`
+
+### Engine Restart Overlay
+
+- Full-screen restart overlay with animated gradient progress
+- Inline `EngineRestartNotice` replaces snackbar/toast prompts
+- Shared restart notice restyled with the update notice
+
+### USB DAC Disconnect & UAC2 Redesign
+
+- Automatic pause on USB DAC unplug
+- `DeviceDetachedEvent` stream for UI notifications
+- Pause-on-disconnect toggle in Settings → Audio → Bluetooth
+- UAC2 settings screen with gradient background and ambient artwork
+- UAC2 preferences screen gradient refresh
+
 ## Files Changed
 
 | Area | Key Paths |
@@ -102,6 +131,10 @@ This beta adds nine headline features:
 | Streaks | `lib/features/milestones/`, `lib/features/settings/screens/interface_screen.dart` |
 | Artwork | `lib/services/artwork_cache_service.dart`, `lib/services/artwork_extraction_service.dart` |
 | Engine Selector | `lib/features/home/widgets/engine_selector.dart` |
+| Animated Art | `lib/widgets/common/animated_album_art.dart`, `lib/widgets/common/scroll_fade_wrapper.dart`, `lib/features/**/detail_screen.dart` |
+| Restart Flow | `lib/features/menu/screens/restarting_screen.dart`, `lib/widgets/common/engine_restart_notice.dart` |
+| USB DAC | `lib/services/uac2_service.dart`, `lib/services/player_service.dart`, `lib/features/settings/screens/bluetooth_settings_screen.dart` |
+| UAC2 Settings | `lib/features/settings/screens/uac2_settings_screen.dart`, `lib/features/settings/screens/uac2_preferences_screen.dart` |
 
 ## Upgrading
 
@@ -111,3 +144,6 @@ This beta adds nine headline features:
 4. Album artwork stretch: Settings → Library → Stretch album artwork
 5. Streak settings: Settings → Interface → Streaks
 6. Blurred backgrounds are automatic on all library screens — no configuration needed
+7. Animated album art: toggle from Settings → Interface → UI Customization → Animated Album Art
+8. Engine restart appears automatically when UAC2 settings change — no action needed
+9. USB DAC disconnect pausing: toggle from Settings → Audio → Bluetooth → Pause on DAC disconnect

--- a/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
+++ b/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
@@ -4,7 +4,7 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/utils/duration_format.dart';
 import 'package:flick/services/player_service.dart';
 
-class SleepTimerBottomSheet extends StatelessWidget {
+class SleepTimerBottomSheet extends StatefulWidget {
   final PlayerService playerService;
   const SleepTimerBottomSheet({super.key, required this.playerService});
 
@@ -17,14 +17,17 @@ class SleepTimerBottomSheet extends StatelessWidget {
   }
 
   @override
+  State<SleepTimerBottomSheet> createState() => _SleepTimerBottomSheetState();
+}
+
+class _SleepTimerBottomSheetState extends State<SleepTimerBottomSheet> {
+  static const _min = 5.0;
+  static const _max = 120.0;
+  static const _step = 5.0;
+  double _value = 30.0;
+
+  @override
   Widget build(BuildContext context) {
-    final timerOptions = [
-      (const Duration(minutes: 15), '15 min'),
-      (const Duration(minutes: 30), '30 min'),
-      (const Duration(minutes: 45), '45 min'),
-      (const Duration(hours: 1), '1 hour'),
-      (const Duration(hours: 2), '2 hours'),
-    ];
     return Container(
       decoration: BoxDecoration(
         color: AppColors.surface,
@@ -58,10 +61,10 @@ class SleepTimerBottomSheet extends StatelessWidget {
                   ),
                 ],
               ),
-              if (playerService.isSleepTimerActive)
+              if (widget.playerService.isSleepTimerActive)
                 TextButton(
                   onPressed: () {
-                    playerService.cancelSleepTimer();
+                    widget.playerService.cancelSleepTimer();
                     Navigator.pop(context);
                   },
                   child: const Text(
@@ -77,7 +80,7 @@ class SleepTimerBottomSheet extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           ValueListenableBuilder<Duration?>(
-            valueListenable: playerService.sleepTimerRemainingNotifier,
+            valueListenable: widget.playerService.sleepTimerRemainingNotifier,
             builder: (context, remaining, _) {
               if (remaining != null) {
                 return Padding(
@@ -120,39 +123,59 @@ class SleepTimerBottomSheet extends StatelessWidget {
               return const SizedBox.shrink();
             },
           ),
-          Wrap(
-            spacing: 12,
-            runSpacing: 12,
-            children: timerOptions.map((option) {
-              return GestureDetector(
-                onTap: () {
-                  playerService.setSleepTimer(option.$1);
-                  Navigator.pop(context);
-                },
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 12,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.glassBackground,
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                      color: AppColors.glassBorder,
-                      width: 1,
-                    ),
-                  ),
-                  child: Text(
-                    option.$2,
-                    style: const TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 16,
-                      color: AppColors.textPrimary,
-                    ),
-                  ),
+          Row(
+            children: [
+              const SizedBox(width: 4),
+              Text(
+                '${_min.round()}m',
+                style: const TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  color: AppColors.textSecondary,
                 ),
-              );
-            }).toList(),
+              ),
+              Expanded(
+                child: Slider(
+                  value: _value,
+                  min: _min,
+                  max: _max,
+                  divisions: ((_max - _min) / _step).round(),
+                  activeColor: AppColors.accent,
+                  inactiveColor: AppColors.glassBorder,
+                  onChanged: (v) {
+                    setState(() {
+                      _value = (v / _step).round() * _step;
+                    });
+                  },
+                  onChangeEnd: (v) {
+                    final minutes = (v / _step).round() * _step;
+                    widget.playerService
+                        .setSleepTimer(Duration(minutes: minutes.toInt()));
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+              Text(
+                '${_max.round()}m',
+                style: const TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 14,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(width: 4),
+            ],
+          ),
+          Center(
+            child: Text(
+              '${_value.round()} min',
+              style: const TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: AppColors.accent,
+              ),
+            ),
           ),
           const SizedBox(height: 16),
         ],

--- a/lib/features/player/widgets/speed_bottom_sheet.dart
+++ b/lib/features/player/widgets/speed_bottom_sheet.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
-import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/services/player_service.dart';
 
 class SpeedBottomSheet extends StatelessWidget {
@@ -18,7 +17,9 @@ class SpeedBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const speeds = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+    const min = 0.5;
+    const max = 2.0;
+    const step = 0.25;
     return Container(
       decoration: BoxDecoration(
         color: AppColors.surface,
@@ -53,50 +54,51 @@ class SpeedBottomSheet extends StatelessWidget {
           ValueListenableBuilder<double>(
             valueListenable: playerService.playbackSpeedNotifier,
             builder: (context, currentSpeed, _) {
-              return Wrap(
-                spacing: 12,
-                runSpacing: 12,
-                children: speeds.map((speed) {
-                  final isSelected = speed == currentSpeed;
-                  return GestureDetector(
-                    onTap: () {
-                      playerService.setPlaybackSpeed(speed);
-                      Navigator.pop(context);
-                    },
-                    child: AnimatedContainer(
-                      duration: AppConstants.animationFast,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 20,
-                        vertical: 12,
-                      ),
-                      decoration: BoxDecoration(
-                        color: isSelected
-                            ? AppColors.accent
-                            : AppColors.glassBackground,
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(
-                          color: isSelected
-                              ? AppColors.accent
-                              : AppColors.glassBorder,
-                          width: 1,
-                        ),
-                      ),
-                      child: Text(
-                        '${speed}x',
-                        style: TextStyle(
+              return Column(
+                children: [
+                  Row(
+                    children: [
+                      const SizedBox(width: 4),
+                      Text(
+                        '${min}x',
+                        style: const TextStyle(
                           fontFamily: 'ProductSans',
-                          fontSize: 16,
-                          fontWeight: isSelected
-                              ? FontWeight.bold
-                              : FontWeight.normal,
-                          color: isSelected
-                              ? Colors.white
-                              : AppColors.textPrimary,
+                          fontSize: 14,
+                          color: AppColors.textSecondary,
                         ),
                       ),
+                      Expanded(
+                        child: Slider(
+                          value: currentSpeed,
+                          min: min,
+                          max: max,
+                          divisions: ((max - min) / step).round(),
+                          activeColor: AppColors.accent,
+                          inactiveColor: AppColors.glassBorder,
+                          onChanged: playerService.setPlaybackSpeed,
+                        ),
+                      ),
+                      Text(
+                        '${max}x',
+                        style: const TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 14,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                    ],
+                  ),
+                  Text(
+                    '${currentSpeed}x',
+                    style: const TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.accent,
                     ),
-                  );
-                }).toList(),
+                  ),
+                ],
               );
             },
           ),

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -127,6 +127,35 @@ const List<ChangelogEntry> kChangelogEntries = [
           'Docs: audio preload scan plan, scan details revamp, audio analysis feature requests.',
         ],
       ),
+      ChangelogSection(
+        title: 'Animated Album Art & Scroll Fade',
+        bullets: [
+          '**Apple Music-style animated album art** on album, artist, and playlist detail screens.',
+          '`ScrollFadeWrapper` fades the hero artwork behind the pinned app bar as you scroll down.',
+          'Album art layer extracted into `AnimatedAlbumArt` variant with scroll-aware fade.',
+          'Toggle in Settings → Interface → UI Customization.',
+          'Tests for `ScrollFadeWrapper` and `AnimatedAlbumArt`.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'Engine Restart Overlay',
+        bullets: [
+          '**Full-screen restart overlay** with animated gradient progress — replaces snackbar/toast prompts.',
+          'Inline `EngineRestartNotice` widget shown when UAC2 settings require an engine restart.',
+          'Shared restart notice widget restyled alongside the update notice.',
+          'Smooth transition from the settings screen into the restart animation.',
+        ],
+      ),
+      ChangelogSection(
+        title: 'USB DAC Disconnect & UAC2 Redesign',
+        bullets: [
+          '**USB DAC disconnect handling** — playback pauses automatically when the DAC is unplugged.',
+          '`DeviceDetachedEvent` stream notifies the UI of DAC removal events.',
+          'Pause-on-disconnect toggle in Settings → Audio → Bluetooth.',
+          '**UAC2 settings screen redesigned** with gradient background and ambient album artwork.',
+          'UAC2 preferences screen background refreshed with gradient styling.',
+        ],
+      ),
     ],
   ),
   ChangelogEntry(


### PR DESCRIPTION
# Summary

- Replace preset speed buttons with continuous slider for precise playback speed control
- Replace preset sleep timer duration options with custom slider for any duration

# Changes

## Speed Control

- Replace discrete speed buttons (0.5×, 1.0×, 1.5×, 2.0×) with continuous slider (80 lines)

## Sleep Timer

- Replace preset sleep timer durations with a slider for custom duration selection (109 lines)

## Files Changed

- `lib/features/player/widgets/speed_bottom_sheet.dart`
- `lib/features/player/widgets/sleep_timer_bottom_sheet.dart`