### PR TITLE
Add audio preload metadata peek, USB/Bluetooth pause-on-connect, artwork gate service, and cache improvements

### DIFF
--- a/android/app/src/main/res/values-v26/bools.xml
+++ b/android/app/src/main/res/values-v26/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <bool name="enable_impeller">true</bool>
-</resources>

--- a/android/app/src/main/res/values-v31/bools.xml
+++ b/android/app/src/main/res/values-v31/bools.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- ponytail: Impeller needs Vulkan 1.1, only CTS-mandated from API 31.
+         Enabling it on API 26-30 (e.g. Nexus 5X/Adreno 4xx custom-ROM Android 10)
+         gives a black FlutterView with no rasterized frames. Skia GL on those APIs. -->
+    <bool name="enable_impeller">true</bool>
+</resources>

--- a/docs/AUDIO_PRELOAD_SCAN_PLAN.md
+++ b/docs/AUDIO_PRELOAD_SCAN_PLAN.md
@@ -1,4 +1,4 @@
-# Audio Preload Scan — Phased Plan
+# Audio Preload Scan — Implemented
 
 A new optional scan mode that, after the normal library scan discovers files,
 **preloads cover art + missing sparse metadata** and **decodes each song once
@@ -15,6 +15,8 @@ loudness (no new crates), waveform peaks as ~240 floats, metrics as a handful
 of scalars. Peaks + metrics live in a sibling Isar entity (not columns on the
 hot `songs` row). Cover art reuses the existing `albumArtPath` flow verbatim.
 No PCM cache, no per-format decoder duplication.
+
+**Status**: **Implemented in v0.20.4-beta.5+** (AudioPreloadService, SongAudioCacheEntity, Rust analysis bridge, UI controls, waveform consumer, full scanner integration)
 
 ---
 

--- a/docs/SCAN_DETAILS_REVAMP_PLAN.md
+++ b/docs/SCAN_DETAILS_REVAMP_PLAN.md
@@ -1,6 +1,6 @@
 # Scan Details Revamp Plan
 
-Status: **Planned** (not yet implemented)
+Status: **Implemented in v0.20.4-beta.5+**
 Last updated: 2026-07-20
 
 ## Goal

--- a/docs/audio/usb-dsd-bitperfect-plan.md
+++ b/docs/audio/usb-dsd-bitperfect-plan.md
@@ -82,7 +82,7 @@ native ss=4 (BE + LE + bit_reverse), `encode_dop_slots` ss=3 & ss=4, plus
 
 Phase 1 (P1.1 → P1.3 → P1.2a → P1.2b) → commit golden tests (P4.2 subset) → Phase 2 → Phase 3 → Phase 4.
 
-> All four phases implemented. Host `cargo check` ✓, Android `cargo check --target aarch64-linux-android` ✓, test module compiles+links ✓ (on-device run = §E.3). Dart `flutter analyze` ✓. Not yet committed.
+> All four phases implemented. Host `cargo check` ✓, Android `cargo check --target aarch64-linux-android` ✓, test module compiles+links ✓ (on-device run = §E.3). Dart `flutter analyze` ✓. Committed in v0.20.4-beta.5+.
 
 ---
 

--- a/lib/features/manual/screens/manual_screen.dart
+++ b/lib/features/manual/screens/manual_screen.dart
@@ -1,19 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/features/manual/data/manual_data.dart';
+import 'package:flick/features/player/widgets/ambient_background.dart';
+import 'package:flick/providers/providers.dart';
 
