### PR TITLE
Add configurable detail screen headers with expanded art and centered title

### DIFF
--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -295,7 +295,10 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
                 controller: _scrollController,
               slivers: [
                 SliverAppBar(
-                  expandedHeight: 280,
+                  expandedHeight:
+                      ref.watch(appPreferencesProvider).detailHeaderArtExpanded
+                          ? 360
+                          : 280,
                   pinned: true,
                   backgroundColor: animatedAppBar,
                   leading: AnimatedOpacity(
@@ -619,7 +622,7 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
               end: Alignment.bottomCenter,
               colors: gradientColors,
               stops: prefs.detailHeaderArtExpanded
-                  ? const [0.0, 0.5, 0.8, 1.0]
+                  ? const [0.0, 0.7, 0.92, 1.0]
                   : null,
             ),
           ),

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -595,6 +595,19 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
   }
 
   Widget _buildAppBarBackground(BuildContext context, Color fadeTo) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final gradientColors = prefs.detailHeaderArtExpanded
+        ? [
+            Colors.transparent,
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.9),
+            fadeTo,
+          ]
+        : [
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.8),
+            fadeTo,
+          ];
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -604,11 +617,10 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
             gradient: LinearGradient(
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
-              colors: [
-                Colors.transparent,
-                fadeTo.withValues(alpha: 0.8),
-                fadeTo,
-              ],
+              colors: gradientColors,
+              stops: prefs.detailHeaderArtExpanded
+                  ? const [0.0, 0.5, 0.8, 1.0]
+                  : null,
             ),
           ),
         ),
@@ -628,7 +640,9 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
           right: AppConstants.spacingLg,
           bottom: 4,
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: prefs.detailHeaderCenteredTitle
+                ? CrossAxisAlignment.center
+                : CrossAxisAlignment.start,
             children: [
               Text(
                 widget.albumName,

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -336,7 +336,10 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
                       controller: _scrollController,
                       slivers: [
                         SliverAppBar(
-                          expandedHeight: 280,
+                          expandedHeight:
+                              ref.watch(appPreferencesProvider).detailHeaderArtExpanded
+                                  ? 360
+                                  : 280,
                           pinned: true,
                           backgroundColor: animatedAppBar,
                           leading: AnimatedOpacity(
@@ -668,7 +671,7 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
               end: Alignment.bottomCenter,
               colors: gradientColors,
               stops: prefs.detailHeaderArtExpanded
-                  ? const [0.0, 0.5, 0.8, 1.0]
+                  ? const [0.0, 0.7, 0.92, 1.0]
                   : null,
             ),
           ),

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -644,6 +644,19 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
     Color fadeTo,
     int albumCount,
   ) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final gradientColors = prefs.detailHeaderArtExpanded
+        ? [
+            Colors.transparent,
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.9),
+            fadeTo,
+          ]
+        : [
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.8),
+            fadeTo,
+          ];
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -653,11 +666,10 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
             gradient: LinearGradient(
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
-              colors: [
-                Colors.transparent,
-                fadeTo.withValues(alpha: 0.8),
-                fadeTo,
-              ],
+              colors: gradientColors,
+              stops: prefs.detailHeaderArtExpanded
+                  ? const [0.0, 0.5, 0.8, 1.0]
+                  : null,
             ),
           ),
         ),
@@ -677,7 +689,9 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
           right: AppConstants.spacingLg,
           bottom: 4,
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: prefs.detailHeaderCenteredTitle
+                ? CrossAxisAlignment.center
+                : CrossAxisAlignment.start,
             children: [
               Text(
                 widget.artistName,

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -575,6 +575,19 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     Playlist playlist,
     Color fadeTo,
   ) {
+    final prefs = ref.watch(appPreferencesProvider);
+    final gradientColors = prefs.detailHeaderArtExpanded
+        ? [
+            Colors.transparent,
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.9),
+            fadeTo,
+          ]
+        : [
+            Colors.transparent,
+            fadeTo.withValues(alpha: 0.8),
+            fadeTo,
+          ];
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -584,11 +597,10 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
             gradient: LinearGradient(
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
-              colors: [
-                Colors.transparent,
-                fadeTo.withValues(alpha: 0.8),
-                fadeTo,
-              ],
+              colors: gradientColors,
+              stops: prefs.detailHeaderArtExpanded
+                  ? const [0.0, 0.5, 0.8, 1.0]
+                  : null,
             ),
           ),
         ),
