### PR TITLE
Add configurable widget text scaling with font size preferences

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/widgets/CompactWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/widgets/CompactWidgetProvider.kt
@@ -31,6 +31,7 @@ class CompactWidgetProvider : AppWidgetProvider() {
         val showArt = WidgetPrefs.getCompactShowAlbumArt(context)
         val showArtist = WidgetPrefs.getCompactShowArtist(context)
         val accentColor = WidgetPrefs.getCompactAccentColor(context)
+        val textScale = WidgetPrefs.getCompactTextScale(context)
 
         val dm = context.resources.displayMetrics
 
@@ -44,12 +45,14 @@ class CompactWidgetProvider : AppWidgetProvider() {
             val widgetWidthPx =
                 if (widgetWidthDp > 0) (widgetWidthDp * dm.density).toInt() else dm.widthPixels
             val textWidthPx = (widgetWidthPx - MARGIN_PAD_DP * dm.density).toInt().coerceAtLeast(100)
+            val titleSp = WidgetPrefs.scaledSp(15, widgetWidthDp, 200f, textScale)
+            val artistSp = WidgetPrefs.scaledSp(12, widgetWidthDp, 200f, textScale)
 
             if (hasSong) {
                 views.setImageViewBitmap(
                     R.id.compact_title,
                     WidgetTextRenderer.createTextBitmap(
-                        context, title, R.font.product_sans_bold, 15, Color.WHITE,
+                        context, title, R.font.product_sans_bold, titleSp, Color.WHITE,
                         textWidthPx, Layout.Alignment.ALIGN_CENTER,
                     ),
                 )
@@ -59,8 +62,8 @@ class CompactWidgetProvider : AppWidgetProvider() {
                     views.setImageViewBitmap(
                         R.id.compact_artist,
                         WidgetTextRenderer.createTextBitmap(
-                            context, artist, R.font.product_sans_regular, 12, accentColor,
-                            textWidthPx, Layout.Alignment.ALIGN_CENTER,
+                        context, artist, R.font.product_sans_regular, artistSp, accentColor,
+                        textWidthPx, Layout.Alignment.ALIGN_CENTER,
                         ),
                     )
                     views.setContentDescription(R.id.compact_artist, artist)
@@ -85,7 +88,7 @@ class CompactWidgetProvider : AppWidgetProvider() {
                 views.setImageViewBitmap(
                     R.id.compact_title,
                     WidgetTextRenderer.createTextBitmap(
-                        context, tapText, R.font.product_sans_bold, 15, Color.WHITE,
+                        context, tapText, R.font.product_sans_bold, titleSp, Color.WHITE,
                         textWidthPx, Layout.Alignment.ALIGN_CENTER,
                     ),
                 )

--- a/android/app/src/main/kotlin/com/mossapps/flick/widgets/FlagshipWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/widgets/FlagshipWidgetProvider.kt
@@ -33,6 +33,7 @@ class FlagshipWidgetProvider : AppWidgetProvider() {
             val artPath = prefs.getString(WidgetPrefs.KEY_ALBUM_ART, "") ?: ""
             val showArtist = WidgetPrefs.getFlagshipShowArtist(context)
             val accentColor = WidgetPrefs.getFlagshipAccentColor(context)
+            val textScale = WidgetPrefs.getFlagshipTextScale(context)
             val isShuffle = prefs.getBoolean(WidgetPrefs.KEY_IS_SHUFFLE, false)
             val loopMode = prefs.getInt(WidgetPrefs.KEY_LOOP_MODE, 0)
             Log.d(TAG, "hasSong=$hasSong, isPlaying=$isPlaying, title=$title, idsCount=${appWidgetIds.size}")
@@ -48,6 +49,8 @@ class FlagshipWidgetProvider : AppWidgetProvider() {
                 val widgetWidthDp = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, 0)
                 val widgetWidthPx = if (widgetWidthDp > 0) (widgetWidthDp * dm.density).toInt() else dm.widthPixels
                 val textWidthPx = (widgetWidthPx - marginPadDp * dm.density).toInt().coerceAtLeast(100)
+                val titleSp = WidgetPrefs.scaledSp(15, widgetWidthDp, 400f, textScale)
+                val artistSp = WidgetPrefs.scaledSp(12, widgetWidthDp, 400f, textScale)
 
                 if (hasSong) {
                     val art = WidgetArtLoader.load(artPath, ART_MAX_PX)
@@ -64,7 +67,7 @@ class FlagshipWidgetProvider : AppWidgetProvider() {
                             context,
                             title,
                             R.font.product_sans_bold,
-                            15,
+                            titleSp,
                             Color.WHITE,
                             textWidthPx,
                             Layout.Alignment.ALIGN_CENTER,
@@ -79,7 +82,7 @@ class FlagshipWidgetProvider : AppWidgetProvider() {
                                 context,
                                 artist,
                                 R.font.product_sans_regular,
-                                12,
+                                artistSp,
                                 accentColor,
                                 textWidthPx,
                                 Layout.Alignment.ALIGN_CENTER,
@@ -173,7 +176,7 @@ class FlagshipWidgetProvider : AppWidgetProvider() {
                             context,
                             tapText,
                             R.font.product_sans_bold,
-                            15,
+                            titleSp,
                             Color.WHITE,
                             textWidthPx,
                             Layout.Alignment.ALIGN_CENTER,

--- a/android/app/src/main/kotlin/com/mossapps/flick/widgets/MiniPlayerWidgetProvider.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/widgets/MiniPlayerWidgetProvider.kt
@@ -34,6 +34,7 @@ class MiniPlayerWidgetProvider : AppWidgetProvider() {
         val showArt = WidgetPrefs.getShowAlbumArt(context)
         val showArtist = WidgetPrefs.getShowArtist(context)
         val accentColor = WidgetPrefs.getAccentColor(context)
+        val textScale = WidgetPrefs.getMiniTextScale(context)
 
         val dm = context.resources.displayMetrics
 
@@ -61,12 +62,14 @@ class MiniPlayerWidgetProvider : AppWidgetProvider() {
             val widgetWidthPx =
                 if (widgetWidthDp > 0) (widgetWidthDp * dm.density).toInt() else dm.widthPixels
             val textWidthPx = (widgetWidthPx - CHROME_DP * dm.density).toInt().coerceAtLeast(80)
+            val titleSp = WidgetPrefs.scaledSp(13, widgetWidthDp, 360f, textScale)
+            val artistSp = WidgetPrefs.scaledSp(11, widgetWidthDp, 360f, textScale)
 
             if (hasSong) {
                 views.setImageViewBitmap(
                     R.id.widget_title,
                     WidgetTextRenderer.createTextBitmap(
-                        context, title, R.font.product_sans_bold, 13, Color.WHITE, textWidthPx,
+                        context, title, R.font.product_sans_bold, titleSp, Color.WHITE, textWidthPx,
                     ),
                 )
                 views.setContentDescription(R.id.widget_title, title)
@@ -75,7 +78,7 @@ class MiniPlayerWidgetProvider : AppWidgetProvider() {
                     views.setImageViewBitmap(
                         R.id.widget_artist,
                         WidgetTextRenderer.createTextBitmap(
-                            context, artist, R.font.product_sans_regular, 11, accentColor, textWidthPx,
+                            context, artist, R.font.product_sans_regular, artistSp, accentColor, textWidthPx,
                         ),
                     )
                     views.setContentDescription(R.id.widget_artist, artist)
@@ -121,7 +124,7 @@ class MiniPlayerWidgetProvider : AppWidgetProvider() {
                 views.setImageViewBitmap(
                     R.id.widget_title,
                     WidgetTextRenderer.createTextBitmap(
-                        context, tapText, R.font.product_sans_bold, 13, Color.WHITE, textWidthPx,
+                        context, tapText, R.font.product_sans_bold, titleSp, Color.WHITE, textWidthPx,
                     ),
                 )
                 views.setContentDescription(R.id.widget_title, tapText)

--- a/android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt
@@ -6,6 +6,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.SharedPreferences
 import com.mossapps.flick.R
+import kotlin.math.roundToInt
 
 internal object WidgetPrefs {
     private const val PREFS_NAME = "HomeWidgetPreferences"
@@ -23,6 +24,7 @@ internal object WidgetPrefs {
     const val KEY_SHOW_ALBUM_ART = "flick_widget_show_album_art"
     const val KEY_SHOW_ARTIST = "flick_widget_show_artist"
     const val KEY_ACCENT_COLOR = "flick_widget_accent_color"
+    const val KEY_TEXT_SCALE = "flick_widget_text_scale"
     const val KEY_POSITION_MS = "flick_widget_position_ms"
     const val KEY_DURATION_MS = "flick_widget_duration_ms"
     const val KEY_QUEUE_COUNT = "flick_widget_queue_count"
@@ -30,6 +32,18 @@ internal object WidgetPrefs {
     private val BG_OPACITY_MAP = mapOf(
         0 to 0x00, 1 to 0x40, 2 to 0x80, 3 to 0xC0, 4 to 0xFF
     )
+
+    // home_widget encodes Dart doubles as Long bits with a companion flag;
+    // decode that here instead of a raw getFloat which would ClassCast.
+    private const val DOUBLE_PREFIX = "home_widget.double."
+    private fun getWidgetDouble(context: Context, key: String, default: Float): Float {
+        val prefs = get(context)
+        return if (prefs.getBoolean("$DOUBLE_PREFIX$key", false)) {
+            Double.fromBits(prefs.getLong(key, default.toDouble().toBits())).toFloat()
+        } else {
+            default
+        }
+    }
 
     fun get(context: Context): SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -63,6 +77,16 @@ internal object WidgetPrefs {
 
     fun getAccentName(context: Context): String =
         get(context).getString(KEY_ACCENT_COLOR, "white") ?: "white"
+
+    fun getMiniTextScale(context: Context): Float =
+        getWidgetDouble(context, KEY_TEXT_SCALE, 1.0f)
+
+    // ponytail: clamp bounds keep text sane across dp sizes; baseline per-widget
+    fun scaledSp(baseSp: Int, widgetWidthDp: Int, baselineDp: Float, manualScale: Float): Int {
+        val widthDp = if (widgetWidthDp > 0) widgetWidthDp else baselineDp.toInt()
+        val auto = (widthDp / baselineDp).coerceIn(0.85f, 1.3f)
+        return (baseSp * auto * manualScale).roundToInt().coerceIn(9, 22)
+    }
 
     fun getAccentColor(context: Context): Int {
         return when (getAccentName(context)) {
@@ -99,12 +123,16 @@ internal object WidgetPrefs {
 
     private const val KEY_FLAGSHIP_ACCENT = "flick_widget_flagship_accent"
     private const val KEY_FLAGSHIP_SHOW_ARTIST = "flick_widget_flagship_show_artist"
+    private const val KEY_FLAGSHIP_TEXT_SCALE = "flick_widget_flagship_text_scale"
 
     fun getFlagshipShowArtist(context: Context): Boolean =
         get(context).getBoolean(KEY_FLAGSHIP_SHOW_ARTIST, true)
 
     fun getFlagshipAccentName(context: Context): String =
         get(context).getString(KEY_FLAGSHIP_ACCENT, "white") ?: "white"
+
+    fun getFlagshipTextScale(context: Context): Float =
+        getWidgetDouble(context, KEY_FLAGSHIP_TEXT_SCALE, 1.0f)
 
     fun getFlagshipAccentColor(context: Context): Int {
         return when (getFlagshipAccentName(context)) {
@@ -122,6 +150,7 @@ internal object WidgetPrefs {
     private const val KEY_COMPACT_SHOW_ALBUM_ART = "flick_widget_compact_show_album_art"
     private const val KEY_COMPACT_SHOW_ARTIST = "flick_widget_compact_show_artist"
     private const val KEY_COMPACT_ACCENT = "flick_widget_compact_accent"
+    private const val KEY_COMPACT_TEXT_SCALE = "flick_widget_compact_text_scale"
 
     fun getCompactBgOpacityAlpha(context: Context): Int {
         val level = get(context).getInt(KEY_COMPACT_BG_OPACITY, 3)
@@ -147,6 +176,9 @@ internal object WidgetPrefs {
 
     fun getCompactAccentName(context: Context): String =
         get(context).getString(KEY_COMPACT_ACCENT, "white") ?: "white"
+
+    fun getCompactTextScale(context: Context): Float =
+        getWidgetDouble(context, KEY_COMPACT_TEXT_SCALE, 1.0f)
 
     fun getCompactAccentColor(context: Context): Int {
         return when (getCompactAccentName(context)) {

--- a/lib/features/settings/screens/widget_settings_screen.dart
+++ b/lib/features/settings/screens/widget_settings_screen.dart
@@ -226,6 +226,32 @@ class _MiniPlayerTab extends ConsumerWidget {
           ],
         ),
         const SizedBox(height: AppConstants.spacingLg),
+        const SettingsSectionHeader('Text Size'),
+        SettingsCard(
+          children: [
+            SliderSetting(
+              icon: LucideIcons.type,
+              title: 'Font Scale',
+              subtitle: 'Scales with widget size automatically',
+              value: prefs.widgetTextScale,
+              displayValue: '${(prefs.widgetTextScale * 100).round()}%',
+              min: 0.8,
+              max: 1.5,
+              divisions: 14,
+              onChanged: (v) => _updateTextScale(ref, v),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _WidgetTextPreview(
+          titleBaseSp: 13,
+          artistBaseSp: 11,
+          baselineDp: 360,
+          manualScale: prefs.widgetTextScale,
+          accentColor: _resolveAccentColor(prefs.widgetAccentColor),
+          centered: false,
+        ),
+        const SizedBox(height: AppConstants.spacingLg),
         const SettingsSectionHeader('Accent Color'),
         SettingsCard(
           children: [
@@ -289,6 +315,14 @@ class _MiniPlayerTab extends ConsumerWidget {
       prefs.copyWith(widgetAccentColor: value),
     );
   }
+
+  void _updateTextScale(WidgetRef ref, double value) {
+    ref.read(appPreferencesProvider.notifier).setWidgetTextScale(value);
+    final prefs = ref.read(appPreferencesProvider);
+    WidgetSyncService.instance.pushCustomization(
+      prefs.copyWith(widgetTextScale: value),
+    );
+  }
 }
 
 class _FlagshipTab extends ConsumerWidget {
@@ -318,6 +352,33 @@ class _FlagshipTab extends ConsumerWidget {
               },
             ),
           ],
+        ),
+        const SizedBox(height: AppConstants.spacingLg),
+        const SettingsSectionHeader('Text Size'),
+        SettingsCard(
+          children: [
+            SliderSetting(
+              icon: LucideIcons.type,
+              title: 'Font Scale',
+              subtitle: 'Scales with widget size automatically',
+              value: prefs.widgetFlagshipTextScale,
+              displayValue:
+                  '${(prefs.widgetFlagshipTextScale * 100).round()}%',
+              min: 0.8,
+              max: 1.5,
+              divisions: 14,
+              onChanged: (v) => _updateFlagshipTextScale(ref, v),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _WidgetTextPreview(
+          titleBaseSp: 15,
+          artistBaseSp: 12,
+          baselineDp: 400,
+          manualScale: prefs.widgetFlagshipTextScale,
+          accentColor: _resolveAccentColor(prefs.widgetFlagshipAccent),
+          centered: true,
         ),
         const SizedBox(height: AppConstants.spacingLg),
         const SettingsSectionHeader('Accent Color'),
@@ -373,6 +434,14 @@ class _FlagshipTab extends ConsumerWidget {
     final prefs = ref.read(appPreferencesProvider);
     WidgetSyncService.instance.pushCustomization(
       prefs.copyWith(widgetFlagshipAccent: value),
+    );
+  }
+
+  void _updateFlagshipTextScale(WidgetRef ref, double value) {
+    ref.read(appPreferencesProvider.notifier).setWidgetFlagshipTextScale(value);
+    final prefs = ref.read(appPreferencesProvider);
+    WidgetSyncService.instance.pushCustomization(
+      prefs.copyWith(widgetFlagshipTextScale: value),
     );
   }
 }
@@ -461,6 +530,33 @@ class _CompactTab extends ConsumerWidget {
           ],
         ),
         const SizedBox(height: AppConstants.spacingLg),
+        const SettingsSectionHeader('Text Size'),
+        SettingsCard(
+          children: [
+            SliderSetting(
+              icon: LucideIcons.type,
+              title: 'Font Scale',
+              subtitle: 'Scales with widget size automatically',
+              value: prefs.widgetCompactTextScale,
+              displayValue:
+                  '${(prefs.widgetCompactTextScale * 100).round()}%',
+              min: 0.8,
+              max: 1.5,
+              divisions: 14,
+              onChanged: (v) => _updateCompactTextScale(ref, v),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _WidgetTextPreview(
+          titleBaseSp: 15,
+          artistBaseSp: 12,
+          baselineDp: 200,
+          manualScale: prefs.widgetCompactTextScale,
+          accentColor: _resolveAccentColor(prefs.widgetCompactAccent),
+          centered: true,
+        ),
+        const SizedBox(height: AppConstants.spacingLg),
         const SettingsSectionHeader('Accent Color'),
         SettingsCard(
           children: [
@@ -526,6 +622,14 @@ class _CompactTab extends ConsumerWidget {
       prefs.copyWith(widgetCompactAccent: value),
     );
   }
+
+  void _updateCompactTextScale(WidgetRef ref, double value) {
+    ref.read(appPreferencesProvider.notifier).setWidgetCompactTextScale(value);
+    final prefs = ref.read(appPreferencesProvider);
+    WidgetSyncService.instance.pushCustomization(
+      prefs.copyWith(widgetCompactTextScale: value),
+    );
+  }
 }
 
 class _OpacityOption extends StatelessWidget {
@@ -589,6 +693,157 @@ class _OpacityOption extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+Color _resolveAccentColor(String name) {
+  return switch (name) {
+    'amber' => const Color(0xFFFFB300),
+    'blue' => const Color(0xFF64B5F6),
+    'green' => const Color(0xFF81C784),
+    'purple' => const Color(0xFFCE93D8),
+    _ => Colors.white,
+  };
+}
+
+class _WidgetTextPreview extends StatefulWidget {
+  const _WidgetTextPreview({
+    required this.titleBaseSp,
+    required this.artistBaseSp,
+    required this.baselineDp,
+    required this.manualScale,
+    required this.accentColor,
+    required this.centered,
+  });
+
+  final int titleBaseSp;
+  final int artistBaseSp;
+  final double baselineDp;
+  final double manualScale;
+  final Color accentColor;
+  final bool centered;
+
+  @override
+  State<_WidgetTextPreview> createState() => _WidgetTextPreviewState();
+}
+
+class _WidgetTextPreviewState extends State<_WidgetTextPreview> {
+  int _sizeIndex = 1;
+
+  static const _autoFactors = [0.85, 1.0, 1.3];
+  static const _sizeLabels = ['S', 'M', 'L'];
+
+  @override
+  Widget build(BuildContext context) {
+    final auto = _autoFactors[_sizeIndex];
+    double clampSp(int base) =>
+        (base * auto * widget.manualScale).round().clamp(9, 22).toDouble();
+    final titleSp = clampSp(widget.titleBaseSp);
+    final artistSp = clampSp(widget.artistBaseSp);
+    final cross = widget.centered
+        ? CrossAxisAlignment.center
+        : CrossAxisAlignment.start;
+
+    return SettingsCard(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppConstants.spacingLg,
+            AppConstants.spacingMd,
+            AppConstants.spacingLg,
+            AppConstants.spacingSm,
+          ),
+          child: Row(
+            children: [
+              Text(
+                'Preview',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                    ),
+              ),
+              const Spacer(),
+              ...List.generate(3, (i) {
+                final selected = i == _sizeIndex;
+                return Padding(
+                  padding: const EdgeInsets.only(left: AppConstants.spacingXs),
+                  child: GestureDetector(
+                    onTap: () => setState(() => _sizeIndex = i),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: selected
+                            ? AppColors.surface.withValues(alpha: 0.8)
+                            : Colors.transparent,
+                        borderRadius:
+                            BorderRadius.circular(AppConstants.radiusSm),
+                        border: selected
+                            ? Border.all(color: AppColors.glassBorder)
+                            : null,
+                      ),
+                      child: Text(
+                        _sizeLabels[i],
+                        style: TextStyle(
+                          fontFamily: 'ProductSans',
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: selected
+                              ? context.adaptiveTextPrimary
+                              : context.adaptiveTextTertiary,
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.fromLTRB(
+            AppConstants.spacingLg,
+            0,
+            AppConstants.spacingLg,
+            AppConstants.spacingLg,
+          ),
+          padding: const EdgeInsets.all(AppConstants.spacingLg),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.75),
+            borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+          ),
+          child: Column(
+            crossAxisAlignment: cross,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Midnight City Dreams',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontWeight: FontWeight.w700,
+                  fontSize: titleSp,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                'Neon Skyline',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: artistSp,
+                  color: widget.accentColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -347,6 +347,28 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setWidgetCompactAccent(value);
   }
 
+  Future<void> setWidgetTextScale(double value) async {
+    if (state.widgetTextScale == value) return;
+    state = state.copyWith(widgetTextScale: value);
+    await ref.read(appPreferencesServiceProvider).setWidgetTextScale(value);
+  }
+
+  Future<void> setWidgetFlagshipTextScale(double value) async {
+    if (state.widgetFlagshipTextScale == value) return;
+    state = state.copyWith(widgetFlagshipTextScale: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setWidgetFlagshipTextScale(value);
+  }
+
+  Future<void> setWidgetCompactTextScale(double value) async {
+    if (state.widgetCompactTextScale == value) return;
+    state = state.copyWith(widgetCompactTextScale: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setWidgetCompactTextScale(value);
+  }
+
   Future<void> setLyricsMatchAudioFilename(bool value) async {
     if (state.lyricsMatchAudioFilename == value) return;
     state = state.copyWith(lyricsMatchAudioFilename: value);

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -46,6 +46,9 @@ class AppPreferences {
   final bool widgetCompactShowAlbumArt;
   final bool widgetCompactShowArtist;
   final String widgetCompactAccent;
+  final double widgetTextScale;
+  final double widgetFlagshipTextScale;
+  final double widgetCompactTextScale;
   final bool lyricsMatchAudioFilename;
   final String leftActionButton;
   final String rightActionButton;
@@ -141,6 +144,9 @@ class AppPreferences {
     this.widgetCompactShowAlbumArt = true,
     this.widgetCompactShowArtist = true,
     this.widgetCompactAccent = 'white',
+    this.widgetTextScale = 1.0,
+    this.widgetFlagshipTextScale = 1.0,
+    this.widgetCompactTextScale = 1.0,
     this.lyricsMatchAudioFilename = false,
     this.leftActionButton = 'lyrics',
     this.rightActionButton = 'favorites',
@@ -237,6 +243,9 @@ class AppPreferences {
     bool? widgetCompactShowAlbumArt,
     bool? widgetCompactShowArtist,
     String? widgetCompactAccent,
+    double? widgetTextScale,
+    double? widgetFlagshipTextScale,
+    double? widgetCompactTextScale,
     bool? lyricsMatchAudioFilename,
     String? leftActionButton,
     String? rightActionButton,
@@ -349,6 +358,11 @@ class AppPreferences {
       widgetCompactShowArtist:
           widgetCompactShowArtist ?? this.widgetCompactShowArtist,
       widgetCompactAccent: widgetCompactAccent ?? this.widgetCompactAccent,
+      widgetTextScale: widgetTextScale ?? this.widgetTextScale,
+      widgetFlagshipTextScale:
+          widgetFlagshipTextScale ?? this.widgetFlagshipTextScale,
+      widgetCompactTextScale:
+          widgetCompactTextScale ?? this.widgetCompactTextScale,
       lyricsMatchAudioFilename:
           lyricsMatchAudioFilename ?? this.lyricsMatchAudioFilename,
       leftActionButton: leftActionButton ?? this.leftActionButton,
@@ -469,6 +483,9 @@ class AppPreferencesService {
   static const _widgetCompactShowAlbumArtKey = 'widget_compact_show_album_art';
   static const _widgetCompactShowArtistKey = 'widget_compact_show_artist';
   static const _widgetCompactAccentKey = 'widget_compact_accent';
+  static const _widgetTextScaleKey = 'widget_text_scale';
+  static const _widgetFlagshipTextScaleKey = 'widget_flagship_text_scale';
+  static const _widgetCompactTextScaleKey = 'widget_compact_text_scale';
   static const _lyricsMatchAudioFilenameKey = 'lyrics_match_audio_filename';
   static const _leftActionButtonKey = 'left_action_button';
   static const _rightActionButtonKey = 'right_action_button';
@@ -593,6 +610,11 @@ class AppPreferencesService {
           prefs.getBool(_widgetCompactShowArtistKey) ?? true,
       widgetCompactAccent:
           prefs.getString(_widgetCompactAccentKey) ?? 'white',
+      widgetTextScale: prefs.getDouble(_widgetTextScaleKey) ?? 1.0,
+      widgetFlagshipTextScale:
+          prefs.getDouble(_widgetFlagshipTextScaleKey) ?? 1.0,
+      widgetCompactTextScale:
+          prefs.getDouble(_widgetCompactTextScaleKey) ?? 1.0,
       lyricsMatchAudioFilename:
           prefs.getBool(_lyricsMatchAudioFilenameKey) ?? false,
       leftActionButton: prefs.getString(_leftActionButtonKey) ?? 'lyrics',
@@ -1061,6 +1083,21 @@ class AppPreferencesService {
   Future<void> setWidgetCompactAccent(String value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_widgetCompactAccentKey, value);
+  }
+
+  Future<void> setWidgetTextScale(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_widgetTextScaleKey, value);
+  }
+
+  Future<void> setWidgetFlagshipTextScale(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_widgetFlagshipTextScaleKey, value);
+  }
+
+  Future<void> setWidgetCompactTextScale(double value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_widgetCompactTextScaleKey, value);
   }
 
   Future<bool> getLyricsMatchAudioFilename() async {

--- a/lib/services/widget_sync_service.dart
+++ b/lib/services/widget_sync_service.dart
@@ -25,6 +25,9 @@ class WidgetSyncService {
   static const String keyCompactShowAlbumArt = 'flick_widget_compact_show_album_art';
   static const String keyCompactShowArtist = 'flick_widget_compact_show_artist';
   static const String keyCompactAccent = 'flick_widget_compact_accent';
+  static const String keyMiniTextScale = 'flick_widget_text_scale';
+  static const String keyFlagshipTextScale = 'flick_widget_flagship_text_scale';
+  static const String keyCompactTextScale = 'flick_widget_compact_text_scale';
 
   static const String keySongId = 'flick_widget_song_id';
   static const String keyTitle = 'flick_widget_title';
@@ -156,6 +159,10 @@ class WidgetSyncService {
         keyAccentColor,
         prefs.widgetAccentColor,
       );
+      await HomeWidget.saveWidgetData<double>(
+        keyMiniTextScale,
+        prefs.widgetTextScale,
+      );
 
       // Flagship widget customization
       await HomeWidget.saveWidgetData<String>(
@@ -165,6 +172,10 @@ class WidgetSyncService {
       await HomeWidget.saveWidgetData<bool>(
         keyFlagshipShowArtist,
         prefs.widgetFlagshipShowArtist,
+      );
+      await HomeWidget.saveWidgetData<double>(
+        keyFlagshipTextScale,
+        prefs.widgetFlagshipTextScale,
       );
 
       // Compact widget customization
@@ -183,6 +194,10 @@ class WidgetSyncService {
       await HomeWidget.saveWidgetData<String>(
         keyCompactAccent,
         prefs.widgetCompactAccent,
+      );
+      await HomeWidget.saveWidgetData<double>(
+        keyCompactTextScale,
+        prefs.widgetCompactTextScale,
       );
 
       await _updateAll();


### PR DESCRIPTION
# Summary

- Add text scale preferences for mini, flagship, and compact widgets
- Add font scale settings to widget customization screen (255 lines)
- Scale widget text based on width preference in `MiniPlayerWidgetProvider`
- Use text scale preference for widget font sizing across all widget providers
- Persist text scale values via widget sync service

# Changes

## Widget Text Scaling

- Add text scale preferences for mini, flagship, and compact widgets (37 lines service, 22 lines provider)
- Add widget text scale setters to preferences provider
- Add text scale support to `WidgetPrefs.kt` (32 lines)
- Add font scale settings to widget customization screen (255 lines)
- Scale mini-player text based on widget width preference
- Use text scale preference for widget font sizing in `MiniPlayerWidgetProvider` and `FlagshipWidgetProvider`
- Persist text scale for all widget types via widget sync service

## Files Changed

- `lib/services/app_preferences_service.dart`
- `lib/services/widget_sync_service.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/features/settings/screens/widget_settings_screen.dart`
- `android/app/src/main/kotlin/com/mossapps/flick/widgets/WidgetPrefs.kt`
- `android/app/src/main/kotlin/com/mossapps/flick/widgets/MiniPlayerWidgetProvider.kt`
- `android/app/src/main/kotlin/com/mossapps/flick/widgets/FlagshipWidgetProvider.kt`