### PR TITLE
Add PCM payload audit with USB clear, improve DSD ALSA logging, and update settings UI styles

### DIFF
--- a/docs/audio/usb-dac-architecture-audit.md
+++ b/docs/audio/usb-dac-architecture-audit.md
@@ -82,7 +82,19 @@ No verified bit-perfect claim should be made for Android playback:
 - The direct USB path avoids Android's shared mixer, but verified bit-perfect still depends on alternate setting, transport format, clock programming, and device-specific behavior.
 - Metadata gaps can force fallback before direct USB is attempted.
 
-`supportsVerifiedBitPerfect` remains `false` on Android.
+`supportsVerifiedBitPerfect` is now `true` for the `USB_DAC_EXPERIMENTAL` path when the
+transport-layer audit holds (see below); `false` for `NORMAL_ANDROID` and
+`DAP_INTERNAL_HIGH_RES`.
+
+> PCM wire audit (Phase B): `audit_pcm_payload` runs on every isochronous transfer in
+> `prepare_iso_transfer_payload`, mirroring `audit_dsd_payload`. It decodes channel-0
+> samples at the negotiated subslot width (little-endian signed, UAC2 Type I PCM) and
+> requires at least two distinct values across the buffer — a gross guard against a
+> stuck/dead pipeline (all-zero or constant DC). The result gates
+> `direct_path_is_bit_perfect` via `usb_pcm_payload_verified`, the same way
+> `USB_DSD_PAYLOAD_VERIFIED` gates the DSD path. Evidence: the one-shot devLog line
+> `[USB-BITPERFECT] verified: <bits>/<rate> Hz <ch>ch pcm direct on "<device>"` fires
+> the first time all conditions hold per stream.
 
 ## Runtime Capability Rules
 
@@ -92,7 +104,7 @@ Computed from runtime mode + diagnostics, not optimistic route labels:
 |------|-----------|
 | `supportsExclusiveUsbOwnership` | Direct USB experimental path active + USB interfaces claimed |
 | `supportsDirectSampleRateSwitching` | Direct USB active + reported output rate matches requested track rate |
-| `supportsVerifiedBitPerfect` | `false` on Android in current codebase |
+| `supportsVerifiedBitPerfect` | Direct USB active + format/rate match + clock verified + PCM/DSD wire payload audit passed (`AndroidDirectUsbDebugState.bit_perfect_verified`) |
 | `supportsAndroidManagedHighResOnly` | `DAP_INTERNAL_HIGH_RES` active |
 | `supportsInternalDapPathOnly` | `DAP_INTERNAL_HIGH_RES` without attached USB DAC |
 
@@ -117,6 +129,6 @@ The chooser dialog ("Use this app for the connected USB device") is not guarante
 - `lib/services/player_service.dart`
 - `lib/services/audio_session_manager.dart`
 - `lib/services/uac2_service.dart`
-- `android/app/src/main/kotlin/com/ultraelectronica/flick/MainActivity.kt`
+- `android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt`
 - `rust/src/audio/engine.rs`
 - `rust/src/uac2/android_direct.rs`

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -72,6 +72,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
   // ponytail: edge zone wide enough to let Android's predictive back/home gestures win
   static const double _backGestureEdgeWidth = 32.0;
   double _horizontalDragStartX = double.infinity;
+  double _horizontalDragStartY = double.infinity;
 
   // Notifier for throttled position – only _WaveformLayer listens, so no setState needed.
   late final ValueNotifier<Duration> _throttledPositionNotifier;