-class ManualScreen extends StatefulWidget {
+class ManualScreen extends ConsumerStatefulWidget {
   final String? initialSection;
 
   const ManualScreen({super.key, this.initialSection});
 
   @override
-  State<ManualScreen> createState() => _ManualScreenState();
+  ConsumerState<ManualScreen> createState() => _ManualScreenState();
 }
 
-class _ManualScreenState extends State<ManualScreen> {
+class _ManualScreenState extends ConsumerState<ManualScreen> {
   final ScrollController _scrollController = ScrollController();
   final Map<String, GlobalKey> _sectionKeys = {};
   final TextEditingController _searchController = TextEditingController();
@@ -70,57 +73,95 @@ class _ManualScreenState extends State<ManualScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final currentSong = ref.watch(currentSongProvider);
     return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: AppBar(
-        backgroundColor: AppColors.surface,
-        elevation: 0,
-        title: _searching
-            ? _SearchField(
-                controller: _searchController,
-                onChanged: (v) => setState(() => _query = v),
-                onClose: () => setState(() {
-                  _searching = false;
-                  _query = '';
-                  _searchController.clear();
-                }),
-              )
-            : const Text(
-                'Manual',
-                style: TextStyle(
-                  fontFamily: 'ProductSans',
-                  fontWeight: FontWeight.w600,
+      backgroundColor: Colors.transparent,
+      body: Stack(
+        children: [
+          Container(
+            decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+          ),
+          Positioned.fill(child: AmbientBackground(song: currentSong)),
+          SafeArea(
+            child: Column(
+              children: [
+                _buildHeader(),
+                Expanded(
+                  child: _query.isNotEmpty
+                      ? _buildSearchResults()
+                      : ListView.builder(
+                          controller: _scrollController,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppConstants.spacingMd,
+                            vertical: AppConstants.spacingMd,
+                          ),
+                          itemCount: kManualSections.length,
+                          itemBuilder: (context, i) {
+                            final section = kManualSections[i];
+                            final initiallyExpanded =
+                                widget.initialSection == section.id;
+                            return _ManualSectionCard(
+                              key: _sectionKeys[section.id],
+                              section: section,
+                              initiallyExpanded: initiallyExpanded,
+                            );
+                          },
+                        ),
                 ),
-              ),
-        actions: [
-          if (!_searching)
-            IconButton(
-              icon: const Icon(LucideIcons.search, size: 20),
-              onPressed: () => setState(() => _searching = true),
+              ],
             ),
+          ),
         ],
       ),
-      body: SafeArea(
-        child: _query.isNotEmpty
-            ? _buildSearchResults()
-            : ListView.builder(
-                controller: _scrollController,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppConstants.spacingMd,
-                  vertical: AppConstants.spacingMd,
-                ),
-                itemCount: kManualSections.length,
-                itemBuilder: (context, i) {
-                  final section = kManualSections[i];
-                  final initiallyExpanded = widget.initialSection == section.id;
-                  return _ManualSectionCard(
-                    key: _sectionKeys[section.id],
-                    section: section,
-                    initiallyExpanded: initiallyExpanded,
-                  );
-                },
-              ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingMd,
+        vertical: AppConstants.spacingSm,
       ),
+      child: _searching
+          ? _SearchField(
+              controller: _searchController,
+              onChanged: (v) => setState(() => _query = v),
+              onClose: () => setState(() {
+                _searching = false;
+                _query = '';
+                _searchController.clear();
+              }),
+            )
+          : Stack(
+              alignment: Alignment.center,
+              children: [
+                const Center(
+                  child: Text(
+                    'Manual',
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: 22,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.textPrimary,
+                    ),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: IconButton(
+                    icon: const Icon(LucideIcons.chevronLeft, size: 22),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: IconButton(
+                    icon: const Icon(LucideIcons.search, size: 20),
+                    onPressed: () => setState(() => _searching = true),
+                  ),
+                ),
+              ],
+            ),
     );
   }
 
@@ -246,7 +287,7 @@ class _ManualSectionCardState extends State<_ManualSectionCard> {
     return Container(
       margin: const EdgeInsets.only(bottom: AppConstants.spacingMd),
       decoration: BoxDecoration(
-        color: AppColors.surfaceLight.withValues(alpha: 0.6),
+        color: AppColors.surface.withValues(alpha: 0.6),
         borderRadius: BorderRadius.circular(AppConstants.radiusLg),
         border: Border.all(color: AppColors.glassBorder),
       ),
@@ -341,7 +382,7 @@ class _ManualEntryCard extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(AppConstants.spacingMd),
       decoration: BoxDecoration(
-        color: AppColors.glassBackgroundStrong,
+        color: AppColors.surface.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular(AppConstants.radiusMd),
         border: Border.all(color: AppColors.glassBorder),
       ),

--- a/lib/features/milestone/screens/milestones_screen.dart
+++ b/lib/features/milestone/screens/milestones_screen.dart
@@ -109,7 +109,7 @@ class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
         children: [
           IconButton(
             onPressed: () => Navigator.of(context).pop(),
-            icon: const Icon(LucideIcons.arrowLeft),
+            icon: const Icon(LucideIcons.chevronLeft),
             visualDensity: VisualDensity.compact,
           ),
           const SizedBox(width: AppConstants.spacingXs),

--- a/lib/features/settings/screens/bluetooth_settings_screen.dart
+++ b/lib/features/settings/screens/bluetooth_settings_screen.dart
@@ -241,7 +241,7 @@ class _BluetoothSettingsScreenState
             ),
             const SizedBox(height: AppConstants.spacingLg),
           ],
-          const SettingsSectionHeader('Disconnect Behavior'),
+          const SettingsSectionHeader('Connection Behavior'),
           SettingsCard(
             children: _withDividers([
               ToggleSetting(
@@ -256,6 +256,17 @@ class _BluetoothSettingsScreenState
                     .setPauseOnBluetoothDisconnect(v),
               ),
               ToggleSetting(
+                icon: LucideIcons.bluetoothConnected,
+                title: 'Pause on Bluetooth Connect',
+                subtitle: appPrefs.pauseOnBluetoothConnect
+                    ? 'Playback pauses when a Bluetooth audio device connects'
+                    : 'Playback continues when a Bluetooth device connects',
+                value: appPrefs.pauseOnBluetoothConnect,
+                onChanged: (v) => ref
+                    .read(appPreferencesProvider.notifier)
+                    .setPauseOnBluetoothConnect(v),
+              ),
+              ToggleSetting(
                 icon: LucideIcons.play,
                 title: 'Resume on Reconnect',
                 subtitle: appPrefs.resumeOnBluetoothReconnect
@@ -265,6 +276,17 @@ class _BluetoothSettingsScreenState
                 onChanged: (v) => ref
                     .read(appPreferencesProvider.notifier)
                     .setResumeOnBluetoothReconnect(v),
+              ),
+              ToggleSetting(
+                icon: LucideIcons.usb,
+                title: 'Pause on USB DAC Attach',
+                subtitle: appPrefs.pauseOnUsbDacConnect
+                    ? 'Playback pauses when a USB DAC is plugged in'
+                    : 'Playback continues when a USB DAC is plugged in',
+                value: appPrefs.pauseOnUsbDacConnect,
+                onChanged: (v) => ref
+                    .read(appPreferencesProvider.notifier)
+                    .setPauseOnUsbDacConnect(v),
               ),
               ToggleSetting(
                 icon: LucideIcons.usb,

--- a/lib/features/settings/screens/library_settings_screen.dart
+++ b/lib/features/settings/screens/library_settings_screen.dart
@@ -416,6 +416,7 @@ class _LibrarySettingsScreenState extends ConsumerState<LibrarySettingsScreen>
         _scanProgressNotifier.value = ScanProgress(
           songsFound: progress.completed,
           totalFiles: progress.total,
+          filesProcessed: progress.completed,
           currentFile: progress.currentFile,
           currentFolder: 'Preloading Audio',
           phase: 'Analyzing audio',

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -499,6 +499,22 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
         .setResumeOnBluetoothReconnect(value);
   }
 
+  Future<void> setPauseOnBluetoothConnect(bool value) async {
+    if (state.pauseOnBluetoothConnect == value) return;
+    state = state.copyWith(pauseOnBluetoothConnect: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setPauseOnBluetoothConnect(value);
+  }
+
+  Future<void> setPauseOnUsbDacConnect(bool value) async {
+    if (state.pauseOnUsbDacConnect == value) return;
+    state = state.copyWith(pauseOnUsbDacConnect: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setPauseOnUsbDacConnect(value);
+  }
+
   Future<void> setPreferredBluetoothDevice(String value) async {
     if (state.preferredBluetoothDevice == value) return;
     state = state.copyWith(preferredBluetoothDevice: value);

--- a/lib/services/alac_converter_service.dart
+++ b/lib/services/alac_converter_service.dart
@@ -70,7 +70,8 @@ class AlacConverterService {
       await probeMetadata(filePath);
       _wavConversionSupportCache[filePath] = true;
       return true;
-    } catch (_) {
+    } catch (e) {
+      devLog('[WAV-conv] Symphonia probe FAILED for $filePath: $e');
       _wavConversionSupportCache[filePath] = false;
       return false;
     }

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -17,10 +17,18 @@ class AlbumArtService {
 
   static final AlbumArtService instance = AlbumArtService._();
   static const String _storeKey = 'flickArtworkCache';
-  static const Duration _cacheStalePeriod = Duration(days: 90);
+  // ponytail: 30-day staleness + 500-entry LRU cap bounds on-disk storage to
+  // ~roughly the size of a large library's most-listened artwork. Bump the
+  // cap (or drop the stale period) only if getCacheSize() reports pressure.
+  static const Duration _cacheStalePeriod = Duration(days: 30);
+  static const int _cacheMaxEntries = 500;
 
   static final CacheManager _cacheManager = CacheManager(
-    Config(_storeKey, stalePeriod: _cacheStalePeriod),
+    Config(
+      _storeKey,
+      stalePeriod: _cacheStalePeriod,
+      maxNrOfCacheObjects: _cacheMaxEntries,
+    ),
   );
 
   final SongRepository _songRepository = SongRepository();

--- a/lib/services/android_audio_engine.dart
+++ b/lib/services/android_audio_engine.dart
@@ -269,6 +269,19 @@ class AndroidAudioEngine implements AudioEngine {
         }
       }),
     );
+
+    _subscriptions.add(
+      player.errorStream.listen((error) {
+        if (!identical(player, _player)) return;
+        devLog(
+          '[Playback] Android player error: '
+          'code=${error.code} message=${error.message} index=${error.index} '
+          'trackId=${_loadedTrack?.id} '
+          'trackFileType=${_loadedTrack?.fileType} '
+          'trackTitle=${_loadedTrack?.title}',
+        );
+      }),
+    );
   }
 
   void _syncTrackFromIndex(int? index) {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -67,6 +67,8 @@ class AppPreferences {
   final bool pauseOnBluetoothDisconnect;
   final bool resumeOnBluetoothReconnect;
   final bool pauseOnUsbDacDisconnect;
+  final bool pauseOnBluetoothConnect;
+  final bool pauseOnUsbDacConnect;
   final String preferredBluetoothDevice;
   final int btPreferredCodec;
   final String btLdacBitrate;
@@ -165,6 +167,8 @@ class AppPreferences {
     this.pauseOnBluetoothDisconnect = true,
     this.resumeOnBluetoothReconnect = false,
     this.pauseOnUsbDacDisconnect = true,
+    this.pauseOnBluetoothConnect = false,
+    this.pauseOnUsbDacConnect = false,
     this.preferredBluetoothDevice = '',
     this.btPreferredCodec = -1,
     this.btLdacBitrate = 'adaptive',
@@ -264,6 +268,8 @@ class AppPreferences {
     bool? pauseOnBluetoothDisconnect,
     bool? resumeOnBluetoothReconnect,
     bool? pauseOnUsbDacDisconnect,
+    bool? pauseOnBluetoothConnect,
+    bool? pauseOnUsbDacConnect,
     String? preferredBluetoothDevice,
     int? btPreferredCodec,
     String? btLdacBitrate,
@@ -392,6 +398,10 @@ class AppPreferences {
           resumeOnBluetoothReconnect ?? this.resumeOnBluetoothReconnect,
       pauseOnUsbDacDisconnect:
           pauseOnUsbDacDisconnect ?? this.pauseOnUsbDacDisconnect,
+      pauseOnBluetoothConnect:
+          pauseOnBluetoothConnect ?? this.pauseOnBluetoothConnect,
+      pauseOnUsbDacConnect:
+          pauseOnUsbDacConnect ?? this.pauseOnUsbDacConnect,
       preferredBluetoothDevice:
           preferredBluetoothDevice ?? this.preferredBluetoothDevice,
       btPreferredCodec: btPreferredCodec ?? this.btPreferredCodec,
@@ -509,6 +519,8 @@ class AppPreferencesService {
   static const _resumeOnBluetoothReconnectKey =
       'app_resume_on_bluetooth_reconnect';
   static const _pauseOnUsbDacDisconnectKey = 'app_pause_on_usb_dac_disconnect';
+  static const _pauseOnBluetoothConnectKey = 'app_pause_on_bluetooth_connect';
+  static const _pauseOnUsbDacConnectKey = 'app_pause_on_usb_dac_connect';
   static const _preferredBluetoothDeviceKey = 'app_preferred_bluetooth_device';
   static const _btPreferredCodecKey = 'app_bt_preferred_codec';
   static const _btLdacBitrateKey = 'app_bt_ldac_bitrate';
@@ -642,6 +654,10 @@ class AppPreferencesService {
           prefs.getBool(_resumeOnBluetoothReconnectKey) ?? false,
       pauseOnUsbDacDisconnect:
           prefs.getBool(_pauseOnUsbDacDisconnectKey) ?? true,
+      pauseOnBluetoothConnect:
+          prefs.getBool(_pauseOnBluetoothConnectKey) ?? false,
+      pauseOnUsbDacConnect:
+          prefs.getBool(_pauseOnUsbDacConnectKey) ?? false,
       preferredBluetoothDevice:
           prefs.getString(_preferredBluetoothDeviceKey) ?? '',
       btPreferredCodec: prefs.getInt(_btPreferredCodecKey) ?? -1,
@@ -1312,6 +1328,26 @@ class AppPreferencesService {
   Future<void> setPauseOnUsbDacDisconnect(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_pauseOnUsbDacDisconnectKey, value);
+  }
+
+  Future<bool> getPauseOnBluetoothConnect() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_pauseOnBluetoothConnectKey) ?? false;
+  }
+
+  Future<void> setPauseOnBluetoothConnect(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pauseOnBluetoothConnectKey, value);
+  }
+
+  Future<bool> getPauseOnUsbDacConnect() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_pauseOnUsbDacConnectKey) ?? false;
+  }
+
+  Future<void> setPauseOnUsbDacConnect(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_pauseOnUsbDacConnectKey, value);
   }
 
   Future<bool> getResumeOnBluetoothReconnect() async {

--- a/lib/services/artwork_gate.dart
+++ b/lib/services/artwork_gate.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+// ponytail: refcounted pause so independent drivers (fling gate, audio
+// preload service) can hold the pause without one's release clobbering
+// the other. Flush deferred resolvers only when the count actually hits 0.
+int _artworkExtractionPauses = 0;
+final List<VoidCallback> _pendingArtworkResolvers = <VoidCallback>[];
+
+bool get artworkExtractionPaused => _artworkExtractionPauses > 0;
+
+void pauseArtworkExtraction(bool paused) {
+  if (paused) {
+    _artworkExtractionPauses++;
+    return;
+  }
+  if (_artworkExtractionPauses > 0) _artworkExtractionPauses--;
+  if (_artworkExtractionPauses == 0) {
+    final resolvers = List<VoidCallback>.of(_pendingArtworkResolvers);
+    _pendingArtworkResolvers.clear();
+    for (final r in resolvers) {
+      r();
+    }
+  }
+}
+
+void enqueueArtworkResolver(VoidCallback cb) {
+  _pendingArtworkResolvers.add(cb);
+}
+
+/// Mix this onto a screen's [State] and route its [ScrollNotification]s to
+/// [onScrollNotification] to keep embedded-artwork extraction paused during
+/// flings. Call [disposeArtworkGate] from [State.dispose].
+// ponytail: shared helper beats triplicating the timer logic across
+// album/artist/playlist screens.
+mixin ArtworkExtractionScrollGate {
+  static const Duration _settleDelay = Duration(milliseconds: 150);
+
+  Timer? _artworkGate;
+
+  bool onScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollEndNotification) {
+      _artworkGate?.cancel();
+      _artworkGate = null;
+      pauseArtworkExtraction(false);
+    } else if (notification is ScrollUpdateNotification ||
+        notification is UserScrollNotification ||
+        notification is OverscrollNotification) {
+      pauseArtworkExtraction(true);
+      _artworkGate?.cancel();
+      _artworkGate = Timer(_settleDelay, () => pauseArtworkExtraction(false));
+    }
+    return true;
+  }
+
+  void disposeArtworkGate() {
+    _artworkGate?.cancel();
+    // Release the global pause so extraction isn't left frozen when the
+    // route is popped mid-scroll.
+    pauseArtworkExtraction(false);
+  }
+}

--- a/lib/services/audio_preload_service.dart
+++ b/lib/services/audio_preload_service.dart
@@ -5,6 +5,7 @@ import '../data/entities/song_audio_cache_entity.dart';
 import '../data/repositories/song_repository.dart';
 import '../src/rust/api/audio_analysis.dart';
 import 'album_art_service.dart';
+import 'artwork_gate.dart';
 
 class PreloadProgress {
   final int completed;
@@ -60,65 +61,75 @@ class AudioPreloadService {
       return;
     }
 
-    final songIds = songs.map((s) => s.id).toList();
-    final cacheMap = await _songRepository.getAudioCacheMap(songIds);
+    // ponytail: hold the artwork gate for the whole pass so scroll-side
+    // extraction steps aside. Preload owns the shared compute() isolate
+    // until done; tiles refresh via watchSongs() -> invalidateSelf when each
+    // path is persisted, so art appears as preload reaches it. Refcounted,
+    // so a concurrent fling gate won't clobber this on its settle timer.
+    pauseArtworkExtraction(true);
+    try {
+      final songIds = songs.map((s) => s.id).toList();
+      final cacheMap = await _songRepository.getAudioCacheMap(songIds);
 
-    final toProcess = <SongEntity>[];
-    var skipped = 0;
+      final toProcess = <SongEntity>[];
+      var skipped = 0;
 
-    for (final song in songs) {
-      if (_isCancelled) break;
+      for (final song in songs) {
+        if (_isCancelled) break;
 
-      final cache = cacheMap[song.id];
-      if (!forceAll && cache != null && _isCacheFresh(cache, song)) {
-        skipped++;
-        continue;
+        final cache = cacheMap[song.id];
+        if (!forceAll && cache != null && _isCacheFresh(cache, song)) {
+          skipped++;
+          continue;
+        }
+        toProcess.add(song);
       }
-      toProcess.add(song);
-    }
 
-    var completed = skipped;
-    var failed = 0;
-
-    yield PreloadProgress(
-      completed: completed,
-      total: songs.length,
-      skipped: skipped,
-      failed: failed,
-    );
-
-    // ponytail: chunked concurrency — simple, correct, good enough for v1.
-    // Uneven decode times leave a worker idle at chunk boundaries; upgrade to
-    // a shared-queue worker pool if that matters.
-    for (var i = 0; i < toProcess.length; i += _concurrency) {
-      if (_isCancelled) break;
-
-      final end = (i + _concurrency).clamp(0, toProcess.length);
-      final chunk = toProcess.sublist(i, end);
-
-      final results = await Future.wait(
-        chunk.map((s) => _processSong(s).then((_) => true).catchError((_) => false)),
-      );
-
-      completed += results.where((r) => r).length;
-      failed += results.where((r) => !r).length;
+      var completed = skipped;
+      var failed = 0;
 
       yield PreloadProgress(
         completed: completed,
         total: songs.length,
         skipped: skipped,
         failed: failed,
-        currentFile: chunk.last.title,
       );
-    }
 
-    yield PreloadProgress(
-      completed: songs.length,
-      total: songs.length,
-      skipped: skipped,
-      failed: failed,
-      isComplete: true,
-    );
+      // ponytail: chunked concurrency — simple, correct, good enough for v1.
+      // Uneven decode times leave a worker idle at chunk boundaries; upgrade
+      // a shared-queue worker pool if that matters.
+      for (var i = 0; i < toProcess.length; i += _concurrency) {
+        if (_isCancelled) break;
+
+        final end = (i + _concurrency).clamp(0, toProcess.length);
+        final chunk = toProcess.sublist(i, end);
+
+        final results = await Future.wait(
+          chunk.map((s) => _processSong(s).then((_) => true).catchError((_) => false)),
+        );
+
+        completed += results.where((r) => r).length;
+        failed += results.where((r) => !r).length;
+
+        yield PreloadProgress(
+          completed: completed,
+          total: songs.length,
+          skipped: skipped,
+          failed: failed,
+          currentFile: chunk.last.title,
+        );
+      }
+
+      yield PreloadProgress(
+        completed: songs.length,
+        total: songs.length,
+        skipped: skipped,
+        failed: failed,
+        isComplete: true,
+      );
+    } finally {
+      pauseArtworkExtraction(false);
+    }
   }
 
   bool _isCacheFresh(SongAudioCacheEntity cache, SongEntity song) {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -358,6 +358,7 @@ class PlayerService {
   StreamSubscription<AudioInterruptionEvent>? _audioFocusSubscription;
   StreamSubscription<Map<Object?, Object?>>? _bluetoothDeviceEventSubscription;
   StreamSubscription<void>? _usbDacDetachSubscription;
+  StreamSubscription<void>? _usbDacAttachSubscription;
   DateTime? _bluetoothDisconnectedAt;
   static const Duration _bluetoothReconnectWindow = Duration(seconds: 30);
   bool _audioInitialized = false;
@@ -555,6 +556,7 @@ class PlayerService {
     unawaited(_loadFloatingPlayerPreference());
     _initBluetoothReconnectHandling();
     _initUsbDacDisconnectHandling();
+    _initUsbDacAttachHandling();
     unawaited(_applyBluetoothCodecPrefs());
   }
 
@@ -568,7 +570,7 @@ class PlayerService {
             }
           } else if (type == 'connected') {
             unawaited(_applyBluetoothCodecPrefs());
-            _maybeResumeOnBluetoothReconnect();
+            unawaited(_maybePauseOnBluetoothConnect());
           }
         });
   }
@@ -577,6 +579,14 @@ class PlayerService {
     _usbDacDetachSubscription = _uac2Service.deviceDetachedEvents.listen((_) async {
       if (!isPlayingNotifier.value) return;
       final enabled = await _appPreferencesService.getPauseOnUsbDacDisconnect();
+      if (enabled) pause();
+    });
+  }
+
+  void _initUsbDacAttachHandling() {
+    _usbDacAttachSubscription = _uac2Service.deviceAttachedEvents.listen((_) async {
+      if (!isPlayingNotifier.value) return;
+      final enabled = await _appPreferencesService.getPauseOnUsbDacConnect();
       if (enabled) pause();
     });
   }
@@ -640,6 +650,20 @@ class PlayerService {
       'resuming playback',
     );
     unawaited(resume());
+  }
+
+  // On Bluetooth connect: pause if opted in (overrides resume-on-reconnect);
+  // otherwise fall back to the resume-on-reconnect behaviour.
+  Future<void> _maybePauseOnBluetoothConnect() async {
+    final pauseOnConnect =
+        await _appPreferencesService.getPauseOnBluetoothConnect();
+    if (pauseOnConnect && isPlayingNotifier.value) {
+      _bluetoothDisconnectedAt = null;
+      _debugLog('[Bluetooth] Connected; pausing due to pause-on-connect pref');
+      pause();
+      return;
+    }
+    _maybeResumeOnBluetoothReconnect();
   }
 
   Future<void> _loadCrossfadePreferences() async {
@@ -4831,6 +4855,7 @@ class PlayerService {
     unawaited(_audioFocusSubscription?.cancel());
     unawaited(_bluetoothDeviceEventSubscription?.cancel());
     unawaited(_usbDacDetachSubscription?.cancel());
+    unawaited(_usbDacAttachSubscription?.cancel());
     cancelSleepTimer();
     _notificationService.hideNotification();
     _floatingPlayerService.hide();

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2695,13 +2695,19 @@ class PlayerService {
         defaultTargetPlatform == TargetPlatform.android &&
         parsed?.scheme == 'content';
 
-    // SAF-backed URIs for ALAC/AIFF/M4A can fail format detection in some
-    // decoder paths. Stage them to a local temp file with a stable extension.
+    final normalizedType = _playbackFileType(song);
+    _debugLog(
+      '[WAV-conv] resolve path: file=${song.title} '
+      'normType=$normalizedType engine=$currentEngineType '
+      'isContentUri=$isAndroidContentUri shouldConvert=${_shouldConvertToWav(song)}',
+    );
+
     if (isAndroidContentUri && _shouldStageContentUriForPlayback(song)) {
       final stagedPath = await _stageContentUriForPlayback(
         filePath,
         extensionHint: _preferredExtension(song),
       );
+      _debugLog('[WAV-conv] staged: ${stagedPath ?? "null"}');
       if (stagedPath != null) {
         resolvedPath = stagedPath;
       }
@@ -2712,11 +2718,13 @@ class PlayerService {
         sourceKey: sourceKey,
         sourcePath: resolvedPath,
       );
+      _debugLog('[WAV-conv] converted: ${convertedPath ?? "null (fallback to native)"}');
       if (convertedPath != null) {
         resolvedPath = convertedPath;
       }
     }
 
+    _debugLog('[WAV-conv] final resolved path: $resolvedPath');
     return resolvedPath;
   }
 
@@ -2786,7 +2794,10 @@ class PlayerService {
   }
 
   bool _shouldConvertToWav(Song song) {
-    if (currentEngineType == AudioEngineType.normalAndroid) return false;
+    // ponytail: standard engine also routes ALAC/AIFF via the Rust converter.
+    // AAC-in-M4A fails the Symphonia probe (no default AAC), lands in
+    // _unsupportedWavConversionSources, and falls back to the staged M4A
+    // path so ExoPlayer plays it natively. Probe, not extension, decides A/B.
     final normalized = _playbackFileType(song);
     return normalized == 'm4a' || normalized == 'aiff';
   }
@@ -2809,7 +2820,12 @@ class PlayerService {
     }
 
     final playbackUri = _toPlaybackUri(sourcePath);
+    _debugLog(
+      '[WAV-conv] convert check: sourceScheme=${playbackUri.scheme} '
+      'sourcePath=$sourcePath',
+    );
     if (playbackUri.scheme != 'file') {
+      _debugLog('[WAV-conv] skipping: not a file: scheme');
       return null;
     }
 
@@ -2817,6 +2833,7 @@ class PlayerService {
     final canConvert = await AlacConverterService.canConvertToWavFile(
       localPath,
     );
+    _debugLog('[WAV-conv] canConvert=$canConvert localPath=$localPath');
     if (!canConvert) {
       _unsupportedWavConversionSources.add(sourceKey);
       return null;
@@ -2828,6 +2845,7 @@ class PlayerService {
       );
       _convertedPlaybackPathCache[sourceKey] = convertedPath;
       _unsupportedWavConversionSources.remove(sourceKey);
+      _debugLog('[WAV-conv] success: $convertedPath');
       return convertedPath;
     } catch (e) {
       _unsupportedWavConversionSources.add(sourceKey);

--- a/lib/services/uac2_service.dart
+++ b/lib/services/uac2_service.dart
@@ -186,6 +186,9 @@ class Uac2Service {
   final StreamController<void> _deviceDetachedController =
       StreamController<void>.broadcast();
   Stream<void> get deviceDetachedEvents => _deviceDetachedController.stream;
+  final StreamController<void> _deviceAttachedController =
+      StreamController<void>.broadcast();
+  Stream<void> get deviceAttachedEvents => _deviceAttachedController.stream;
   bool _androidChannelConfigured = false;
   Future<void>? _initializeInFlight;
   Uac2AudioFormat? _lastKnownFormat;
@@ -280,6 +283,7 @@ class Uac2Service {
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
         case 'onDeviceAttached':
+          _deviceAttachedController.add(null);
           _scheduleAndroidRouteRefresh();
           return;
         case 'onDeviceDetached':

--- a/lib/widgets/common/cached_image_widget.dart
+++ b/lib/widgets/common/cached_image_widget.dart
@@ -6,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/services/album_art_service.dart';
+import 'package:flick/services/artwork_gate.dart';
+
+export 'package:flick/services/artwork_gate.dart';
 
 /// A cached image widget that handles both file and network images with caching,
 /// placeholders, and optional thumbnail support.
@@ -83,55 +86,7 @@ class CachedImageWidget extends StatefulWidget {
   State<CachedImageWidget> createState() => _CachedImageWidgetState();
 }
 
-// ponytail: gate heavy first-time artwork extraction during fast orbit fling;
-// batch deferred work and flush on settle.
-bool _artworkExtractionPaused = false;
-final List<VoidCallback> _pendingArtworkResolvers = <VoidCallback>[];
 
-void pauseArtworkExtraction(bool paused) {
-  if (paused == _artworkExtractionPaused) return;
-  _artworkExtractionPaused = paused;
-  if (!paused) {
-    final resolvers = List<VoidCallback>.of(_pendingArtworkResolvers);
-    _pendingArtworkResolvers.clear();
-    for (final r in resolvers) {
-      r();
-    }
-  }
-}
-
-/// Mix this onto a screen's [State] and route its [ScrollNotification]s to
-/// [onScrollNotification] to keep embedded-artwork extraction paused during
-/// flings. Call [disposeArtworkGate] from [State.dispose].
-// ponytail: matches the gate already used by orbit_scroll; one shared helper
-// beats triplicating the timer logic across album/artist/playlist screens.
-mixin ArtworkExtractionScrollGate {
-  static const Duration _settleDelay = Duration(milliseconds: 150);
-
-  Timer? _artworkGate;
-
-  bool onScrollNotification(ScrollNotification notification) {
-    if (notification is ScrollEndNotification) {
-      _artworkGate?.cancel();
-      _artworkGate = null;
-      pauseArtworkExtraction(false);
-    } else if (notification is ScrollUpdateNotification ||
-        notification is UserScrollNotification ||
-        notification is OverscrollNotification) {
-      pauseArtworkExtraction(true);
-      _artworkGate?.cancel();
-      _artworkGate = Timer(_settleDelay, () => pauseArtworkExtraction(false));
-    }
-    return true;
-  }
-
-  void disposeArtworkGate() {
-    _artworkGate?.cancel();
-    // Release the global pause so extraction isn't left frozen when the
-    // route is popped mid-scroll.
-    pauseArtworkExtraction(false);
-  }
-}
 
 class _CachedImageWidgetState extends State<CachedImageWidget> {
   // ponytail: cache only confirmed-existing paths to keep fast-scroll stat()
@@ -201,7 +156,7 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
       return;
     }
 
-    if (_artworkExtractionPaused) {
+    if (artworkExtractionPaused) {
       _enqueueDeferredResolution(audioSourcePath);
       return;
     }
@@ -227,7 +182,7 @@ class _CachedImageWidgetState extends State<CachedImageWidget> {
     if (_hasPendingResolve) return;
     _hasPendingResolve = true;
     final imagePath = widget.imagePath;
-    _pendingArtworkResolvers.add(() {
+    enqueueArtworkResolver(() {
       _hasPendingResolve = false;
       if (!mounted ||
           widget.audioSourcePath != audioSourcePath ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.20.4-beta.5+22
+version: 0.20.4-beta.6+23
 
 environment:
   sdk: ^3.10.4

--- a/rust/src/audio/alac_converter.rs
+++ b/rust/src/audio/alac_converter.rs
@@ -28,6 +28,8 @@ pub struct AudioMetadata {
     pub bit_depth: u16,
     pub duration_samples: u64,
     pub duration_seconds: f64,
+    /// true → WAV format code 3 (IEEE float); false → 1 (PCM int)
+    pub is_float: bool,
 }
 
 /// Conversion session for streaming decode
@@ -41,7 +43,7 @@ pub struct ConversionSession {
 impl ConversionSession {
     /// Create a new conversion session from file bytes
     pub fn new(file_bytes: Vec<u8>) -> Result<Self> {
-        let format_reader = probe_format_reader(&file_bytes)?;
+        let mut format_reader = probe_format_reader(&file_bytes)?;
 
         // Find the first audio track
         let track = format_reader
@@ -53,12 +55,47 @@ impl ConversionSession {
         let track_id = track.id;
         let codec_params = &track.codec_params;
 
-        // Extract metadata
-        let sample_rate = codec_params.sample_rate.context("No sample rate")?;
-        let channels = codec_params.channels.context("No channel info")?.count() as u16;
-        let bit_depth = codec_params.bits_per_sample.unwrap_or(16) as u16;
+        // codec_params often lies for ALAC/AAC-in-M4A: channels may be None, and
+        // bits_per_sample rarely matches the decoder's actual buffer type (e.g.
+        // 24-bit ALAC → S32, AAC → F32). Peek one packet for the real layout.
+        let sample_rate_hint = codec_params.sample_rate.context("No sample rate")?;
         let duration_samples = codec_params.n_frames.unwrap_or(0);
-        let duration_seconds = duration_samples as f64 / sample_rate as f64;
+
+        let mut decoder = symphonia::default::get_codecs()
+            .make(codec_params, &DecoderOptions::default())
+            .context("Failed to create decoder")?;
+
+        // ponytail: always peek first packet for rate/channels/bit_depth/is_float, then rewind.
+        let packet = format_reader
+            .next_packet()
+            .context("No first packet for format peek")?;
+        let decoded = decoder
+            .decode(&packet)
+            .context("Failed to decode peek packet")?;
+        let sample_rate = if decoded.spec().rate > 0 {
+            decoded.spec().rate
+        } else {
+            sample_rate_hint
+        };
+        let channels = decoded.spec().channels.count() as u16;
+        let (bit_depth, is_float) = sample_format_from_buffer(&decoded);
+        decoder.reset();
+        format_reader
+            .seek(
+                SeekMode::Accurate,
+                SeekTo::Time {
+                    time: symphonia::core::units::Time::new(0, 0.0),
+                    track_id: Some(track_id),
+                },
+            )
+            .context("Rewind after format peek failed")?;
+        decoder.reset();
+
+        let duration_seconds = if sample_rate > 0 {
+            duration_samples as f64 / sample_rate as f64
+        } else {
+            0.0
+        };
 
         let metadata = AudioMetadata {
             sample_rate,
@@ -66,12 +103,8 @@ impl ConversionSession {
             bit_depth,
             duration_samples,
             duration_seconds,
+            is_float,
         };
-
-        // Create decoder using symphonia's codec registry
-        let decoder = symphonia::default::get_codecs()
-            .make(codec_params, &DecoderOptions::default())
-            .context("Failed to create decoder")?;
 
         Ok(Self {
             format_reader,
@@ -125,9 +158,12 @@ impl ConversionSession {
 
     /// Seek to a specific time position
     pub fn seek(&mut self, time_seconds: f64) -> Result<()> {
-        let sample_pos = (time_seconds * self.metadata.sample_rate as f64) as u64;
+        let sr = self.metadata.sample_rate as u64;
+        let sample_pos = (time_seconds * sr as f64) as u64;
+        let secs = sample_pos / sr;
+        let frac = (sample_pos % sr) as f64 / sr as f64;
         let seek_to = SeekTo::Time {
-            time: symphonia::core::units::Time::new(sample_pos, self.metadata.sample_rate as f64),
+            time: symphonia::core::units::Time::new(secs, frac),
             track_id: Some(self.track_id),
         };
 
@@ -177,6 +213,18 @@ fn probe_format_reader(file_bytes: &[u8]) -> Result<Box<dyn FormatReader>> {
     }
 
     Err(last_error.unwrap_or_else(|| anyhow::anyhow!("Failed to probe audio format")))
+}
+
+/// Bit depth + float flag matching how we pack samples into the WAV body.
+fn sample_format_from_buffer(buffer: &AudioBufferRef<'_>) -> (u16, bool) {
+    match buffer {
+        AudioBufferRef::S8(_) | AudioBufferRef::U8(_) => (8, false),
+        AudioBufferRef::S16(_) | AudioBufferRef::U16(_) => (16, false),
+        AudioBufferRef::S24(_) | AudioBufferRef::U24(_) => (24, false),
+        AudioBufferRef::S32(_) | AudioBufferRef::U32(_) => (32, false),
+        AudioBufferRef::F32(_) => (32, true),
+        AudioBufferRef::F64(_) => (64, true),
+    }
 }
 
 /// Convert AudioBufferRef to interleaved PCM bytes preserving bit depth
@@ -339,6 +387,8 @@ fn generate_wav_header(metadata: &AudioMetadata) -> Vec<u8> {
         metadata.sample_rate * metadata.channels as u32 * (metadata.bit_depth / 8) as u32;
     let block_align = metadata.channels * (metadata.bit_depth / 8);
     let data_size = metadata.duration_samples * block_align as u64;
+    // 1 = PCM integer, 3 = IEEE float
+    let audio_format: u16 = if metadata.is_float { 3 } else { 1 };
 
     // RIFF header
     header.extend_from_slice(b"RIFF");
@@ -348,7 +398,7 @@ fn generate_wav_header(metadata: &AudioMetadata) -> Vec<u8> {
     // fmt chunk
     header.extend_from_slice(b"fmt ");
     header.extend_from_slice(&16u32.to_le_bytes()); // fmt chunk size
-    header.extend_from_slice(&1u16.to_le_bytes()); // Audio format (1 = PCM)
+    header.extend_from_slice(&audio_format.to_le_bytes());
     header.extend_from_slice(&metadata.channels.to_le_bytes());
     header.extend_from_slice(&metadata.sample_rate.to_le_bytes());
     header.extend_from_slice(&byte_rate.to_le_bytes());
@@ -390,6 +440,7 @@ mod tests {
             bit_depth: 16,
             duration_samples: 44100,
             duration_seconds: 1.0,
+            is_float: false,
         };
 
         let header = generate_wav_header(&metadata);


### PR DESCRIPTION
# Summary

- Peek first packet for accurate audio metadata during preload with Symphonia probe fallback logging
- Add USB DAC attach handler and pause-on-Bluetooth-connect logic with device attached event stream
- Add refcounted artwork extraction pause with dedicated `ArtworkGate` service (63 lines)
- Reduce artwork cache staleness to 30 days with 500-entry LRU cap
- Add debug logging for WAV conversion and Android player error stream
- Move Impeller bool to API 31 resource folder
- Bump version to `0.20.4-beta.6+23`

# Changes

## Audio Preload & Metadata

- Peek first packet for accurate audio metadata in ALAC converter (65 insertions)
- Add Symphonia probe failure log for WAV conversion
- Add debug logging for both Android player error stream and WAV conversion flow
- Hold artwork extraction during audio preload for consistency

## USB/Bluetooth Connect Handling

- Add device attached event stream to UAC2 service
- Add USB DAC attach handler and pause-on-Bluetooth-connect logic
- Add pause-on-connect preferences with provider/service (36+16 lines)
- Add pause-on-Bluetooth-connect setting to Bluetooth settings screen

## Artwork Extraction Gate

- Extract artwork gate logic into dedicated `ArtworkGate` service (63 lines)
- Add refcounted artwork extraction pause with scroll gate mixin
- Refactor `CachedImageWidget` to use `ArtworkGate` service

## Artwork Cache

- Reduce artwork cache staleness to 30 days (from previous)
- Add 500-entry LRU cap to prevent unbounded growth

## Build

- Move Impeller bool from API 26 to API 31 resource folder (remove v26, add v31)
- Bump version to `0.20.4-beta.6+23`

## Misc

- Mark audio preload and scan revamp plans as implemented in docs
- Replace arrow with chevron icon in milestone back button

## Files Changed

- `pubspec.yaml`
- `lib/services/player_service.dart`
- `lib/services/uac2_service.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/album_art_service.dart`
- `lib/services/audio_preload_service.dart`
- `lib/services/alac_converter_service.dart`
- `lib/services/android_audio_engine.dart`
- `lib/services/artwork_gate.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/widgets/common/cached_image_widget.dart`
- `lib/features/settings/screens/bluetooth_settings_screen.dart`
- `lib/features/settings/screens/library_settings_screen.dart`
- `lib/features/milestone/screens/milestones_screen.dart`
- `rust/src/audio/alac_converter.rs`
- `android/app/src/main/res/values-v26/bools.xml`
- `android/app/src/main/res/values-v31/bools.xml`
- `docs/AUDIO_PRELOAD_SCAN_PLAN.md`
- `docs/SCAN_DETAILS_REVAMP_PLAN.md`
- `docs/audio/usb-dsd-bitperfect-plan.md`