### PR TITLE
Add hidden nav bar buttons configuration and network sources plan

### DIFF
--- a/docs/NETWORK_SOURCES_PLAN.md
+++ b/docs/NETWORK_SOURCES_PLAN.md
@@ -1,0 +1,287 @@
+# Network Sources (Self-Hosted Local & Cloud) — Phased Plan
+
+Play from self-hosted music servers — on-LAN NAS boxes and remote/cloud-hosted
+instances — through the **existing Rust audio engine**, so bit-perfect PCM,
+native DSD, the full DSP chain, gapless and crossfade all keep working. One
+playback path. No second engine for "network songs."
+
+Scope: a new `source` abstraction over the audio path, protocol adapters
+(Subsonic, WebDAV, Jellyfin, later SMB/UPnP), a bounded on-device cache, and a
+remote-library browser that reuses the existing songs/albums UI.
+
+**Ponytail policy**: no new deps for v1. Subsonic and WebDAV are plain HTTP and
+ride the existing `http` package. SMB and UPnP each need a crate/package and
+are deferred until v1 proves the abstraction. Bytes go through the Rust engine
+as a seekable `MediaSource` — same decoders, same DSP, same DSD pipeline. No
+server-side transcode requests; if a server transcodes by default we pass the
+raw-format params to opt out. We do not ship a parallel `just_audio` HTTP path.
+
+---
+
+## A. What "self-hosted local & cloud server playing" means here
+
+| Server class | Where it runs | Examples | Protocol |
+|--------------|---------------|----------|----------|
+| Subsonic-compatible | LAN or cloud | Navidrome, Airsonic/Advanced Airsonic, gonic, Bonob, Supysonic, Funkwhale, Ampache (Subsonic shim), Music Assistant (Subsonic endpoint) | Subsonic REST API (HTTP + XML/JSON) |
+| WebDAV | LAN or cloud | Nextcloud Music, ownCloud, Synology WebDAV, generic | HTTP verbs (GET/PROPFIND) |
+| Jellyfin | LAN or cloud | Jellyfin, *arr-compatible forks | Jellyfin REST API (HTTP + JSON) |
+| SMB/CIFS share | LAN only | NAS boxes, Samba | SMB2/3 (new dep — deferred) |
+| UPnP/DLNA media server | LAN only | ReadyMedia/minidlna, Gerbera, vendor NAS | UPnP MediaServer + ContentDirectory (new dep — deferred) |
+
+**Out of scope:** commercial cloud streaming (Tidal/Spotify/Qobuz/Apple Music).
+DRM and licensing are a different product. Tidal already has its own
+`FEATURE_REQUESTS.md` line; it stays there until someone wants to pay for the
+SDK. Self-hosted = you control the server, you own the files.
+
+---
+
+## B. The one real design fork: how bytes reach the engine
+
+The Rust engine is path-based (`audio_api.rs`) and decodes from a
+`MediaSource` (Read + Seek) trait. Two ways to feed it a network song:
+
+1. **Cache-then-play.** Download the full file to a temp path, hand the path to
+   the engine. Simplest. Loses instant-start. Wasteful for "skip after 5 s".
+2. **Seekable HTTP `MediaSource`.** A Rust `HttpMediaSource` implementing
+   `MediaSource` via HTTP `Range` requests: `read` pulls the next bytes, `seek`
+   opens a new range. Engine streams over the network, bit-perfect, full DSP.
+   Instant-start. Seek = one round-trip.
+
+**Decision: v1 = cache-then-play. v2 = `HttpMediaSource`.** One playback path
+either way — the difference is latency and storage, not architecture. v1 reuses
+the exact `playFile(path)` call the engine already has; the only new piece is a
+download job per song. v2 swaps the source object behind the same engine
+entrypoint. No double engine, ever.
+
+**Bit-perfect contract.** Adapters MUST request raw containers:
+- Subsonic `stream`: no `maxBitRate`, no `format`/`convertedFormat` → raw file.
+- Jellyfin `/Audio/<id>/stream`: no `container`/`audioCodec`/`bitrate`
+  query → raw file. Reject `transcodingReason` in the response when possible.
+- WebDAV `GET`: raw file by definition.
+
+If a server forces transcode (rare for self-hosted), we surface a
+"transcoded" badge in the UI and keep playing — no silent quality loss
+disguised as bit-perfect.
+
+---
+
+## C. Where it plugs in
+
+| Point | File | Change |
+|-------|------|--------|
+| `PlaybackSource` enum | `lib/models/playback_context.dart:1` | add `network` (and keep `folder` etc.). UI labels switch on it. |
+| Song model | `lib/data/entities/song_entity.dart` | a `sourceType` (`local` \| `subsonic` \| `webdav` \| `jellyfin`) and `remoteId` (the server's song id) + `remoteServerId`. Local songs: both null. |
+| Repository | `lib/data/repositories/song_repository.dart` | queries already filter by folder/source; add `byRemoteServer` filter for the browser. |
+| Audio playback entrypoint | `lib/services/audio_player_service.dart` (or wherever `playFile(path)` lives) | branch: local → existing path; network → `NetworkSourceService.play(remoteSong)` → cache file → existing path. |
+| Rust engine | `rust/src/api/audio_api.rs` | **unchanged in v1.** v2 adds `playFromHttp(url, headers)` and a `HttpMediaSource`. |
+| Scanner | `lib/services/library_scanner_service.dart` | network "scan" is a metadata fetch, not a file walk. New `network_scanner_service.dart` per protocol. |
+| Settings | `lib/features/settings/` | new "Network Sources" screen: list configured servers, add/edit/remove, test connection. |
+| Cache | new `lib/services/network_cache_service.dart` | bounded LRU dir under `getApplicationCacheDirectory()/network_cache/`. Default 2 GB, configurable. Eviction on write past cap. |
+
+**One `MediaSource`-shaped seam.** A `RemoteSource` Rust struct (v2) or a
+`cachedFilePath` (v1) is the only thing the engine knows about. Protocol
+adapters live entirely on the Dart side and produce either a cached file path
+(v1) or an `(url, headers)` pair (v2). Rust never sees Subsonic or Jellyfin.
+
+---
+
+## D. Confirmed gaps (what does not exist yet)
+
+| # | Gap | Severity | Location |
+|---|-----|----------|----------|
+| N1 | No `remoteId` / `sourceType` / `remoteServerId` on `SongEntity`. | High | `lib/data/entities/song_entity.dart` |
+| N2 | No `network` value on `PlaybackSource`; UI label plumbing assumes local. | Medium | `lib/models/playback_context.dart:1` |
+| N3 | No `NetworkServer` config entity (id, label, protocol, baseUrl, user, token, lastSyncedAt). | High | new `lib/data/entities/network_server_entity.dart` |
+| N4 | No `NetworkCacheService` (bounded LRU download cache). | High | new `lib/services/network_cache_service.dart` |
+| N5 | No `RemoteSource` abstraction over the audio path (v1: path; v2: `MediaSource`). | High | `lib/services/remote_source_service.dart` (v1), `rust/src/audio/http_source.rs` (v2) |
+| N6 | No Subsonic adapter (auth salt+md5, `ping`/`getArtists`/`getAlbum`/`stream`). | High | new `lib/services/sources/subsonic_service.dart` |
+| N7 | No WebDAV adapter (PROPFIND album list, GET file). | Medium | new `lib/services/sources/webdav_service.dart` |
+| N8 | No Jellyfin adapter (`/Users/.../Items` browse, `/Audio/<id>/stream`). | Medium | new `lib/services/sources/jellyfin_service.dart` |
+| N9 | No "Network Sources" settings screen; no add/edit/test flow. | High | new `lib/features/settings/screens/network_sources_screen.dart` |
+| N10 | Audio engine has no HTTP `MediaSource` (v2). | Medium (v2) | `rust/src/audio/source.rs`, `rust/src/api/audio_api.rs` |
+| N11 | Gapless/crossfade assumes next file is local & instant. Network next-track needs prefetch. | Medium | `lib/services/queue/` (prefetch on `position < duration - 10s`) |
+| N12 | No SMB adapter. | Low (deferred) | needs `smb_connect` or Rust `pavao`/`puffer` crate |
+| N13 | No UPnP/DLNA media-server adapter. | Low (deferred) | needs `upnp-client` crate; `FEATURE_REQUESTS.md` already lists DLNA casting (separate direction) |
+| N14 | Album-art, lyrics, and Replay hand off network songs through paths that assume local files. | Medium | `album_art_service.dart`, `lyrics_service.dart`, `recap` — resolve network art to cache bytes, lyrics to LRCLib as today |
+
+---
+
+## E. Phases
+
+### Phase 1 — Subsonic-compatible (covers ~80% of self-hosted servers)
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P1.1 | N3 | `NetworkServerEntity` (id, label, protocol, baseUrl, username, token (salted-hash, not plaintext — store the Subsonic `sHex` salt+md5 form), lastSyncedAt). Register in `database.dart`. |
+| P1.2 | N1, N2 | Add `sourceType`, `remoteId`, `remoteServerId` to `SongEntity`; `network` to `PlaybackSource` with label "Network"; UI label plumbing. Local songs: the three new fields null. |
+| P1.3 | N4 | `NetworkCacheService`: LRU dir with size cap (default 2 GB), `getPath(remoteServerId, remoteId)` → cached `<hash>.<ext>` or null, `stash(bytes, ...)` evicting oldest past cap. One class, stdlib + `path` + `crypto` (already deps). |
+| P1.4 | N6 | `SubsonicService`: salt+md5 auth (`t=<md5(salt+pw)>&s=<salt>`), `ping`, `getArtists`/`getAlbumList2`/`getAlbum` (build `SongEntity`s with `sourceType=subsonic`), `getCoverArt` → write to album-art cache like existing `album_art_service.dart:101`, `stream(id)` → `http.get(stream)` with opt-out transcode params, body → `NetworkCacheService.stash`. |
+| P1.5 | N5, v1 | `RemoteSourceService.play(remoteSong)`: if cached → existing `playFile(path)`; else kick download (with progress → existing `_scanProgressNotifier` plumbing reused), then `playFile`. |
+| P1.6 | N9 | "Network Sources" settings screen: list, add (server URL + user + password + "Test" button), edit, delete. Test calls `ping`. |
+| P1.7 | N11 | Prefetch: when queue position < duration − 10 s and next song is `sourceType=subsonic`, start `stream(id)` download into cache so gapless/crossfade reads a local path at handoff. |
+| P1.8 | N14 | Cover art for network songs resolves via `getCoverArt` bytes → existing `albumArtPath` flow; lyrics fall back to LRCLib as today (network songs have no local tags to mine). |
+
+### Phase 2 — WebDAV (Nextcloud, ownCloud, generic)
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P2.1 | N7 | `WebDavService`: `PROPFIND` on the music root with Depth:1 to list folders-as-albums, recursive `PROPFIND` for tracks, basic-auth or bearer token. Build `SongEntity` with `sourceType=webdav`, `remoteId` = file URL. Cover art: `Thumbs`/`Cover.jpg` conventions or skip (fall back to `getCoverArt`-style “first image in folder”). |
+| P2.2 | — | Register WebDAV in `NetworkServerEntity.protocol`. Settings add/edit flow branches on protocol. |
+| P2.3 | — | `RemoteSourceService` extension: WebDAV `GET` → cache, same `playFile` path. |
+
+### Phase 3 — Jellyfin
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P3.1 | N8 | `JellyfinService`: `/Users/AuthenticateByName` for token, `/Users/<id>/Items?IncludeItemTypes=MusicAlbum`, `/Items?ParentId=...` for tracks, `/Audio/<id>/stream` for bytes (no transcode params). `remoteId` = Jellyfin `Item.Id`. |
+| P3.2 | — | Register branch. Cover art via `/Items/<id>/Images/Primary` → cache. |
+
+### Phase 4 — Seekable HTTP `MediaSource` (v2, latency win)
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P4.1 | N10 | New `rust/src/audio/http_source.rs`: `HttpMediaSource { url, headers, pos, range_buf }` implementing `Symphonia` `MediaSource` (`read`/`seek`/...). `seek` = drop buffer, save target offset; next `read` issues `Range: bytes=N-`. Headers carry Subsonic/Jellyfin/WebDAV auth. |
+| P4.2 | N10 | `rust/src/api/audio_api.rs`: `play_from_http(url, headers)` mirror of the existing path-based entrypoint, swaps only the `MediaSource` construction. Everything downstream (DSP, DSD, gapless) is reused. |
+| P4.3 | N5 | `RemoteSourceService.play` v2 path: prefer `play_from_http` when range supported (Subsonic `stream` ✓, WebDAV GET ✓, Jellyfin stream ✓ — all return `Accept-Ranges: bytes`). Fall back to cache-then-play if server says no ranges or on transport error. |
+| P4.4 | — | Cache becomes a prefetch/seek-ahead buffer, not a full-file requirement. Keep `NetworkCacheService` for offline and replay; size cap stays. |
+
+### Phase 5 — SMB (LAN only; needs a new dep)
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P5.1 | N12 | Evaluate `pavao`/`puffer` (Rust SMB2/3) vs Dart `smb_connect`. Decision driven by: does it go through the Rust engine (preferred — keeps DSP) or only through `just_audio`'s URI handler (rejected — loses engine). If no Rust crate is acceptable, **defer or skip SMB.** SMB isn't worth a second playback path. |
+| P5.2 | — | If a Rust path: `SmbSource` implementing `MediaSource` like the HTTP one, mounted lazily. Auth via NTLMv2. Read-only — we never write back metadata edits to SMB shares in v1. |
+
+### Phase 6 — UPnP/DLNA media-server browsing (LAN only; needs a new dep)
+
+| Task | Gap | Change |
+|------|-----|--------|
+| P6.1 | N13 | Evaluate `upnp-client` Rust crate for ContentDirectory browsing + `http-get` resource URLs. The DLNA *casting* item in `FEATURE_REQUESTS.md` is a different direction (Flick as renderer); this phase is Flick as **control point / player pulling from a media server**. Don't conflate them. |
+| P6.2 | — | If adopted: same `MediaSource` seam as HTTP/SMB; resources are plain HTTP `res` URLs, so they may ride the Phase 4 `HttpMediaSource` directly with no new Rust code. |
+
+### Phase 7 — Self-checks (ponytail: one runnable check per non-trivial unit)
+
+| Task | Change |
+|------|--------|
+| P7.1 | Dart unit test for `NetworkCacheService`: cap is enforced; LRU evicts oldest on overflow; `stash` then `getPath` returns the same file. |
+| P7.2 | Dart unit test for `SubsonicService` auth: with a known salt+password, assert the `t=`/`s=` query matches the documented md5(salt+password) form. Use a mock `http.Client` for `ping`/`getAlbum`. |
+| P7.3 | Dart integration test: configure a server pointing at a fixture (or a recorded HTTP cassette), "scan" returns `SongEntity`s with `sourceType=subsonic` and `remoteId` set. |
+| P7.4 | (v2) Rust `#[test]` for `HttpMediaSource`: a `Cursor`-backed fake server, `read` returns contiguous bytes, `seek` followed by `read` returns the right slice, `stream_len` matches. |
+| P7.5 | Manual: real Navidrome + real Jellyfin + a Nextcloud over WebDAV, on both LAN and a cloud VPS, through a USB DAC. Confirm bit-perfect badge, native DSD passthrough on a DSF served by Navidrome, gapless between two network songs, crossfade between a local and a network song. |
+
+---
+
+## F. Procedures (operational)
+
+### F.1 Adding a server (user flow)
+
+1. Settings → Network Sources → Add.
+2. Pick protocol: Subsonic / WebDAV / Jellyfin. (SMB/UPnP listed but
+   greyed-out until Phase 5/6 land, with a one-line "needs a new dependency"
+   note.)
+3. Enter label, base URL, username, password (Subsonic) / bearer token
+   (WebDAV) / username+password (Jellyfin, exchanged for a token on first
+   connect). Stored on `NetworkServerEntity`. Passwords never logged; the
+   Subsonic salt+md5 is computed at request time, plaintext not retained.
+4. "Test connection" → adapter `ping`/`PROPFIND`/`AuthenticateByName`. Show
+   pass/fail with the server-reported version string.
+5. Save → trigger a network scan (metadata fetch) for that server.
+
+### F.2 Library sync (not a file walk)
+
+- Network "scan" = fetch the server's album/track index via the adapter's
+  browse call, upsert `SongEntity` rows with `sourceType` + `remoteId` +
+  `remoteServerId`. Same Isar DB, same UI query paths.
+- Differential: store `lastSyncedAt` on `NetworkServerEntity`; adapters expose a
+  "changed since" query where the protocol supports it (Subsonic
+  `getAlbumList2?type=newest&size=...` + `ifModifiedSince`; Jellyfin
+  `/Items?MinDateCreated=...`). WebDAV falls back to full `PROPFIND` with
+  `getlastmodified` comparison.
+- Manual re-sync per server. No background polling by default (ponytail: don't
+
+  burn battery for a feature that's only useful when the user opens the app).
+
+### F.3 Playback
+
+- Tap a network song → `RemoteSourceService.play`:
+  - **v1:** `NetworkCacheService.getPath(...)` → hit → `playFile(path)`. Miss
+    → download `stream`/`GET`/`/Audio/.../stream` with raw-format params →
+    `stash` → `playFile`. Progress shown via existing scan-progress notifier.
+  - **v2:** `play_from_http(url, headers)` if range-supported, else v1 path.
+- Gapless/crossfade: prefetch next network song into cache when current
+  position ≤ duration − 10 s (Phase 1.7). The crossfader already reads file
+  paths; it doesn't care they came from HTTP.
+- Error handling: transport failure mid-stream → log via `app_log.dart`
+  (`LogSource.source`), surface a toast, advance or halt per user setting.
+  Partial cache file deleted.
+
+### F.4 Cache & storage
+
+- Location: `getApplicationCacheDirectory()/network_cache/<serverId>/<hash>.<ext>`.
+- Cap: 2 GB default, configurable in Settings. Eviction is LRU by
+  last-accessed mtime; eviction runs after each `stash`.
+- Offline: a network song whose cache file exists is playable with the server
+  offline. We do not pre-emptively cache whole libraries — ponytail: storage
+  cost would dwarf the feature.
+- Metadata edits: write-back is local-only (`metadata_editor.rs`). Editing a
+  network song is a no-op with a toast, not silently written to cache.
+
+### F.5 DSP & DSD
+
+- Network songs run through the same 31-band EQ, convolution reverb, dynamics,
+  crossfade, waveform seek bar, FFT visualizer. No branching in the DSP path.
+- Native DSD served by a Subsonic server (Navidrome can serve DSF): the
+  `dsd_native_backend` reads from the cached path (v1) or the
+  `HttpMediaSource` (v2) identically to local DSD. Confirm with the P7.5
+  manual check. DoP/USB DAC path unchanged.
+
+### F.6 Security
+
+- Plaintext passwords never persisted. Subsonic stores salt+md5 form only;
+  Jellyfin stores the server-returned token; WebDAV stores a bearer token or a
+  username:base64(password) for basic auth. All in Isar, not in shared prefs.
+- HTTP (not HTTPS) base URLs are allowed but warn on save (self-hosted LAN is
+  fine; cloud should be HTTPS). No cert pinning in v1.
+
+---
+
+## G. Risks & open questions
+
+- **Bit-perfect contract vs server transcode.** Most self-hosted servers
+  serve raw by default, but a misconfigured Navidrome/Jellyfin profile can
+  transcode. Mitigation: adapters pass the explicit "no transcode" params;
+  UI surfaces a "transcoded" badge if the response `Content-Type`/length
+  disagrees with the known file size. We never *claim* bit-perfect on a
+  network song that came back smaller than expected.
+- **Seek latency (v2).** Each seek = one HTTP round-trip. On a high-latency
+  cloud server this is perceptible. Mitigation: read-ahead buffer (a few MB
+  past the current position) so small seeks stay in buffer. Cache-then-play
+  (v1) has no seek penalty, which is why it's v1.
+- **Range support.** Subsonic `stream`, WebDAV `GET`, and Jellyfin `stream`
+  all advertise `Accept-Ranges: bytes` in practice. If a server doesn't, v2
+  falls back to v1 (download-then-play) automatically. No user-visible
+  difference except seek lag.
+- **Large libraries over the wire.** A 50k-track Navidrome sync is a lot of
+  `getAlbum` calls. Differential sync + a per-server "full re-sync" button
+  (under the ellipsis menu, beside the existing ones in
+  `library_settings_screen.dart:1140`) keep it bounded. Phase 1 caps initial
+  sync to recent N; streaming the rest on browse.
+- ** smb / UPnP new-dep gate.** Both need a crate/package the project doesn't
+  have. CONTRIBUTING.md says no new deps without a reason. The reason is
+  "users asked for NAS shares / DLNA media servers." Only after v1 (Subsonic
+  + WebDAV + Jellyfin) is in, real users bump into the gap, and the chosen
+  crate is audited. Don't pre-add.
+- **DLNA casting confusion.** This plan is Flick *pulling from* a DLNA media
+  server (Phase 6). The `FEATURE_REQUESTS.md` DLNA/Chromecast/UPnP items are
+  Flick *pushing to* a renderer. Different directions, different code, don't
+  merge them in one PR.
+- **Tidal / commercial cloud.** Explicitly out. DRM, licensing, dev keys,
+  NDAs. Separate effort, separate plan if ever.
+- **just_audio's HTTP capability.** The project already has `just_audio`,
+  which can stream HTTP URLs out of the box. Using it would be the "one line"
+  rung of the ladder — but it bypasses the Rust engine and loses bit-perfect,
+  DSD, EQ, reverb, gapless, the lot. That's not Flick. The one-line option is
+
+  rejected here because it violates the product's core contract; cache-then-
+  play through the existing path is the lazy solution that *keeps the product
+  the product*.

--- a/lib/features/settings/screens/bottom_bar_settings_screen.dart
+++ b/lib/features/settings/screens/bottom_bar_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/models/nav_bar_config.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
@@ -18,7 +19,9 @@ class BottomBarSettingsScreen extends ConsumerWidget {
     final appPreferences = ref.watch(appPreferencesProvider);
     final enabled = config.enabledButtons;
     final enabledCount = enabled.length;
-    final disabled = NavBarButton.values.where((b) => !enabled.contains(b)).toList();
+    final hidden = config.hidden;
+    final disabledVisible = NavBarButton.values.where((b) => !enabled.contains(b) && !hidden.contains(b)).toList();
+    final hiddenButtons = NavBarButton.values.where((b) => hidden.contains(b)).toList();
 
     return SettingsScaffold(
       title: 'Bottom Bar',
@@ -165,24 +168,38 @@ class BottomBarSettingsScreen extends ConsumerWidget {
               },
             ),
           ),
-          if (disabled.isNotEmpty) ...[
+          if (disabledVisible.isNotEmpty) ...[
             const SizedBox(height: AppConstants.spacingLg),
             const SettingsSectionHeader('Disabled'),
             SettingsCard(
               children: [
-                for (int i = 0; i < disabled.length; i++) ...[
+                for (int i = 0; i < disabledVisible.length; i++) ...[
                   if (i > 0) const SettingsDivider(),
-                  ToggleSetting(
-                    icon: disabled[i].icon,
-                    title: disabled[i].label,
-                    subtitle:
-                    'Enable to show the ${disabled[i].label} tab in the bottom bar',
-                    value: false,
-                    onChanged: (_) {
-                      ref
-                          .read(navBarConfigProvider.notifier)
-                          .toggleButton(disabled[i]);
+                  _DisabledNavItem(
+                    button: disabledVisible[i],
+                    isHidden: false,
+                    onEnable: () => ref.read(navBarConfigProvider.notifier).toggleButton(disabledVisible[i]),
+                    onToggleHide: () => ref.read(navBarConfigProvider.notifier).toggleHidden(disabledVisible[i]),
+                  ),
+                ],
+              ],
+            ),
+          ],
+          if (hiddenButtons.isNotEmpty) ...[
+            const SizedBox(height: AppConstants.spacingLg),
+            const SettingsSectionHeader('Hidden'),
+            SettingsCard(
+              children: [
+                for (int i = 0; i < hiddenButtons.length; i++) ...[
+                  if (i > 0) const SettingsDivider(),
+                  _DisabledNavItem(
+                    button: hiddenButtons[i],
+                    isHidden: true,
+                    onEnable: () {
+                      ref.read(navBarConfigProvider.notifier).toggleButton(hiddenButtons[i]);
+                      ref.read(navBarConfigProvider.notifier).toggleHidden(hiddenButtons[i]);
                     },
+                    onToggleHide: () => ref.read(navBarConfigProvider.notifier).toggleHidden(hiddenButtons[i]),
                   ),
                 ],
               ],
@@ -306,5 +323,83 @@ class BottomBarSettingsScreen extends ConsumerWidget {
       ),
     );
   }
+}
 
+class _DisabledNavItem extends StatelessWidget {
+  final NavBarButton button;
+  final bool isHidden;
+  final VoidCallback onEnable;
+  final VoidCallback onToggleHide;
+
+  const _DisabledNavItem({
+    required this.button,
+    required this.isHidden,
+    required this.onEnable,
+    required this.onToggleHide,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          AppHaptics.tap();
+          onEnable();
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(AppConstants.spacingLg),
+          child: Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: AppColors.glassBackgroundStrong,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  button.icon,
+                  color: context.adaptiveTextSecondary,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingMd),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      button.label,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: context.adaptiveTextPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      isHidden
+                          ? 'Completely hidden from the bottom bar'
+                          : 'Appears in the overflow menu',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: context.adaptiveTextTertiary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: Icon(
+                  isHidden ? LucideIcons.eye : LucideIcons.eyeOff,
+                  size: 20,
+                  color: context.adaptiveTextTertiary,
+                ),
+                onPressed: onToggleHide,
+              ),
+              CustomSwitch(value: false, onChanged: (_) => onEnable()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/models/nav_bar_config.dart
+++ b/lib/models/nav_bar_config.dart
@@ -21,6 +21,7 @@ enum NavBarButton {
 
 class NavBarConfig {
   final List<NavBarButton> enabledButtons;
+  final Set<NavBarButton> hidden;
   final double barSizeFactor;
   final double buttonSpacingFactor;
   final double iconSizeFactor;
@@ -34,6 +35,7 @@ class NavBarConfig {
 
   const NavBarConfig({
     this.enabledButtons = allButtons,
+    this.hidden = const {},
     this.barSizeFactor = 1.0,
     this.buttonSpacingFactor = 1.0,
     this.iconSizeFactor = 1.0,
@@ -51,7 +53,9 @@ class NavBarConfig {
 
   List<NavBarButton> get missingEssentials {
     const essential = {NavBarButton.menu, NavBarButton.songs, NavBarButton.settings};
-    return essential.where((b) => !enabledButtons.contains(b)).toList()
+    return essential
+        .where((b) => !enabledButtons.contains(b) && !hidden.contains(b))
+        .toList()
       ..sort((a, b) => a.pageIndex.compareTo(b.pageIndex));
   }
 
@@ -65,6 +69,7 @@ class NavBarConfig {
 
   NavBarConfig copyWith({
     List<NavBarButton>? enabledButtons,
+    Set<NavBarButton>? hidden,
     double? barSizeFactor,
     double? buttonSpacingFactor,
     double? iconSizeFactor,
@@ -72,6 +77,7 @@ class NavBarConfig {
   }) {
     return NavBarConfig(
       enabledButtons: enabledButtons ?? this.enabledButtons,
+      hidden: hidden ?? this.hidden,
       barSizeFactor: barSizeFactor ?? this.barSizeFactor,
       buttonSpacingFactor: buttonSpacingFactor ?? this.buttonSpacingFactor,
       iconSizeFactor: iconSizeFactor ?? this.iconSizeFactor,

--- a/lib/providers/nav_bar_config_provider.dart
+++ b/lib/providers/nav_bar_config_provider.dart
@@ -5,6 +5,7 @@ import 'package:flick/models/nav_bar_config.dart';
 
 class NavBarConfigNotifier extends Notifier<NavBarConfig> {
   static const _buttonsKey = 'nav_bar_buttons';
+  static const _hiddenKey = 'nav_bar_hidden';
   static const _sizeKey = 'nav_bar_size';
   static const _spacingKey = 'nav_bar_spacing';
   static const _iconSizeKey = 'nav_bar_icon_size';
@@ -30,8 +31,14 @@ class NavBarConfigNotifier extends Notifier<NavBarConfig> {
         ? _parseButtons(buttonsStr)
         : NavBarConfig.allButtons;
 
+    final hiddenStr = prefs.getString(_hiddenKey);
+    final hidden = hiddenStr != null
+        ? _parseButtonSet(hiddenStr)
+        : <NavBarButton>{};
+
     state = NavBarConfig(
       enabledButtons: buttons.isEmpty ? NavBarConfig.allButtons : buttons,
+      hidden: hidden,
       barSizeFactor: prefs.getDouble(_sizeKey) ?? 1.0,
       buttonSpacingFactor: prefs.getDouble(_spacingKey) ?? 1.0,
       iconSizeFactor: prefs.getDouble(_iconSizeKey) ?? 1.0,
@@ -51,13 +58,30 @@ class NavBarConfigNotifier extends Notifier<NavBarConfig> {
     return result;
   }
 
+  Set<NavBarButton> _parseButtonSet(String raw) {
+    final result = <NavBarButton>{};
+    for (final name in raw.split(',')) {
+      final trimmed = name.trim();
+      if (trimmed.isEmpty) continue;
+      try {
+        result.add(NavBarButton.values.byName(trimmed));
+      } catch (_) {}
+    }
+    return result;
+  }
+
   String _serializeButtons(List<NavBarButton> buttons) {
+    return buttons.map((b) => b.name).join(',');
+  }
+
+  String _serializeButtonSet(Set<NavBarButton> buttons) {
     return buttons.map((b) => b.name).join(',');
   }
 
   Future<void> _persist() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_buttonsKey, _serializeButtons(state.enabledButtons));
+    await prefs.setString(_hiddenKey, _serializeButtonSet(state.hidden));
     await prefs.setDouble(_sizeKey, state.barSizeFactor);
     await prefs.setDouble(_spacingKey, state.buttonSpacingFactor);
     await prefs.setDouble(_iconSizeKey, state.iconSizeFactor);
@@ -80,6 +104,17 @@ class NavBarConfigNotifier extends Notifier<NavBarConfig> {
       updated.add(button);
     }
     state = state.copyWith(enabledButtons: updated);
+    await _persist();
+  }
+
+  Future<void> toggleHidden(NavBarButton button) async {
+    final updated = Set<NavBarButton>.from(state.hidden);
+    if (updated.contains(button)) {
+      updated.remove(button);
+    } else {
+      updated.add(button);
+    }
+    state = state.copyWith(hidden: updated);
     await _persist();
   }
 


### PR DESCRIPTION
# Summary

- Add hidden buttons set to `NavBarConfig` model for persisting hidden state across sessions
- Add shared preference persistence for hidden nav bar buttons via provider
- Add network sources plan document for self-hosted music server support

# Changes

## Navigation Bar

- Add hidden buttons set to `NavBarConfig` model
- Add persistence for hidden nav bar buttons via shared preferences in provider (35 lines)

## Documentation

- Add network sources plan (287 lines) for self-hosted music server integration

## Files Changed

- `lib/models/nav_bar_config.dart`
- `lib/providers/nav_bar_config_provider.dart`
- `docs/NETWORK_SOURCES_PLAN.md`