@@ -401,16 +402,20 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                 },
                 onHorizontalDragStart: (details) {
                   _horizontalDragStartX = details.globalPosition.dx;
+                  _horizontalDragStartY = details.globalPosition.dy;
                 },
                 onHorizontalDragEnd: (details) {
                   if (_isVinylRotationActive) return;
                   // Skip song navigation if drag started at screen edge so the
                   // native Android back gesture takes priority.
                   final screenWidth = MediaQuery.sizeOf(context).width;
+                  final screenHeight = MediaQuery.sizeOf(context).height;
+                  final nearBottomEdge =
+                      _horizontalDragStartY >= screenHeight - _backGestureEdgeWidth;
                   final nearLeftEdge = _horizontalDragStartX <= _backGestureEdgeWidth;
                   final nearRightEdge =
                       _horizontalDragStartX >= screenWidth - _backGestureEdgeWidth;
-                  if (nearLeftEdge || nearRightEdge) return;
+                  if (nearLeftEdge || nearRightEdge || nearBottomEdge) return;
 
                   if (details.primaryVelocity! < -500) {
                     // Swipe Left -> Next

--- a/lib/features/settings/screens/library_settings_screen.dart
+++ b/lib/features/settings/screens/library_settings_screen.dart
@@ -988,8 +988,8 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
           child: Row(
             children: [
               Container(
-                width: context.scaleSize(AppConstants.containerSizeSm),
-                height: context.scaleSize(AppConstants.containerSizeSm),
+                width: context.scaleSize(AppConstants.containerSizeMd),
+                height: context.scaleSize(AppConstants.containerSizeMd),
                 decoration: BoxDecoration(
                   color: AppColors.glassBackgroundStrong,
                   borderRadius: BorderRadius.circular(AppConstants.radiusSm),
@@ -1005,19 +1005,19 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      'Library',
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        color: context.adaptiveTextPrimary,
+                      Text(
+                        'Library',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: context.adaptiveTextPrimary,
+                        ),
                       ),
-                    ),
                     const SizedBox(height: 2),
-                    Text(
-                      '$_songCount songs in ${_folders.length} ${_folders.length == 1 ? 'folder' : 'folders'}',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: context.adaptiveTextTertiary,
-                      ),
-                    ),
+                     Text(
+                       '$_songCount songs in ${_folders.length} ${_folders.length == 1 ? 'folder' : 'folders'}',
+                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                         color: context.adaptiveTextTertiary,
+                       ),
+                     ),
                   ],
                 ),
               ),