@@ -608,7 +620,9 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
           right: AppConstants.spacingLg,
           bottom: 4,
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: prefs.detailHeaderCenteredTitle
+                ? CrossAxisAlignment.center
+                : CrossAxisAlignment.start,
             children: [
               Text(
                 playlist.name,

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -269,7 +269,10 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                 controller: _scrollController,
               slivers: [
                 SliverAppBar(
-                  expandedHeight: 280,
+                  expandedHeight:
+                      ref.watch(appPreferencesProvider).detailHeaderArtExpanded
+                          ? 360
+                          : 280,
                   pinned: true,
                   backgroundColor: animatedAppBar,
                   leading: AnimatedOpacity(
@@ -599,7 +602,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
               end: Alignment.bottomCenter,
               colors: gradientColors,
               stops: prefs.detailHeaderArtExpanded
-                  ? const [0.0, 0.5, 0.8, 1.0]
+                  ? const [0.0, 0.7, 0.92, 1.0]
                   : null,
             ),
           ),

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -108,7 +108,7 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
-          const SettingsSectionHeader('Album Detail'),
+          const SettingsSectionHeader('Detail Screens'),
           SettingsCard(
             children: [
               ToggleSetting(
@@ -145,6 +145,31 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                   ref
                       .read(appPreferencesProvider.notifier)
                       .setAnimatedAlbumArt(value);
+                },
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.image,
+                title: 'Expanded Header Art',
+                subtitle:
+                    'Show more album art by fading only the bottom of the header',
+                value: appPreferences.detailHeaderArtExpanded,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setDetailHeaderArtExpanded(value);
+                },
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.alignCenter,
+                title: 'Centered Header Title',
+                subtitle: 'Center the title and info in the detail header',
+                value: appPreferences.detailHeaderCenteredTitle,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setDetailHeaderCenteredTitle(value);
                 },
               ),
             ],

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -152,7 +152,7 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                 icon: LucideIcons.image,
                 title: 'Expanded Header Art',
                 subtitle:
-                    'Show more album art by fading only the bottom of the header',
+                    'Show more art by fading only the bottom of the header and lowering body content',
                 value: appPreferences.detailHeaderArtExpanded,
                 onChanged: (value) {
                   ref

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -657,6 +657,22 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setShowMoreArtists(value);
   }
 
+  Future<void> setDetailHeaderArtExpanded(bool value) async {
+    if (state.detailHeaderArtExpanded == value) return;
+    state = state.copyWith(detailHeaderArtExpanded: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setDetailHeaderArtExpanded(value);
+  }
+
+  Future<void> setDetailHeaderCenteredTitle(bool value) async {
+    if (state.detailHeaderCenteredTitle == value) return;
+    state = state.copyWith(detailHeaderCenteredTitle: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setDetailHeaderCenteredTitle(value);
+  }
+
   Future<void> resetOrbitSettings() async {
     state = state.copyWith(
       orbitRadiusRatio: 1.0,

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -92,6 +92,8 @@ class AppPreferences {
   final bool streaksEnabled;
   final bool showMoreFromArtist;
   final bool showMoreArtists;
+  final bool detailHeaderArtExpanded;
+  final bool detailHeaderCenteredTitle;
 
   const AppPreferences({
     this.animationsEnabled = true,
@@ -185,6 +187,8 @@ class AppPreferences {
     this.streaksEnabled = true,
     this.showMoreFromArtist = true,
     this.showMoreArtists = true,
+    this.detailHeaderArtExpanded = true,
+    this.detailHeaderCenteredTitle = false,
   });
 
   AppPreferences copyWith({
@@ -279,6 +283,8 @@ class AppPreferences {
     bool? streaksEnabled,
     bool? showMoreFromArtist,
     bool? showMoreArtists,
+    bool? detailHeaderArtExpanded,
+    bool? detailHeaderCenteredTitle,
   }) {
     return AppPreferences(
       animationsEnabled: animationsEnabled ?? this.animationsEnabled,
@@ -409,6 +415,10 @@ class AppPreferences {
       streaksEnabled: streaksEnabled ?? this.streaksEnabled,
       showMoreFromArtist: showMoreFromArtist ?? this.showMoreFromArtist,
       showMoreArtists: showMoreArtists ?? this.showMoreArtists,
+      detailHeaderArtExpanded:
+          detailHeaderArtExpanded ?? this.detailHeaderArtExpanded,
+      detailHeaderCenteredTitle:
+          detailHeaderCenteredTitle ?? this.detailHeaderCenteredTitle,
     );
   }
 }
@@ -511,6 +521,8 @@ class AppPreferencesService {
   static const _streaksEnabledKey = 'streaks_enabled';
   static const _showMoreFromArtistKey = 'album_show_more_from_artist';
   static const _showMoreArtistsKey = 'album_show_more_artists';
+  static const _detailHeaderArtExpandedKey = 'detail_header_art_expanded';
+  static const _detailHeaderCenteredTitleKey = 'detail_header_centered_title';
   static const _shuffleModeKey = 'playback_shuffle_mode';
   static const _loopModeKey = 'playback_loop_mode';
   static const _advanceListOrderKey = 'playback_advance_list_order';
@@ -644,6 +656,10 @@ class AppPreferencesService {
       streaksEnabled: prefs.getBool(_streaksEnabledKey) ?? true,
       showMoreFromArtist: prefs.getBool(_showMoreFromArtistKey) ?? true,
       showMoreArtists: prefs.getBool(_showMoreArtistsKey) ?? true,
+      detailHeaderArtExpanded:
+          prefs.getBool(_detailHeaderArtExpandedKey) ?? true,
+      detailHeaderCenteredTitle:
+          prefs.getBool(_detailHeaderCenteredTitleKey) ?? false,
     );
   }
 
@@ -1489,6 +1505,26 @@ class AppPreferencesService {
   Future<void> setShowMoreArtists(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_showMoreArtistsKey, value);
+  }
+
+  Future<bool> getDetailHeaderArtExpanded() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_detailHeaderArtExpandedKey) ?? true;
+  }
+
+  Future<void> setDetailHeaderArtExpanded(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_detailHeaderArtExpandedKey, value);
+  }
+
+  Future<bool> getDetailHeaderCenteredTitle() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_detailHeaderCenteredTitleKey) ?? false;
+  }
+
+  Future<void> setDetailHeaderCenteredTitle(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_detailHeaderCenteredTitleKey, value);
   }
 
   Future<void> clearOrbitSettings() async {


### PR DESCRIPTION
# Summary

- Add detail header art and title preferences (expanded art height, centered title, gradient stop adjustments)
- Conditionally expand album, artist, and playlist detail header art and center title
- Add detail screen header settings section to UI customization screen
- Adjust expanded header art heights and gradient stops across all detail screens

# Changes

## Detail Screen Headers

- Add detail header art and title preferences with provider/service (36+16 lines)
- Make gradient and title alignment configurable across album, artist, and playlist detail screens
- Conditionally expand playlist detail header art and center title
- Adjust expanded header art heights and gradient stops
- Add detail screen header settings (26 lines) to UI customization screen

## Files Changed

- `lib/services/app_preferences_service.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/features/albums/screens/album_detail_screen.dart`
- `lib/features/artists/screens/artist_detail_screen.dart`
- `lib/features/playlists/screens/playlist_detail_screen.dart`
- `lib/features/settings/screens/ui_customization_settings_screen.dart`