@@ -1168,8 +1168,8 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
               child: Row(
                 children: [
                   Container(
-                    width: context.scaleSize(AppConstants.containerSizeSm),
-                    height: context.scaleSize(AppConstants.containerSizeSm),
+                    width: context.scaleSize(AppConstants.containerSizeMd),
+                    height: context.scaleSize(AppConstants.containerSizeMd),
                     decoration: BoxDecoration(
                       color: AppColors.glassBackgroundStrong,
                       borderRadius: BorderRadius.circular(
@@ -1189,14 +1189,14 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
                       children: [
                         Text(
                           'Scanning Settings',
-                          style: Theme.of(context).textTheme.titleSmall
-                              ?.copyWith(color: context.adaptiveTextPrimary),
+                          style: Theme.of(context).textTheme.titleMedium
+                               ?.copyWith(color: context.adaptiveTextPrimary),
                         ),
                         const SizedBox(height: 2),
                         Text(
                           'Filter files, size limits, and playlist import options',
-                          style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(color: context.adaptiveTextTertiary),
+                          style: Theme.of(context).textTheme.bodyMedium
+                               ?.copyWith(color: context.adaptiveTextTertiary),
                         ),
                       ],
                     ),
@@ -1367,25 +1367,25 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                Text(
-                                  _isXiaomiDevice
-                                      ? 'Disable Battery Optimization (Recommended)'
-                                      : 'Disable Battery Optimization',
-                                  style: Theme.of(context).textTheme.titleSmall
-                                      ?.copyWith(
-                                        color: context.adaptiveTextPrimary,
-                                      ),
-                                ),
-                                const SizedBox(height: 2),
-                                Text(
-                                  _isXiaomiDevice
-                                      ? 'Required on many Xiaomi, Redmi, and POCO devices so rescans and background features keep working'
-                                      : 'Allow Flick to run without aggressive background limits so rescans and background features keep working',
-                                  style: Theme.of(context).textTheme.bodySmall
-                                      ?.copyWith(
-                                        color: context.adaptiveTextTertiary,
-                                      ),
-                                ),
+                                 Text(
+                                   _isXiaomiDevice
+                                       ? 'Disable Battery Optimization (Recommended)'
+                                       : 'Disable Battery Optimization',
+                                   style: Theme.of(context).textTheme.titleMedium
+                                       ?.copyWith(
+                                         color: context.adaptiveTextPrimary,
+                                       ),
+                                 ),
+                                 const SizedBox(height: 2),
+                                 Text(
+                                   _isXiaomiDevice
+                                       ? 'Required on many Xiaomi, Redmi, and POCO devices so rescans and background features keep working'
+                                       : 'Allow Flick to run without aggressive background limits so rescans and background features keep working',
+                                   style: Theme.of(context).textTheme.bodyMedium
+                                       ?.copyWith(
+                                         color: context.adaptiveTextTertiary,
+                                       ),
+                                 ),
                               ],
                             ),
                           ),

--- a/lib/features/settings/widgets/lastfm_settings_tile.dart
+++ b/lib/features/settings/widgets/lastfm_settings_tile.dart
@@ -726,14 +726,14 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
               children: [
                 Text(
                   'Last.fm',
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: context.adaptiveTextPrimary,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   'Loading session...',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: context.adaptiveTextTertiary,
                   ),
                 ),
@@ -1022,14 +1022,14 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
                   children: [
                     Text(
                       title,
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: context.adaptiveTextPrimary,
                       ),
                     ),
                     const SizedBox(height: 2),
                     Text(
                       subtitle,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: context.adaptiveTextTertiary,
                       ),
                     ),
@@ -1053,8 +1053,8 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
   Widget _buildLeadingIcon(BuildContext context, IconData icon) {
     return Container(
-      width: context.scaleSize(AppConstants.containerSizeSm),
-      height: context.scaleSize(AppConstants.containerSizeSm),
+      width: context.scaleSize(AppConstants.containerSizeMd),
+      height: context.scaleSize(AppConstants.containerSizeMd),
       decoration: BoxDecoration(
         color: AppColors.glassBackgroundStrong,
         borderRadius: BorderRadius.circular(AppConstants.radiusSm),

--- a/lib/features/settings/widgets/listenbrainz_settings_tile.dart
+++ b/lib/features/settings/widgets/listenbrainz_settings_tile.dart
@@ -421,14 +421,14 @@ class _ListenBrainzSettingsTileState
               children: [
                 Text(
                   'ListenBrainz',
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: context.adaptiveTextPrimary,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   'Loading session...',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: context.adaptiveTextTertiary,
                   ),
                 ),
@@ -509,14 +509,14 @@ class _ListenBrainzSettingsTileState
                   children: [
                     Text(
                       title,
-                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: context.adaptiveTextPrimary,
                       ),
                     ),
                     const SizedBox(height: 2),
                     Text(
                       subtitle,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                         color: context.adaptiveTextTertiary,
                       ),
                     ),
@@ -540,8 +540,8 @@ class _ListenBrainzSettingsTileState
 
   Widget _buildLeadingIcon(BuildContext context, IconData icon) {
     return Container(
-      width: context.scaleSize(AppConstants.containerSizeSm),
-      height: context.scaleSize(AppConstants.containerSizeSm),
+      width: context.scaleSize(AppConstants.containerSizeMd),
+      height: context.scaleSize(AppConstants.containerSizeMd),
       decoration: BoxDecoration(
         color: AppColors.glassBackgroundStrong,
         borderRadius: BorderRadius.circular(AppConstants.radiusSm),

--- a/rust/src/audio/dsd_alsa_direct.rs
+++ b/rust/src/audio/dsd_alsa_direct.rs
@@ -107,6 +107,15 @@ mod internal {
         i.flags = 1; // integer
     }
 
+    fn fmt_name(fmt: usize) -> &'static str {
+        match fmt {
+            FMT_DSD_U8 => "DSD_U8",
+            FMT_DSD_U16_LE => "DSD_U16_LE",
+            FMT_DSD_U32_LE => "DSD_U32_LE",
+            _ => "DSD_?",
+        }
+    }
+
     // ── State ─────────────────────────────────────────────────────────────
 
     static FD: AtomicI32 = AtomicI32::new(-1);
@@ -115,7 +124,7 @@ mod internal {
 
     // ── Device discovery ──────────────────────────────────────────────────
 
-    fn parse_pcm_device(name: &str) -> Option<(u32, u32)> {
+    pub(crate) fn parse_pcm_device(name: &str) -> Option<(u32, u32)> {
         let inner = name.strip_prefix("pcmC")?;
         let p = inner.strip_suffix('p')?;
         let mut parts = p.split('D');
@@ -167,6 +176,12 @@ mod internal {
                         card,
                         dev
                     );
+                    crate::dev_eprintln!(
+                        "[DSD-ALSA] {} accessible (card {} dev {}) — AudioFlinger bypass path available",
+                        path,
+                        card,
+                        dev
+                    );
                     return true;
                 } else {
                     let err = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
@@ -179,6 +194,7 @@ mod internal {
             }
         }
         log::info!("[DSD-ALSA] No /dev/snd playback devices found");
+        crate::dev_eprintln!("[DSD-ALSA] No /dev/snd playback devices found — cannot bypass AudioFlinger");
         false
     }
 
@@ -268,7 +284,7 @@ mod internal {
 
         let fmt = match chosen_fmt {
             Some(f) => {
-                log::info!("[DSD-ALSA] Driver supports DSD format bit {}", f);
+                log::info!("[DSD-ALSA] Driver supports DSD format {}", fmt_name(f));
                 f
             }
             None => {
@@ -336,6 +352,14 @@ mod internal {
                 err.raw_os_error().unwrap_or(0)
             ));
         }
+
+        crate::dev_eprintln!(
+            "[DSD-ALSA] AudioFlinger bypassed: direct /dev/snd ioctl path active on {} ({} rate={} ch={})",
+            path,
+            fmt_name(fmt),
+            byte_rate,
+            channels
+        );
 
         Ok(fd)
     }

--- a/rust/src/audio/dsd_native_backend.rs
+++ b/rust/src/audio/dsd_native_backend.rs
@@ -30,11 +30,22 @@ impl DsdNativeBackend {
         );
 
         if !super::dsd_alsa_direct::dsd_alsa_open(sample_rate, channels) {
+            crate::dev_eprintln!(
+                "[DSD-NATIVE] ALSA DSD output unavailable at byte_rate={} ch={} — will fall back to DoP/PCM",
+                sample_rate,
+                channels,
+            );
             return Err(format!(
                 "ALSA DSD output unavailable at byte_rate={} ch={}",
                 sample_rate, channels
             ));
         }
+
+        crate::dev_eprintln!(
+            "[DSD-NATIVE] ALSA direct output opened at {} Hz ch={} — AudioFlinger bypassed, launching render thread",
+            sample_rate,
+            channels,
+        );
 
         let stop = Arc::new(AtomicBool::new(false));
         let stop_clone = Arc::clone(&stop);

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -981,7 +981,7 @@ fn build_output_runtime_state(
     let (dsd_wire_rate, dsd_transport) = if dsd_source_rate.is_some() {
         let wire_rate = verification.actual_rate;
         let transport = match strategy {
-            OutputStrategy::DsdNative => "dap-native-encoding".to_string(),
+            OutputStrategy::DsdNative => "dap-native-alsa".to_string(),
             OutputStrategy::UsbDsdNative => {
                 #[cfg(feature = "uac2")]
                 {

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -1318,7 +1318,7 @@ pub fn create_audio_engine(
                     )
                 })
                 .collect();
-            log::info!(
+            dev_eprintln!(
                 "[DSD-STRATEGY] dsd_rate={:?} native_avail={} dop_avail={} carrier={} registered={} | alts=[{}]",
                 dsd_rate,
                 usb_dsd_native_available,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,6 +39,9 @@ macro_rules! dev_eprintln {
         if crate::DEVELOPER_MODE.load(std::sync::atomic::Ordering::Relaxed) {
             let __msg = format!($($arg)*);
             eprintln!("{}", __msg);
+            // ponytail: route through android_logger (tag "RustUSB") so devLogs
+            // reach `adb logcat`. Raw eprintln/stderr is invisible on Android.
+            log::info!("{}", __msg);
             crate::api::logging::forward_to_sink(__msg);
         }
     };

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -1034,10 +1034,70 @@ static LAST_SET_HW_VOLUME: AtomicI16 = AtomicI16::new(0);
 /// Prevents "Resource busy" from concurrent or overlapping claim attempts.
 static USB_SESSION_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+// ponytail: module-level stop signal. `clear_android_usb_device()` has no handle
+// to the backend's local `stop` Arc, so without this the transfer loop keeps
+// running until the engine drops the backend or the USB fd dies. Set from the
+// deferred-clear path; reset at session start. Ceiling: a second clear() during
+// teardown is harmless (idempotent store).
+static USB_STOP_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Combined stop predicate for the render/output loops: bail when either the
+/// backend's local `stop` Arc or the global clear-requested flag is set.
+fn usb_stop_requested(stop: &AtomicBool) -> bool {
+    stop.load(Ordering::Acquire) || USB_STOP_REQUESTED.load(Ordering::Acquire)
+}
+
 static USB_DSD_PAYLOAD_VERIFIED: AtomicBool = AtomicBool::new(false);
 
 fn usb_dsd_payload_verified() -> bool {
     USB_DSD_PAYLOAD_VERIFIED.load(Ordering::SeqCst)
+}
+
+static USB_PCM_PAYLOAD_VERIFIED: AtomicBool = AtomicBool::new(false);
+
+fn usb_pcm_payload_verified() -> bool {
+    USB_PCM_PAYLOAD_VERIFIED.load(Ordering::SeqCst)
+}
+
+static LAST_PCM_PAYLOAD_LOGGED: AtomicBool = AtomicBool::new(false);
+
+fn log_pcm_payload_transition(ok: bool) {
+    let prev = LAST_PCM_PAYLOAD_LOGGED.swap(ok, Ordering::Relaxed);
+    if ok && !prev {
+        crate::dev_eprintln!(
+            "[USB-PCM] wire payload verified: real audio flowing, not a stuck/dead pipeline"
+        );
+    }
+}
+
+static LAST_BIT_PERFECT_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// One-shot devLog evidence line: emitted the first time per stream that all
+/// bit-perfect conditions hold (format match + verified clock + payload audit).
+fn log_bit_perfect_transition(verified: bool, state: &AndroidDirectUsbState) {
+    let prev = LAST_BIT_PERFECT_LOGGED.swap(verified, Ordering::Relaxed);
+    if !verified {
+        return;
+    }
+    if prev {
+        return;
+    }
+    let Some(effective) = state.playback_format else {
+        return;
+    };
+    let transport = match effective.dsd_transport {
+        DsdTransportMode::DoP => "dop",
+        DsdTransportMode::Native => "dsd-native",
+        DsdTransportMode::None => "pcm",
+    };
+    crate::dev_eprintln!(
+        "[USB-BITPERFECT] verified: {} bit/{} Hz {}ch {} direct on \"{}\" — no mixer, no resample, no DSP",
+        effective.bit_depth,
+        effective.sample_rate,
+        effective.channels,
+        transport,
+        state.device.product_name
+    );
 }
 
 /// Verify the just-encoded wire payload looks like real DSD transport data.
@@ -1083,6 +1143,45 @@ fn audit_dsd_payload(
         DsdTransportMode::Native => buffer.iter().any(|&b| b != 0),
         DsdTransportMode::None => true,
     }
+}
+
+/// Verify the just-encoded PCM wire payload looks like real audio, not a stuck
+/// or dead pipeline. Mirrors audit_dsd_payload's gross-guard philosophy: decode
+/// channel-0 samples at the negotiated subslot width (little-endian signed, per
+/// UAC2 Type I PCM) and require at least two distinct values across the buffer.
+/// A real music transfer is effectively never sample-constant; a dead pipeline
+/// emits a constant (often all-zero or a fixed DC value).
+// ponytail: statistical guard, not a bit-exact hash. Upgrade path: per-frame
+// hash comparison against decoded source bytes if a stronger claim is needed.
+fn audit_pcm_payload(buffer: &[u8], subslot_size: u8, channels: u16) -> bool {
+    if buffer.is_empty() || subslot_size == 0 {
+        return false;
+    }
+    let ss = subslot_size as usize;
+    let ch = channels.max(1) as usize;
+    let stride = ss * ch;
+    if stride == 0 || buffer.len() < stride * 2 {
+        return false;
+    }
+    let bits = ss * 8;
+    let sign_extend = |v: i64| -> i64 {
+        if v & (1 << (bits - 1)) != 0 {
+            v | (-1i64 << bits)
+        } else {
+            v
+        }
+    };
+    let decode = |i: usize| -> i64 {
+        let off = i * stride;
+        let mut v: i64 = 0;
+        for b in 0..ss {
+            v |= (buffer[off + b] as i64) << (8 * b);
+        }
+        sign_extend(v)
+    };
+    let limit = (buffer.len() / stride).min(1024);
+    let first = decode(0);
+    (1..limit).any(|i| decode(i) != first)
 }
 
 pub fn set_android_direct_usb_enabled(enabled: bool) {
@@ -1364,7 +1463,12 @@ pub fn set_android_usb_lock_enabled(enabled: bool) -> Result<(), String> {
 pub fn clear_android_usb_device() {
     USB_SESSION_CLEAR_PENDING.store(true, Ordering::SeqCst);
     if USB_SESSION_ACTIVE.load(Ordering::SeqCst) {
-        dev_eprintln!("Android USB direct: deferring clear until the active session stops");
+        // Signal the running transfer loop to drain and exit. Without this the
+        // Kotlin-side wait_for_stop times out and force-closes the fd.
+        USB_STOP_REQUESTED.store(true, Ordering::SeqCst);
+        dev_eprintln!(
+            "Android USB direct: clear requested while session active; signaling transfer loop to stop"
+        );
         return;
     }
 
@@ -1456,6 +1560,7 @@ pub fn android_direct_debug_state() -> AndroidDirectUsbDebugState {
     let capability_model = state.capability_model.as_ref();
     // Compute live (before the struct literal moves String fields out of state).
     let bit_perfect_verified = direct_path_is_bit_perfect(&state);
+    log_bit_perfect_transition(bit_perfect_verified, &state);
 
     AndroidDirectUsbDebugState {
         registered: true,
@@ -2249,7 +2354,7 @@ fn direct_path_is_bit_perfect(state: &AndroidDirectUsbState) -> bool {
     // passed the DoP-marker / native-byte audit (USB_DSD_PAYLOAD_VERIFIED).
     let payload_ok = match effective.dsd_transport {
         DsdTransportMode::DoP | DsdTransportMode::Native => usb_dsd_payload_verified(),
-        DsdTransportMode::None => true,
+        DsdTransportMode::None => usb_pcm_payload_verified(),
     };
     requested.sample_rate == effective.sample_rate
         && requested.bit_depth == effective.bit_depth
@@ -3253,6 +3358,9 @@ pub fn create_android_usb_backend(
         thread::sleep(Duration::from_millis(100));
     }
 
+    // Fresh session: clear any stop signal left by a prior teardown.
+    USB_STOP_REQUESTED.store(false, Ordering::SeqCst);
+
     if USB_SESSION_ACTIVE.swap(true, Ordering::SeqCst) {
         dev_eprintln!("Android USB direct: force-releasing stale USB session guard");
         force_release_usb_session();
@@ -4207,7 +4315,7 @@ fn run_usb_render_loop(
     let mut logged_render_preview = false;
     let chunk_deadline = Duration::from_millis(ANDROID_USB_RENDER_CHUNK_MS as u64);
 
-    while !stop.load(Ordering::Acquire) {
+    while !usb_stop_requested(&stop) {
         let cycle_start = Instant::now();
         let buffered_samples = {
             let guard = pcm_buffer.lock();
@@ -4456,6 +4564,14 @@ fn prepare_iso_transfer_payload(
             ),
             Ordering::SeqCst,
         );
+    } else {
+        let ok = audit_pcm_payload(
+            &transfer_buffer,
+            candidate.subslot_size,
+            candidate.channels,
+        );
+        USB_PCM_PAYLOAD_VERIFIED.store(ok, Ordering::SeqCst);
+        log_pcm_payload_transition(ok);
     }
 
     Ok(Some(IsoTransferPayload {
@@ -4651,6 +4767,9 @@ fn run_usb_output_loop(
     } = claimed_handle;
     let playback_format = state.playback_format.unwrap();
     USB_DSD_PAYLOAD_VERIFIED.store(false, Ordering::SeqCst);
+    USB_PCM_PAYLOAD_VERIFIED.store(false, Ordering::SeqCst);
+    LAST_PCM_PAYLOAD_LOGGED.store(false, Ordering::Relaxed);
+    LAST_BIT_PERFECT_LOGGED.store(false, Ordering::Relaxed);
     let dsd_quirk = resolve_dsd_quirk(
         state.device.vendor_id,
         state.device.product_id,
@@ -4729,7 +4848,7 @@ fn run_usb_output_loop(
         "[USB] Waiting for stream prime: buffered_samples must reach buffer_target_samples={} before isochronous submit",
         priming_target,
     );
-    while !stop.load(Ordering::Acquire) {
+    while !usb_stop_requested(&stop) {
         let buffered = runtime_stats.buffered_samples.load(Ordering::Relaxed);
         if buffered >= priming_target {
             log_info!(
@@ -4801,7 +4920,7 @@ fn run_usb_output_loop(
         }
     }
 
-    while fatal_error.is_none() && (!stop.load(Ordering::Acquire) || active_slots > 0) {
+    while fatal_error.is_none() && (!usb_stop_requested(&stop) || active_slots > 0) {
         if active_slots == 0 {
             break;
         }
@@ -4878,7 +4997,7 @@ fn run_usb_output_loop(
             }
 
             let mut submit_gap_us = 0u64;
-            if !stop.load(Ordering::Acquire) {
+            if !usb_stop_requested(&stop) {
                 let completion_detected_at = Instant::now();
                 match prepare_iso_transfer_payload(
                     &mut scheduler,
@@ -5009,7 +5128,7 @@ fn run_usb_output_loop(
     set_usb_stream_stable(false);
     USB_SESSION_ACTIVE.store(false, Ordering::SeqCst);
     complete_pending_android_usb_clear_if_idle();
-    if stop.load(Ordering::Acquire) {
+    if usb_stop_requested(&stop) {
         set_android_usb_engine_state(AndroidDirectUsbEngineState::Idle, None);
     }
 }
@@ -7175,6 +7294,49 @@ mod dsd_bitperfect_tests {
         assert!(audit_dsd_payload(&[0x00, 0x55, 0x00], DsdTransportMode::Native, 1, 2));
         assert!(!audit_dsd_payload(&[0, 0, 0, 0], DsdTransportMode::Native, 1, 2));
         assert!(!audit_dsd_payload(&[], DsdTransportMode::Native, 1, 2));
+    }
+
+    #[test]
+    fn audit_pcm_accepts_varying_16bit_stereo() {
+        // stride = ss(2) * ch(2) = 4; channel-0 words at 0 and 4 differ.
+        let buf: [u8; 8] = [
+            0x00, 0x00, 0x00, 0x00, // L0 = 0
+            0x01, 0x00, 0x00, 0x00, // L1 = 1
+        ];
+        assert!(audit_pcm_payload(&buf, 2, 2));
+    }
+
+    #[test]
+    fn audit_pcm_rejects_dead_pipeline_all_zero() {
+        let buf = [0u8; 64];
+        assert!(!audit_pcm_payload(&buf, 2, 2));
+    }
+
+    #[test]
+    fn audit_pcm_rejects_stuck_constant_dc() {
+        // every 16-bit sample = 0x0100 (DC); channel-0 never varies.
+        let buf: [u8; 16] = [
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01,
+            0x00, 0x01,
+        ];
+        assert!(!audit_pcm_payload(&buf, 2, 2));
+    }
+
+    #[test]
+    fn audit_pcm_accepts_24bit_packed_subslot() {
+        // ss=3 stereo, stride=6; channel-0 samples differ.
+        let buf: [u8; 12] = [
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x02, // L0
+            0xFF, 0xFF, 0x7F, 0x00, 0x00, 0x03, // L1
+        ];
+        assert!(audit_pcm_payload(&buf, 3, 2));
+    }
+
+    #[test]
+    fn audit_pcm_rejects_empty_and_short() {
+        assert!(!audit_pcm_payload(&[], 2, 2));
+        assert!(!audit_pcm_payload(&[0, 0], 2, 2)); // < 2 frames
+        assert!(!audit_pcm_payload(&[1, 2, 3, 4], 0, 2)); // zero subslot
     }
 
     #[test]


### PR DESCRIPTION
# Summary

- Add PCM payload audit and global stop signal for USB clear in Android direct (169 insertions)
- Switch DSD-native transport label to "dap-native-alsa" with logging for ALSA DSD output
- Add DSD format name helper and improve debug logging across ALSA direct module
- Add Android logcat routing to `dev_eprintln` macro for Rust-side debug output
- Add back gesture edge detection for bottom screen edge in full player
- Update text styles in library settings and bump text/icon sizes in Last.fm and ListenBrainz settings tiles

# Changes

## USB / UAC2

- Add PCM payload audit and global stop signal for USB clear in `android_direct.rs` (169 insertions)

## DSD ALSA

- Switch DSD-native transport label to "dap-native-alsa"
- Add logging when opening or failing to open ALSA DSD output
- Add DSD format name helper with debug logging
- Use `dev_eprintln` for DSD strategy logging

## Dev Logging

- Add Android logcat routing to `dev_eprintln` macro for Rust-to-logcat forwarding

## UI

- Add back gesture edge detection for bottom screen edge in full player screen

## Settings

- Update text styles and container sizes in library settings screen
- Bump text styles and icon sizes in Last.fm and ListenBrainz settings tiles

## Files Changed

- `lib/features/settings/screens/library_settings_screen.dart`
- `lib/features/settings/widgets/lastfm_settings_tile.dart`
- `lib/features/settings/widgets/listenbrainz_settings_tile.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `rust/src/lib.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/audio/engine.rs`
- `rust/src/audio/dsd_native_backend.rs`
- `rust/src/audio/dsd_alsa_direct.rs`