### PR TITLE
Add multi-protocol network music sources (Subsonic, Jellyfin, UPnP, WebDAV), USB volume preferences, and engine fixes

### DIFF
--- a/android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt
@@ -16,6 +16,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
+import android.os.PowerManager
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
@@ -44,6 +45,7 @@ class MusicNotificationService : Service() {
     private lateinit var notificationManager: NotificationManager
     private var methodChannel: MethodChannel? = null
     private var isForegroundServiceStarted = false
+    private var wakeLock: PowerManager.WakeLock? = null
 
     private var currentTitle: String = "Unknown"
     private var currentArtist: String = "Unknown Artist"
@@ -202,6 +204,8 @@ class MusicNotificationService : Service() {
             notificationManager.notify(NOTIFICATION_ID, notification)
         }
 
+        updateWakeLock()
+
         return START_NOT_STICKY
     }
 
@@ -245,6 +249,10 @@ class MusicNotificationService : Service() {
             unregisterReceiver(noisyReceiver)
         } catch (e: Exception) {
         }
+        if (wakeLock?.isHeld == true) {
+            wakeLock?.release()
+        }
+        wakeLock = null
         mediaSession.release()
         isForegroundServiceStarted = false
         hideFloatingOverlay()
@@ -265,6 +273,11 @@ class MusicNotificationService : Service() {
             }
         } catch (_: Exception) {
         }
+
+        if (wakeLock?.isHeld == true) {
+            wakeLock?.release()
+        }
+        wakeLock = null
 
         try {
             FlutterEngineCache.getInstance().remove("main_engine")
@@ -440,6 +453,34 @@ class MusicNotificationService : Service() {
         }
 
         mediaSession.setPlaybackState(stateBuilder.build())
+    }
+
+    private fun updateWakeLock() {
+        val pm = getSystemService(Context.POWER_SERVICE) as? PowerManager
+        if (pm == null) {
+            android.util.Log.w("MusicNotification", "[WakeLock] PowerManager unavailable")
+            return
+        }
+
+        if (isPlaying) {
+            if (wakeLock == null) {
+                wakeLock = pm.newWakeLock(
+                    PowerManager.PARTIAL_WAKE_LOCK,
+                    "Flick:audio_playback"
+                ).apply {
+                    setReferenceCounted(false)
+                }
+            }
+            if (wakeLock?.isHeld != true) {
+                wakeLock?.acquire(/* 1 hour max, auto-renewed on each notification update */)
+                android.util.Log.d("MusicNotification", "[WakeLock] Acquired PARTIAL_WAKE_LOCK")
+            }
+        } else {
+            if (wakeLock?.isHeld == true) {
+                wakeLock?.release()
+                android.util.Log.d("MusicNotification", "[WakeLock] Released PARTIAL_WAKE_LOCK")
+            }
+        }
     }
 
     private fun syncAudioFocusState() {

--- a/docs/NETWORK_SOURCES_PLAN.md
+++ b/docs/NETWORK_SOURCES_PLAN.md
@@ -16,6 +16,29 @@ as a seekable `MediaSource` — same decoders, same DSP, same DSD pipeline. No
 server-side transcode requests; if a server transcodes by default we pass the
 raw-format params to opt out. We do not ship a parallel `just_audio` HTTP path.
 
+**Status**: Phase 1 done. P1.1–P1.3 (`NetworkServerEntity` + registration in
+`database.dart`, `SongEntity` source fields, `PlaybackSource.network`,
+`NetworkCacheService` with LRU eviction; `path` promoted to a direct dep),
+P1.4–P1.8 (SubsonicService, RemoteSourceService, Network Sources settings UI,
+next-track prefetch, network cover art), and P7.1 + P7.2 (cache + Subsonic
+auth unit tests) all shipped. Tests: `test/services/subsonic_service_test.dart`
+(spec known-answer vector for auth, URL params, field mapping, pagination,
+double-tolerant numeric fields).
+
+Small deviations from the text below, all benign:
+- Subsonic token order is the spec-correct `t = md5(password + salt)` — P1.4's
+  parenthetical had the operands reversed; pinned by the P7.2 test.
+- Download progress surfaces on `RemoteSourceService.downloadProgressNotifier`
+  (a per-song download shouldn't pop the library-scan overlay); sync progress
+  reuses the `ScanProgress` class over the same stream shape.
+- Network songs get synthetic `subsonic://<serverId>/<remoteId>` file paths
+  (unique, satisfies the composite index) and keep a `subsonic-cover://<id>`
+  marker in `SongEntity.albumArtPath` so cover art re-resolves after eviction.
+- Save does not auto-trigger a sync; sync is manual per server (refresh icon),
+  matching F.2's "no background polling".
+- Playback errors log via `LogSource.dart` (`LogSource.source` doesn't exist
+  yet).
+
 ---
 
 ## A. What "self-hosted local & cloud server playing" means here
@@ -89,20 +112,20 @@ adapters live entirely on the Dart side and produce either a cached file path
 
 | # | Gap | Severity | Location |
 |---|-----|----------|----------|
-| N1 | No `remoteId` / `sourceType` / `remoteServerId` on `SongEntity`. | High | `lib/data/entities/song_entity.dart` |
-| N2 | No `network` value on `PlaybackSource`; UI label plumbing assumes local. | Medium | `lib/models/playback_context.dart:1` |
-| N3 | No `NetworkServer` config entity (id, label, protocol, baseUrl, user, token, lastSyncedAt). | High | new `lib/data/entities/network_server_entity.dart` |
-| N4 | No `NetworkCacheService` (bounded LRU download cache). | High | new `lib/services/network_cache_service.dart` |
-| N5 | No `RemoteSource` abstraction over the audio path (v1: path; v2: `MediaSource`). | High | `lib/services/remote_source_service.dart` (v1), `rust/src/audio/http_source.rs` (v2) |
-| N6 | No Subsonic adapter (auth salt+md5, `ping`/`getArtists`/`getAlbum`/`stream`). | High | new `lib/services/sources/subsonic_service.dart` |
+| N1 | ~~No `remoteId` / `sourceType` / `remoteServerId` on `SongEntity`.~~ **Done (P1.2)** | High | `lib/data/entities/song_entity.dart` |
+| N2 | ~~No `network` value on `PlaybackSource`; UI label plumbing assumes local.~~ **Done (P1.2)** | Medium | `lib/models/playback_context.dart:1` |
+| N3 | ~~No `NetworkServer` config entity (id, label, protocol, baseUrl, user, token, lastSyncedAt).~~ **Done (P1.1)** | High | `lib/data/entities/network_server_entity.dart` |
+| N4 | ~~No `NetworkCacheService` (bounded LRU download cache).~~ **Done (P1.3)** | High | `lib/services/network_cache_service.dart` |
+| N5 | ~~No `RemoteSource` abstraction over the audio path (v1: path; v2: `MediaSource`).~~ **Done (P1.5, v1 path)** | High | `lib/services/remote_source_service.dart` (v1), `rust/src/audio/http_source.rs` (v2) |
+| N6 | ~~No Subsonic adapter (auth salt+md5, `ping`/`getArtists`/`getAlbum`/`stream`).~~ **Done (P1.4)** | High | `lib/services/sources/subsonic_service.dart` |
 | N7 | No WebDAV adapter (PROPFIND album list, GET file). | Medium | new `lib/services/sources/webdav_service.dart` |
 | N8 | No Jellyfin adapter (`/Users/.../Items` browse, `/Audio/<id>/stream`). | Medium | new `lib/services/sources/jellyfin_service.dart` |
-| N9 | No "Network Sources" settings screen; no add/edit/test flow. | High | new `lib/features/settings/screens/network_sources_screen.dart` |
+| N9 | ~~No "Network Sources" settings screen; no add/edit/test flow.~~ **Done (P1.6)** | High | `lib/features/settings/screens/network_sources_screen.dart` |
 | N10 | Audio engine has no HTTP `MediaSource` (v2). | Medium (v2) | `rust/src/audio/source.rs`, `rust/src/api/audio_api.rs` |
-| N11 | Gapless/crossfade assumes next file is local & instant. Network next-track needs prefetch. | Medium | `lib/services/queue/` (prefetch on `position < duration - 10s`) |
+| N11 | ~~Gapless/crossfade assumes next file is local & instant. Network next-track needs prefetch.~~ **Done (P1.7)** | Medium | `lib/services/player_service.dart` (`_maybePrefetchNextNetworkSong`) |
 | N12 | No SMB adapter. | Low (deferred) | needs `smb_connect` or Rust `pavao`/`puffer` crate |
 | N13 | No UPnP/DLNA media-server adapter. | Low (deferred) | needs `upnp-client` crate; `FEATURE_REQUESTS.md` already lists DLNA casting (separate direction) |
-| N14 | Album-art, lyrics, and Replay hand off network songs through paths that assume local files. | Medium | `album_art_service.dart`, `lyrics_service.dart`, `recap` — resolve network art to cache bytes, lyrics to LRCLib as today |
+| N14 | ~~Album-art, lyrics, and Replay hand off network songs through paths that assume local files.~~ **Done (P1.8)** | Medium | `album_art_service.dart`, `lyrics_service.dart`, `recap` — resolve network art to cache bytes, lyrics to LRCLib as today |
 
 ---
 
@@ -112,14 +135,14 @@ adapters live entirely on the Dart side and produce either a cached file path
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P1.1 | N3 | `NetworkServerEntity` (id, label, protocol, baseUrl, username, token (salted-hash, not plaintext — store the Subsonic `sHex` salt+md5 form), lastSyncedAt). Register in `database.dart`. |
-| P1.2 | N1, N2 | Add `sourceType`, `remoteId`, `remoteServerId` to `SongEntity`; `network` to `PlaybackSource` with label "Network"; UI label plumbing. Local songs: the three new fields null. |
-| P1.3 | N4 | `NetworkCacheService`: LRU dir with size cap (default 2 GB), `getPath(remoteServerId, remoteId)` → cached `<hash>.<ext>` or null, `stash(bytes, ...)` evicting oldest past cap. One class, stdlib + `path` + `crypto` (already deps). |
-| P1.4 | N6 | `SubsonicService`: salt+md5 auth (`t=<md5(salt+pw)>&s=<salt>`), `ping`, `getArtists`/`getAlbumList2`/`getAlbum` (build `SongEntity`s with `sourceType=subsonic`), `getCoverArt` → write to album-art cache like existing `album_art_service.dart:101`, `stream(id)` → `http.get(stream)` with opt-out transcode params, body → `NetworkCacheService.stash`. |
-| P1.5 | N5, v1 | `RemoteSourceService.play(remoteSong)`: if cached → existing `playFile(path)`; else kick download (with progress → existing `_scanProgressNotifier` plumbing reused), then `playFile`. |
-| P1.6 | N9 | "Network Sources" settings screen: list, add (server URL + user + password + "Test" button), edit, delete. Test calls `ping`. |
-| P1.7 | N11 | Prefetch: when queue position < duration − 10 s and next song is `sourceType=subsonic`, start `stream(id)` download into cache so gapless/crossfade reads a local path at handoff. |
-| P1.8 | N14 | Cover art for network songs resolves via `getCoverArt` bytes → existing `albumArtPath` flow; lyrics fall back to LRCLib as today (network songs have no local tags to mine). |
+| P1.1 **(done)** | N3 | `NetworkServerEntity` (id, label, protocol, baseUrl, username, token (salted-hash, not plaintext — store the Subsonic `sHex` salt+md5 form), lastSyncedAt). Register in `database.dart`. |
+| P1.2 **(done)** | N1, N2 | Add `sourceType`, `remoteId`, `remoteServerId` to `SongEntity`; `network` to `PlaybackSource` with label "Network"; UI label plumbing. Local songs: the three new fields null. |
+| P1.3 **(done)** | N4 | `NetworkCacheService`: LRU dir with size cap (default 2 GB), `getPath(remoteServerId, remoteId)` → cached `<hash>.<ext>` or null, `stash(bytes, ...)` evicting oldest past cap. One class, stdlib + `path` + `crypto` (already deps). |
+| P1.4 **(done)** | N6 | `SubsonicService`: salt+md5 auth (`t=md5(password+salt)&s=<salt>` — spec order, password first), `ping`, `getAlbumList2` (paginated) / `getAlbum` (build `SongEntity`s with `sourceType=subsonic`, synthetic `subsonic://<serverId>/<remoteId>` paths), `getCoverArt` → album-art cache via `album_art_service.dart`, `stream(id)` → `http.get(stream)` with no transcode params, body → `NetworkCacheService.stash`. Sync = metadata fetch + upsert + stale purge + `lastSyncedAt` stamp. |
+| P1.5 **(done)** | N5, v1 | `RemoteSourceService.ensureLocal(remoteSong)`: cached → existing local path; miss → download (progress on `downloadProgressNotifier`), then play. `player_service.dart` branches at the top of `_resolvePreparedPlaybackPath`, so both engines (just_audio + Rust) reuse it. |
+| P1.6 **(done)** | N9 | "Network Sources" settings screen: list (label, protocol chip, URL, synced-at, edit/delete/sync), add (URL + user + password + "Test" button), edit, delete. Test calls `ping`. Protocol picker: Subsonic enabled; WebDAV/Jellyfin/SMB/UPnP greyed with "needs a new dependency". Password salted+hashed at save, plaintext never persisted. |
+| P1.7 **(done)** | N11 | Prefetch: 5 s position timer checks position ≥ duration − 10 s and next song is `sourceType=subsonic`, starts `stream(id)` download into cache (marker prevents repeats) so gapless/crossfade reads a local path at handoff. |
+| P1.8 **(done)** | N14 | Cover art for network songs resolves via `getCoverArt` bytes (marker `subsonic-cover://<id>` in `albumArtPath`) → existing `albumArtPath` cache flow; lyrics fall back to LRCLib as today (network songs have no local tags to mine). |
 
 ### Phase 2 — WebDAV (Nextcloud, ownCloud, generic)
 
@@ -163,8 +186,8 @@ adapters live entirely on the Dart side and produce either a cached file path
 
 | Task | Change |
 |------|--------|
-| P7.1 | Dart unit test for `NetworkCacheService`: cap is enforced; LRU evicts oldest on overflow; `stash` then `getPath` returns the same file. |
-| P7.2 | Dart unit test for `SubsonicService` auth: with a known salt+password, assert the `t=`/`s=` query matches the documented md5(salt+password) form. Use a mock `http.Client` for `ping`/`getAlbum`. |
+| P7.1 **(done)** | Dart unit test for `NetworkCacheService`: cap is enforced; LRU evicts oldest on overflow; `stash` then `getPath` returns the same file. |
+| P7.2 **(done)** | Dart unit test for `SubsonicService` auth: known salt+password (`sesame`/`c19b2d` → `t=26719a1196d2a940705a59634eb18eab`), asserts `t=`/`s=` query params against the spec form `md5(password+salt)`; mock `http.Client` for `ping`/`getAlbum`/`getAlbumList2`. |
 | P7.3 | Dart integration test: configure a server pointing at a fixture (or a recorded HTTP cassette), "scan" returns `SongEntity`s with `sourceType=subsonic` and `remoteId` set. |
 | P7.4 | (v2) Rust `#[test]` for `HttpMediaSource`: a `Cursor`-backed fake server, `read` returns contiguous bytes, `seek` followed by `read` returns the right slice, `stream_len` matches. |
 | P7.5 | Manual: real Navidrome + real Jellyfin + a Nextcloud over WebDAV, on both LAN and a cloud VPS, through a USB DAC. Confirm bit-perfect badge, native DSD passthrough on a DSF served by Navidrome, gapless between two network songs, crossfade between a local and a network song. |
@@ -182,10 +205,12 @@ adapters live entirely on the Dart side and produce either a cached file path
 3. Enter label, base URL, username, password (Subsonic) / bearer token
    (WebDAV) / username+password (Jellyfin, exchanged for a token on first
    connect). Stored on `NetworkServerEntity`. Passwords never logged; the
-   Subsonic salt+md5 is computed at request time, plaintext not retained.
+   Subsonic salt+md5 is computed at save time and stored as the
+   `salt:md5hex` token — plaintext is not retained.
 4. "Test connection" → adapter `ping`/`PROPFIND`/`AuthenticateByName`. Show
    pass/fail with the server-reported version string.
-5. Save → trigger a network scan (metadata fetch) for that server.
+5. Save, then sync manually per server (refresh icon) — F.2's "no background
+   polling" applies.
 
 ### F.2 Library sync (not a file walk)
 
@@ -203,17 +228,17 @@ adapters live entirely on the Dart side and produce either a cached file path
 
 ### F.3 Playback
 
-- Tap a network song → `RemoteSourceService.play`:
-  - **v1:** `NetworkCacheService.getPath(...)` → hit → `playFile(path)`. Miss
+- Tap a network song → `RemoteSourceService.ensureLocal`:
+  - **v1:** `NetworkCacheService.getPath(...)` → hit → cached path. Miss
     → download `stream`/`GET`/`/Audio/.../stream` with raw-format params →
-    `stash` → `playFile`. Progress shown via existing scan-progress notifier.
+    `stash` → cached path. Progress on `downloadProgressNotifier`.
   - **v2:** `play_from_http(url, headers)` if range-supported, else v1 path.
 - Gapless/crossfade: prefetch next network song into cache when current
   position ≤ duration − 10 s (Phase 1.7). The crossfader already reads file
   paths; it doesn't care they came from HTTP.
 - Error handling: transport failure mid-stream → log via `app_log.dart`
-  (`LogSource.source`), surface a toast, advance or halt per user setting.
-  Partial cache file deleted.
+  (`LogSource.dart`; `LogSource.source` doesn't exist yet), surface a toast,
+  advance or halt per user setting. Partial cache file deleted.
 
 ### F.4 Cache & storage
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -5,12 +5,14 @@ import 'package:path_provider/path_provider.dart';
 
 import 'entities/artist_entity.dart';
 import 'entities/folder_entity.dart';
+import 'entities/network_server_entity.dart';
 import 'entities/recently_played_entity.dart';
 import 'entities/song_audio_cache_entity.dart';
 import 'entities/song_entity.dart';
 
 export 'entities/artist_entity.dart';
 export 'entities/folder_entity.dart';
+export 'entities/network_server_entity.dart';
 export 'entities/recently_played_entity.dart';
 export 'entities/song_audio_cache_entity.dart';
 export 'entities/song_entity.dart';
@@ -39,6 +41,7 @@ class Database {
       RecentlyPlayedEntitySchema,
       ArtistEntitySchema,
       SongAudioCacheEntitySchema,
+      NetworkServerEntitySchema,
     ];
 
     try {
@@ -114,4 +117,8 @@ class Database {
   /// Get the song audio cache collection.
   static IsarCollection<SongAudioCacheEntity> get songAudioCache =>
       _instance!.songAudioCacheEntitys;
+
+  /// Get the network server collection.
+  static IsarCollection<NetworkServerEntity> get networkServers =>
+      _instance!.networkServerEntitys;
 }

--- a/lib/data/entities/network_server_entity.dart
+++ b/lib/data/entities/network_server_entity.dart
@@ -1,0 +1,29 @@
+import 'package:isar_community/isar.dart';
+
+part 'network_server_entity.g.dart';
+
+/// Configured self-hosted music server (Subsonic / WebDAV / Jellyfin).
+@collection
+class NetworkServerEntity {
+  Id id = Isar.autoIncrement;
+
+  /// Display name shown in the Network Sources settings screen.
+  late String label;
+
+  /// Protocol: 'subsonic' | 'webdav' | 'jellyfin' (SMB/UPnP deferred).
+  late String protocol;
+
+  /// Base URL of the server, e.g. https://music.example.com/subsonic.
+  late String baseUrl;
+
+  /// User name used for authentication.
+  String? username;
+
+  /// Secret, never plaintext: Subsonic stores the salt+md5 hex form
+  /// (`salt:md5hex`), Jellyfin stores the server-issued token, WebDAV the
+  /// bearer token.
+  String? token;
+
+  /// Last time a library sync (metadata fetch) succeeded for this server.
+  DateTime? lastSyncedAt;
+}

--- a/lib/data/entities/network_server_entity.g.dart
+++ b/lib/data/entities/network_server_entity.g.dart
@@ -1,0 +1,1405 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'network_server_entity.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetNetworkServerEntityCollection on Isar {
+  IsarCollection<NetworkServerEntity> get networkServerEntitys =>
+      this.collection();
+}
+
+const NetworkServerEntitySchema = CollectionSchema(
+  name: r'NetworkServerEntity',
+  id: 6116953719064664553,
+  properties: {
+    r'baseUrl': PropertySchema(id: 0, name: r'baseUrl', type: IsarType.string),
+    r'label': PropertySchema(id: 1, name: r'label', type: IsarType.string),
+    r'lastSyncedAt': PropertySchema(
+      id: 2,
+      name: r'lastSyncedAt',
+      type: IsarType.dateTime,
+    ),
+    r'protocol': PropertySchema(
+      id: 3,
+      name: r'protocol',
+      type: IsarType.string,
+    ),
+    r'token': PropertySchema(id: 4, name: r'token', type: IsarType.string),
+    r'username': PropertySchema(
+      id: 5,
+      name: r'username',
+      type: IsarType.string,
+    ),
+  },
+
+  estimateSize: _networkServerEntityEstimateSize,
+  serialize: _networkServerEntitySerialize,
+  deserialize: _networkServerEntityDeserialize,
+  deserializeProp: _networkServerEntityDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+
+  getId: _networkServerEntityGetId,
+  getLinks: _networkServerEntityGetLinks,
+  attach: _networkServerEntityAttach,
+  version: '3.3.2',
+);
+
+int _networkServerEntityEstimateSize(
+  NetworkServerEntity object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.baseUrl.length * 3;
+  bytesCount += 3 + object.label.length * 3;
+  bytesCount += 3 + object.protocol.length * 3;
+  {
+    final value = object.token;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.username;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _networkServerEntitySerialize(
+  NetworkServerEntity object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.baseUrl);
+  writer.writeString(offsets[1], object.label);
+  writer.writeDateTime(offsets[2], object.lastSyncedAt);
+  writer.writeString(offsets[3], object.protocol);
+  writer.writeString(offsets[4], object.token);
+  writer.writeString(offsets[5], object.username);
+}
+
+NetworkServerEntity _networkServerEntityDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = NetworkServerEntity();
+  object.baseUrl = reader.readString(offsets[0]);
+  object.id = id;
+  object.label = reader.readString(offsets[1]);
+  object.lastSyncedAt = reader.readDateTimeOrNull(offsets[2]);
+  object.protocol = reader.readString(offsets[3]);
+  object.token = reader.readStringOrNull(offsets[4]);
+  object.username = reader.readStringOrNull(offsets[5]);
+  return object;
+}
+
+P _networkServerEntityDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readString(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 3:
+      return (reader.readString(offset)) as P;
+    case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (reader.readStringOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _networkServerEntityGetId(NetworkServerEntity object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _networkServerEntityGetLinks(
+  NetworkServerEntity object,
+) {
+  return [];
+}
+
+void _networkServerEntityAttach(
+  IsarCollection<dynamic> col,
+  Id id,
+  NetworkServerEntity object,
+) {
+  object.id = id;
+}
+
+extension NetworkServerEntityQueryWhereSort
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QWhere> {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension NetworkServerEntityQueryWhere
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QWhereClause> {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhereClause>
+  idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(lower: id, upper: id));
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhereClause>
+  idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhereClause>
+  idGreaterThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhereClause>
+  idLessThan(Id id, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterWhereClause>
+  idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.between(
+          lower: lowerId,
+          includeLower: includeLower,
+          upper: upperId,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+}
+
+extension NetworkServerEntityQueryFilter
+    on
+        QueryBuilder<
+          NetworkServerEntity,
+          NetworkServerEntity,
+          QFilterCondition
+        > {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlEqualTo(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'baseUrl',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'baseUrl',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'baseUrl',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'baseUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  baseUrlIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'baseUrl', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'id', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  idGreaterThan(Id value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'id',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  idLessThan(Id value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'id',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'id',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelEqualTo(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'label',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'label',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'label',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'label', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  labelIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'label', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'lastSyncedAt'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'lastSyncedAt'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'lastSyncedAt', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtGreaterThan(DateTime? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'lastSyncedAt',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtLessThan(DateTime? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'lastSyncedAt',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  lastSyncedAtBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'lastSyncedAt',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolEqualTo(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'protocol',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'protocol',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'protocol',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'protocol', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  protocolIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'protocol', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'token'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'token'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenEqualTo(String? value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'token',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'token',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'token',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'token', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  tokenIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'token', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'username'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'username'),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameEqualTo(String? value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'username',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'username',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'username',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'username', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterFilterCondition>
+  usernameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'username', value: ''),
+      );
+    });
+  }
+}
+
+extension NetworkServerEntityQueryObject
+    on
+        QueryBuilder<
+          NetworkServerEntity,
+          NetworkServerEntity,
+          QFilterCondition
+        > {}
+
+extension NetworkServerEntityQueryLinks
+    on
+        QueryBuilder<
+          NetworkServerEntity,
+          NetworkServerEntity,
+          QFilterCondition
+        > {}
+
+extension NetworkServerEntityQuerySortBy
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QSortBy> {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByBaseUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByBaseUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByLabel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByLabelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByLastSyncedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastSyncedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByLastSyncedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastSyncedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByProtocol() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'protocol', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByProtocolDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'protocol', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByToken() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'token', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByTokenDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'token', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByUsername() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'username', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  sortByUsernameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'username', Sort.desc);
+    });
+  }
+}
+
+extension NetworkServerEntityQuerySortThenBy
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QSortThenBy> {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByBaseUrl() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByBaseUrlDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'baseUrl', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByLabel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByLabelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'label', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByLastSyncedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastSyncedAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByLastSyncedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastSyncedAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByProtocol() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'protocol', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByProtocolDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'protocol', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByToken() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'token', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByTokenDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'token', Sort.desc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByUsername() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'username', Sort.asc);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QAfterSortBy>
+  thenByUsernameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'username', Sort.desc);
+    });
+  }
+}
+
+extension NetworkServerEntityQueryWhereDistinct
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct> {
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByBaseUrl({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'baseUrl', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByLabel({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'label', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByLastSyncedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lastSyncedAt');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByProtocol({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'protocol', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByToken({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'token', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, NetworkServerEntity, QDistinct>
+  distinctByUsername({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'username', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension NetworkServerEntityQueryProperty
+    on QueryBuilder<NetworkServerEntity, NetworkServerEntity, QQueryProperty> {
+  QueryBuilder<NetworkServerEntity, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, String, QQueryOperations>
+  baseUrlProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'baseUrl');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, String, QQueryOperations> labelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'label');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, DateTime?, QQueryOperations>
+  lastSyncedAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lastSyncedAt');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, String, QQueryOperations>
+  protocolProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'protocol');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, String?, QQueryOperations> tokenProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'token');
+    });
+  }
+
+  QueryBuilder<NetworkServerEntity, String?, QQueryOperations>
+  usernameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'username');
+    });
+  }
+}

--- a/lib/data/entities/song_entity.dart
+++ b/lib/data/entities/song_entity.dart
@@ -107,4 +107,17 @@ class SongEntity {
   /// of being overwritten by file tags.
   @Index()
   bool hasLocalEdits = false;
+
+  /// Where this song came from: null = local file, otherwise one of
+  /// 'subsonic' | 'webdav' | 'jellyfin'.
+  @Index()
+  String? sourceType;
+
+  /// The server's song id (Subsonic song id, WebDAV file URL, Jellyfin Item.Id).
+  @Index()
+  String? remoteId;
+
+  /// [NetworkServerEntity.id] of the server this song was synced from.
+  @Index()
+  int? remoteServerId;
 }

--- a/lib/data/entities/song_entity.g.dart
+++ b/lib/data/entities/song_entity.g.dart
@@ -100,25 +100,40 @@ const SongEntitySchema = CollectionSchema(
       name: r'readMode',
       type: IsarType.string,
     ),
-    r'ripper': PropertySchema(id: 23, name: r'ripper', type: IsarType.string),
-    r'sampleRate': PropertySchema(
+    r'remoteId': PropertySchema(
+      id: 23,
+      name: r'remoteId',
+      type: IsarType.string,
+    ),
+    r'remoteServerId': PropertySchema(
       id: 24,
+      name: r'remoteServerId',
+      type: IsarType.long,
+    ),
+    r'ripper': PropertySchema(id: 25, name: r'ripper', type: IsarType.string),
+    r'sampleRate': PropertySchema(
+      id: 26,
       name: r'sampleRate',
       type: IsarType.long,
     ),
+    r'sourceType': PropertySchema(
+      id: 27,
+      name: r'sourceType',
+      type: IsarType.string,
+    ),
     r'startOffsetMs': PropertySchema(
-      id: 25,
+      id: 28,
       name: r'startOffsetMs',
       type: IsarType.long,
     ),
-    r'testCrc': PropertySchema(id: 26, name: r'testCrc', type: IsarType.string),
-    r'title': PropertySchema(id: 27, name: r'title', type: IsarType.string),
+    r'testCrc': PropertySchema(id: 29, name: r'testCrc', type: IsarType.string),
+    r'title': PropertySchema(id: 30, name: r'title', type: IsarType.string),
     r'trackNumber': PropertySchema(
-      id: 28,
+      id: 31,
       name: r'trackNumber',
       type: IsarType.long,
     ),
-    r'year': PropertySchema(id: 29, name: r'year', type: IsarType.long),
+    r'year': PropertySchema(id: 32, name: r'year', type: IsarType.long),
   },
 
   estimateSize: _songEntityEstimateSize,
@@ -236,6 +251,45 @@ const SongEntitySchema = CollectionSchema(
         ),
       ],
     ),
+    r'sourceType': IndexSchema(
+      id: 5365578901051110922,
+      name: r'sourceType',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'sourceType',
+          type: IndexType.hash,
+          caseSensitive: true,
+        ),
+      ],
+    ),
+    r'remoteId': IndexSchema(
+      id: 6301175856541681032,
+      name: r'remoteId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'remoteId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        ),
+      ],
+    ),
+    r'remoteServerId': IndexSchema(
+      id: 8355482941067776172,
+      name: r'remoteServerId',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'remoteServerId',
+          type: IndexType.value,
+          caseSensitive: false,
+        ),
+      ],
+    ),
   },
   links: {},
   embeddedSchemas: {},
@@ -309,7 +363,19 @@ int _songEntityEstimateSize(
     }
   }
   {
+    final value = object.remoteId;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.ripper;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.sourceType;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
     }
@@ -353,13 +419,16 @@ void _songEntitySerialize(
   writer.writeString(offsets[20], object.mediaStoreUri);
   writer.writeBool(offsets[21], object.metadataComplete);
   writer.writeString(offsets[22], object.readMode);
-  writer.writeString(offsets[23], object.ripper);
-  writer.writeLong(offsets[24], object.sampleRate);
-  writer.writeLong(offsets[25], object.startOffsetMs);
-  writer.writeString(offsets[26], object.testCrc);
-  writer.writeString(offsets[27], object.title);
-  writer.writeLong(offsets[28], object.trackNumber);
-  writer.writeLong(offsets[29], object.year);
+  writer.writeString(offsets[23], object.remoteId);
+  writer.writeLong(offsets[24], object.remoteServerId);
+  writer.writeString(offsets[25], object.ripper);
+  writer.writeLong(offsets[26], object.sampleRate);
+  writer.writeString(offsets[27], object.sourceType);
+  writer.writeLong(offsets[28], object.startOffsetMs);
+  writer.writeString(offsets[29], object.testCrc);
+  writer.writeString(offsets[30], object.title);
+  writer.writeLong(offsets[31], object.trackNumber);
+  writer.writeLong(offsets[32], object.year);
 }
 
 SongEntity _songEntityDeserialize(
@@ -393,13 +462,16 @@ SongEntity _songEntityDeserialize(
   object.mediaStoreUri = reader.readStringOrNull(offsets[20]);
   object.metadataComplete = reader.readBool(offsets[21]);
   object.readMode = reader.readStringOrNull(offsets[22]);
-  object.ripper = reader.readStringOrNull(offsets[23]);
-  object.sampleRate = reader.readLongOrNull(offsets[24]);
-  object.startOffsetMs = reader.readLongOrNull(offsets[25]);
-  object.testCrc = reader.readStringOrNull(offsets[26]);
-  object.title = reader.readString(offsets[27]);
-  object.trackNumber = reader.readLongOrNull(offsets[28]);
-  object.year = reader.readLongOrNull(offsets[29]);
+  object.remoteId = reader.readStringOrNull(offsets[23]);
+  object.remoteServerId = reader.readLongOrNull(offsets[24]);
+  object.ripper = reader.readStringOrNull(offsets[25]);
+  object.sampleRate = reader.readLongOrNull(offsets[26]);
+  object.sourceType = reader.readStringOrNull(offsets[27]);
+  object.startOffsetMs = reader.readLongOrNull(offsets[28]);
+  object.testCrc = reader.readStringOrNull(offsets[29]);
+  object.title = reader.readString(offsets[30]);
+  object.trackNumber = reader.readLongOrNull(offsets[31]);
+  object.year = reader.readLongOrNull(offsets[32]);
   return object;
 }
 
@@ -461,14 +533,20 @@ P _songEntityDeserializeProp<P>(
     case 24:
       return (reader.readLongOrNull(offset)) as P;
     case 25:
-      return (reader.readLongOrNull(offset)) as P;
-    case 26:
       return (reader.readStringOrNull(offset)) as P;
+    case 26:
+      return (reader.readLongOrNull(offset)) as P;
     case 27:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 28:
       return (reader.readLongOrNull(offset)) as P;
     case 29:
+      return (reader.readStringOrNull(offset)) as P;
+    case 30:
+      return (reader.readString(offset)) as P;
+    case 31:
+      return (reader.readLongOrNull(offset)) as P;
+    case 32:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -651,6 +729,14 @@ extension SongEntityQueryWhereSort
     return QueryBuilder.apply(this, (query) {
       return query.addWhereClause(
         const IndexWhereClause.any(indexName: r'hasLocalEdits'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhere> anyRemoteServerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        const IndexWhereClause.any(indexName: r'remoteServerId'),
       );
     });
   }
@@ -1467,6 +1553,283 @@ extension SongEntityQueryWhere
               ),
             );
       }
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> sourceTypeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'sourceType', value: [null]),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  sourceTypeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'sourceType',
+          lower: [null],
+          includeLower: false,
+          upper: [],
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> sourceTypeEqualTo(
+    String? sourceType,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'sourceType', value: [sourceType]),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> sourceTypeNotEqualTo(
+    String? sourceType,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'sourceType',
+                lower: [],
+                upper: [sourceType],
+                includeUpper: false,
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'sourceType',
+                lower: [sourceType],
+                includeLower: false,
+                upper: [],
+              ),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'sourceType',
+                lower: [sourceType],
+                includeLower: false,
+                upper: [],
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'sourceType',
+                lower: [],
+                upper: [sourceType],
+                includeUpper: false,
+              ),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'remoteId', value: [null]),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'remoteId',
+          lower: [null],
+          includeLower: false,
+          upper: [],
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteIdEqualTo(
+    String? remoteId,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'remoteId', value: [remoteId]),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteIdNotEqualTo(
+    String? remoteId,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteId',
+                lower: [],
+                upper: [remoteId],
+                includeUpper: false,
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteId',
+                lower: [remoteId],
+                includeLower: false,
+                upper: [],
+              ),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteId',
+                lower: [remoteId],
+                includeLower: false,
+                upper: [],
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteId',
+                lower: [],
+                upper: [remoteId],
+                includeUpper: false,
+              ),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  remoteServerIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(indexName: r'remoteServerId', value: [null]),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  remoteServerIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'remoteServerId',
+          lower: [null],
+          includeLower: false,
+          upper: [],
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteServerIdEqualTo(
+    int? remoteServerId,
+  ) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.equalTo(
+          indexName: r'remoteServerId',
+          value: [remoteServerId],
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  remoteServerIdNotEqualTo(int? remoteServerId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteServerId',
+                lower: [],
+                upper: [remoteServerId],
+                includeUpper: false,
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteServerId',
+                lower: [remoteServerId],
+                includeLower: false,
+                upper: [],
+              ),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteServerId',
+                lower: [remoteServerId],
+                includeLower: false,
+                upper: [],
+              ),
+            )
+            .addWhereClause(
+              IndexWhereClause.between(
+                indexName: r'remoteServerId',
+                lower: [],
+                upper: [remoteServerId],
+                includeUpper: false,
+              ),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  remoteServerIdGreaterThan(int? remoteServerId, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'remoteServerId',
+          lower: [remoteServerId],
+          includeLower: include,
+          upper: [],
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause>
+  remoteServerIdLessThan(int? remoteServerId, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'remoteServerId',
+          lower: [],
+          upper: [remoteServerId],
+          includeUpper: include,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterWhereClause> remoteServerIdBetween(
+    int? lowerRemoteServerId,
+    int? upperRemoteServerId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IndexWhereClause.between(
+          indexName: r'remoteServerId',
+          lower: [lowerRemoteServerId],
+          includeLower: includeLower,
+          upper: [upperRemoteServerId],
+          includeUpper: includeUpper,
+        ),
+      );
     });
   }
 }
@@ -3977,6 +4340,243 @@ extension SongEntityQueryFilter
     });
   }
 
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'remoteId'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'remoteId'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteIdGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'remoteId',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteIdStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdContains(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'remoteId',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> remoteIdMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'remoteId',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'remoteId', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'remoteId', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'remoteServerId'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'remoteServerId'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'remoteServerId', value: value),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdGreaterThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'remoteServerId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdLessThan(int? value, {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'remoteServerId',
+          value: value,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  remoteServerIdBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'remoteServerId',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+        ),
+      );
+    });
+  }
+
   QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> ripperIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(
@@ -4210,6 +4810,168 @@ extension SongEntityQueryFilter
           upper: upper,
           includeUpper: includeUpper,
         ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNull(property: r'sourceType'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        const FilterCondition.isNotNull(property: r'sourceType'),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> sourceTypeEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(
+          include: include,
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.lessThan(
+          include: include,
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> sourceTypeBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.between(
+          property: r'sourceType',
+          lower: lower,
+          includeLower: includeLower,
+          upper: upper,
+          includeUpper: includeUpper,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeStartsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.startsWith(
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeEndsWith(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.endsWith(
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.contains(
+          property: r'sourceType',
+          value: value,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition> sourceTypeMatches(
+    String pattern, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.matches(
+          property: r'sourceType',
+          wildcard: pattern,
+          caseSensitive: caseSensitive,
+        ),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.equalTo(property: r'sourceType', value: ''),
+      );
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterFilterCondition>
+  sourceTypeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(
+        FilterCondition.greaterThan(property: r'sourceType', value: ''),
       );
     });
   }
@@ -5033,6 +5795,31 @@ extension SongEntityQuerySortBy
     });
   }
 
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortByRemoteServerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteServerId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy>
+  sortByRemoteServerIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteServerId', Sort.desc);
+    });
+  }
+
   QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortByRipper() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'ripper', Sort.asc);
@@ -5054,6 +5841,18 @@ extension SongEntityQuerySortBy
   QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortBySampleRateDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'sampleRate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortBySourceType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceType', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> sortBySourceTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceType', Sort.desc);
     });
   }
 
@@ -5409,6 +6208,31 @@ extension SongEntityQuerySortThenBy
     });
   }
 
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenByRemoteId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenByRemoteIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenByRemoteServerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteServerId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy>
+  thenByRemoteServerIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'remoteServerId', Sort.desc);
+    });
+  }
+
   QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenByRipper() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'ripper', Sort.asc);
@@ -5430,6 +6254,18 @@ extension SongEntityQuerySortThenBy
   QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenBySampleRateDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'sampleRate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenBySourceType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceType', Sort.asc);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QAfterSortBy> thenBySourceTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'sourceType', Sort.desc);
     });
   }
 
@@ -5659,6 +6495,20 @@ extension SongEntityQueryWhereDistinct
     });
   }
 
+  QueryBuilder<SongEntity, SongEntity, QDistinct> distinctByRemoteId({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'remoteId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QDistinct> distinctByRemoteServerId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'remoteServerId');
+    });
+  }
+
   QueryBuilder<SongEntity, SongEntity, QDistinct> distinctByRipper({
     bool caseSensitive = true,
   }) {
@@ -5670,6 +6520,14 @@ extension SongEntityQueryWhereDistinct
   QueryBuilder<SongEntity, SongEntity, QDistinct> distinctBySampleRate() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'sampleRate');
+    });
+  }
+
+  QueryBuilder<SongEntity, SongEntity, QDistinct> distinctBySourceType({
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'sourceType', caseSensitive: caseSensitive);
     });
   }
 
@@ -5854,6 +6712,18 @@ extension SongEntityQueryProperty
     });
   }
 
+  QueryBuilder<SongEntity, String?, QQueryOperations> remoteIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'remoteId');
+    });
+  }
+
+  QueryBuilder<SongEntity, int?, QQueryOperations> remoteServerIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'remoteServerId');
+    });
+  }
+
   QueryBuilder<SongEntity, String?, QQueryOperations> ripperProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'ripper');
@@ -5863,6 +6733,12 @@ extension SongEntityQueryProperty
   QueryBuilder<SongEntity, int?, QQueryOperations> sampleRateProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'sampleRate');
+    });
+  }
+
+  QueryBuilder<SongEntity, String?, QQueryOperations> sourceTypeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'sourceType');
     });
   }
 

--- a/lib/data/repositories/recently_played_repository.dart
+++ b/lib/data/repositories/recently_played_repository.dart
@@ -711,6 +711,9 @@ class RecentlyPlayedRepository {
       album: entity.album,
       filePath: entity.filePath,
       dateAdded: entity.dateAdded,
+      sourceType: entity.sourceType,
+      remoteId: entity.remoteId,
+      remoteServerId: entity.remoteServerId,
     );
   }
 

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -122,6 +122,24 @@ class SongRepository {
     });
   }
 
+  /// All songs synced from a network server (used by network sync purge).
+  Future<List<SongEntity>> getSongsByRemoteServer(int remoteServerId) async {
+    return await _isar.songEntitys
+        .where()
+        .remoteServerIdEqualTo(remoteServerId)
+        .findAll();
+  }
+
+  /// Delete all songs synced from a network server.
+  Future<void> deleteSongsForRemoteServer(int remoteServerId) async {
+    await _isar.writeTxn(() async {
+      await _isar.songEntitys
+          .where()
+          .remoteServerIdEqualTo(remoteServerId)
+          .deleteAll();
+    });
+  }
+
   /// Get all song entities (internal use)
   Future<List<SongEntity>> getAllSongEntities() async {
     return await _isar.songEntitys.where().findAll();
@@ -401,6 +419,9 @@ class SongRepository {
       filePath: entity.filePath,
       folderUri: entity.folderUri,
       dateAdded: entity.dateAdded,
+      sourceType: entity.sourceType,
+      remoteId: entity.remoteId,
+      remoteServerId: entity.remoteServerId,
     );
   }
 

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -130,6 +130,14 @@ class SongRepository {
         .findAll();
   }
 
+  /// Count songs synced from a network server (cheaper than fetching).
+  Future<int> countSongsByRemoteServer(int remoteServerId) async {
+    return await _isar.songEntitys
+        .where()
+        .remoteServerIdEqualTo(remoteServerId)
+        .count();
+  }
+
   /// Delete all songs synced from a network server.
   Future<void> deleteSongsForRemoteServer(int remoteServerId) async {
     await _isar.writeTxn(() async {

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -11,7 +11,6 @@ import 'package:flick/models/song.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/albums/screens/album_detail_screen.dart';
 import 'package:flick/services/player_service.dart';
-import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/providers/navigation_provider.dart';
@@ -166,22 +165,20 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
     return DisplayModeWrapper(
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: BlurredSongBackground(
-          child: SafeArea(
-            bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildHeader(context),
-                Expanded(
-                  child: _isLoading
-                      ? _buildLoadingState()
-                      : _sortedAlbums.isEmpty
-                      ? _buildEmptyState()
-                      : _buildAlbumsGrid(),
-                ),
-              ],
-            ),
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(context),
+              Expanded(
+                child: _isLoading
+                    ? _buildLoadingState()
+                    : _sortedAlbums.isEmpty
+                    ? _buildEmptyState()
+                    : _buildAlbumsGrid(),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/artists/screens/artists_screen.dart
+++ b/lib/features/artists/screens/artists_screen.dart
@@ -11,7 +11,6 @@ import 'package:flick/models/song.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/artists/screens/artist_detail_screen.dart';
 import 'package:flick/services/player_service.dart';
-import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/providers/navigation_provider.dart';
 import 'package:flick/providers/app_preferences_provider.dart';
@@ -195,22 +194,20 @@ class _ArtistsScreenState extends ConsumerState<ArtistsScreen> {
     return DisplayModeWrapper(
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: BlurredSongBackground(
-          child: SafeArea(
-            bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildHeader(context),
-                Expanded(
-                  child: _isLoading
-                      ? _buildLoadingState()
-                      : _artists.isEmpty
-                      ? _buildEmptyState()
-                      : _buildArtistsList(),
-                ),
-              ],
-            ),
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(context),
+              Expanded(
+                child: _isLoading
+                    ? _buildLoadingState()
+                    : _artists.isEmpty
+                    ? _buildEmptyState()
+                    : _buildArtistsList(),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/favorites/screens/favorites_screen.dart
+++ b/lib/features/favorites/screens/favorites_screen.dart
@@ -6,7 +6,6 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
-import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/services/favorites_service.dart';
@@ -200,25 +199,23 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
     return DisplayModeWrapper(
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: BlurredSongBackground(
-          child: SafeArea(
-            bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (_selectionMode)
-                  _buildSelectionHeader(context)
-                else
-                  _buildHeader(context),
-                Expanded(
-                  child: _isLoading
-                      ? _buildLoadingState()
-                      : _favorites.isEmpty
-                          ? _buildEmptyState()
-                          : _buildFavoritesList(removalMode),
-                ),
-              ],
-            ),
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (_selectionMode)
+                _buildSelectionHeader(context)
+              else
+                _buildHeader(context),
+              Expanded(
+                child: _isLoading
+                    ? _buildLoadingState()
+                    : _favorites.isEmpty
+                        ? _buildEmptyState()
+                        : _buildFavoritesList(removalMode),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/folders/screens/folders_screen.dart
+++ b/lib/features/folders/screens/folders_screen.dart
@@ -216,28 +216,26 @@ class _FoldersScreenState extends ConsumerState<FoldersScreen> {
     return DisplayModeWrapper(
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: BlurredSongBackground(
-          child: SafeArea(
-            bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildHeader(context),
-                Expanded(
-                  child: _isLoading
-                      ? const Center(
-                          child: CircularProgressIndicator(
-                            color: AppColors.textSecondary,
-                          ),
-                        )
-                      : _folders.isEmpty
-                          ? _buildEmptyState()
-                          : _viewMode == FolderViewMode.tree
-                              ? _buildFoldersTree()
-                              : _buildRootFoldersGrid(),
-                ),
-              ],
-            ),
+        body: SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildHeader(context),
+              Expanded(
+                child: _isLoading
+                    ? const Center(
+                        child: CircularProgressIndicator(
+                          color: AppColors.textSecondary,
+                        ),
+                      )
+                    : _folders.isEmpty
+                        ? _buildEmptyState()
+                        : _viewMode == FolderViewMode.tree
+                            ? _buildFoldersTree()
+                            : _buildRootFoldersGrid(),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -34,6 +34,7 @@ import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/engine_restart_notice.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
+import 'package:flick/widgets/uac2/uac2_volume_control.dart';
 
 /// Music-home menu screen inspired by streaming app landing pages.
 class MenuScreen extends ConsumerStatefulWidget {
@@ -708,6 +709,27 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
                                       ),
                                     )
                                   : const SizedBox.shrink(),
+                        ),
+                      ),
+                    if (appPreferences.showUsbVolumeOnMenu)
+                      SliverToBoxAdapter(
+                        child: AnimatedSize(
+                          duration: AppConstants.animationNormal,
+                          curve: Curves.easeInOut,
+                          alignment: Alignment.topCenter,
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(
+                              AppConstants.spacingLg,
+                              0,
+                              AppConstants.spacingLg,
+                              AppConstants.spacingMd,
+                            ),
+                            child: Uac2VolumeControl(
+                              useGradientBackground: true,
+                              gradientColors:
+                                  _heroGradientColors(_heroDominantColor),
+                            ),
+                          ),
                         ),
                       ),
                     if (_pendingEngineRestart &&

--- a/lib/features/playlists/screens/playlists_screen.dart
+++ b/lib/features/playlists/screens/playlists_screen.dart
@@ -10,7 +10,6 @@ import 'package:flick/models/playlist.dart';
 import 'package:flick/providers/playlist_provider.dart';
 import 'package:flick/providers/songs_provider.dart';
 import 'package:flick/providers/navigation_provider.dart';
-import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/features/playlists/screens/playlist_detail_screen.dart';
 
@@ -26,24 +25,22 @@ class PlaylistsScreen extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: Colors.transparent,
-      body: BlurredSongBackground(
-        child: SafeArea(
-          bottom: false,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildHeader(context, ref),
-              Expanded(
-                child: playlistsAsync.when(
-                  loading: () => _buildLoadingState(context),
-                  error: (e, _) => _buildErrorState(context, e.toString()),
-                  data: (state) => state.playlists.isEmpty
-                      ? _buildEmptyState(context)
-                      : _buildPlaylistsList(context, ref, state.playlists),
-                ),
+      body: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(context, ref),
+            Expanded(
+              child: playlistsAsync.when(
+                loading: () => _buildLoadingState(context),
+                error: (e, _) => _buildErrorState(context, e.toString()),
+                data: (state) => state.playlists.isEmpty
+                    ? _buildEmptyState(context)
+                    : _buildPlaylistsList(context, ref, state.playlists),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
 

--- a/lib/features/settings/screens/equalizer_screen.dart
+++ b/lib/features/settings/screens/equalizer_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
@@ -16,8 +15,9 @@ import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/features/player/widgets/ambient_background.dart';
 import 'package:flick/providers/equalizer_provider.dart';
-import 'package:flick/providers/navigation_provider.dart';
+import 'package:flick/providers/providers.dart';
 import 'package:flick/services/eq_preset_file_service.dart';
 import 'package:flick/services/eq_preset_service.dart';
 import 'package:flick/services/equalizer_service.dart';
@@ -81,11 +81,13 @@ class _EqualizerScreenState extends ConsumerState<EqualizerScreen> {
   @override
   Widget build(BuildContext context) {
     final activePresetName = ref.watch(eqActivePresetNameProvider);
+    final currentSong = ref.watch(currentSongProvider);
 
     return Stack(
       children: [
+        Positioned.fill(child: AmbientBackground(song: currentSong)),
         Scaffold(
-          backgroundColor: AppColors.background,
+          backgroundColor: Colors.transparent,
           body: SafeArea(
             bottom: false,
             child: Column(
@@ -1178,20 +1180,14 @@ class _Header extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Container(
-            decoration: BoxDecoration(
-              color: AppColors.glassBackground,
-              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-              border: Border.all(color: AppColors.glassBorder),
+          IconButton(
+            icon: Icon(
+              LucideIcons.chevronLeft,
+              color: context.adaptiveTextPrimary,
+              size: context.responsiveIcon(AppConstants.iconSizeMd),
             ),
-            child: IconButton(
-              icon: Icon(
-                LucideIcons.arrowLeft,
-                color: context.adaptiveTextPrimary,
-                size: context.responsiveIcon(AppConstants.iconSizeMd),
-              ),
-              onPressed: onBack,
-            ),
+            onPressed: onBack,
+            visualDensity: VisualDensity.compact,
           ),
           const SizedBox(width: AppConstants.spacingMd),
           Expanded(
@@ -1215,21 +1211,15 @@ class _Header extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            decoration: BoxDecoration(
-              color: AppColors.glassBackground,
-              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-              border: Border.all(color: AppColors.glassBorder),
+          IconButton(
+            tooltip: 'Presets',
+            icon: Icon(
+              LucideIcons.library,
+              color: context.adaptiveTextPrimary,
+              size: context.responsiveIcon(AppConstants.iconSizeMd),
             ),
-            child: IconButton(
-              tooltip: 'Presets',
-              icon: Icon(
-                LucideIcons.library,
-                color: context.adaptiveTextPrimary,
-                size: context.responsiveIcon(AppConstants.iconSizeMd),
-              ),
-              onPressed: onPresets,
-            ),
+            onPressed: onPresets,
+            visualDensity: VisualDensity.compact,
           ),
         ],
       ),
@@ -4366,22 +4356,18 @@ class _GlassCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return RepaintBoundary(
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(
-            sigmaX: AppConstants.glassBlurSigmaLight,
-            sigmaY: AppConstants.glassBlurSigmaLight,
-          ),
-          child: Container(
-            decoration: BoxDecoration(
-              color: AppColors.glassBackground,
-              borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-              border: Border.all(color: AppColors.glassBorder, width: 1),
-            ),
-            child: child,
-          ),
+      // ponytail: opaque fill instead of BackdropFilter. The ambient bg is
+      // already pre-blurred, so a second blur was redundant GPU cost AND it
+      // re-sampled different album-art regions per scroll position, making
+      // the card (and the knobs on it) shift lighter/darker. surfaceLight
+      // (0x1E) stays lighter than the knob body (0x14) so contrast holds.
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.surfaceLight.withValues(alpha: 0.9),
+          borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+          border: Border.all(color: AppColors.glassBorder, width: 1),
         ),
+        child: child,
       ),
     );
   }

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -6,11 +6,12 @@ import '../../../core/theme/adaptive_color_provider.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/utils/app_haptics.dart';
 import '../../../data/database.dart';
+import '../../../data/repositories/song_repository.dart';
 import '../../../services/sources/subsonic_service.dart';
 import '../widgets/settings_widgets.dart';
 
 /// Add or edit a network server. Subsonic is the only enabled protocol in
-/// v1; the rest are greyed out with a "needs a new dependency" note.
+/// v1; the rest are deferred and surfaced as a single "coming soon" note.
 class NetworkServerEditScreen extends StatefulWidget {
   const NetworkServerEditScreen({super.key, this.server});
 
@@ -21,22 +22,14 @@ class NetworkServerEditScreen extends StatefulWidget {
 }
 
 class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
-  static const _protocols = [
-    ('subsonic', 'Subsonic', 'Navidrome, Airsonic, Gonic', true),
-    ('webdav', 'WebDAV', 'Needs a new dependency', false),
-    ('jellyfin', 'Jellyfin', 'Needs a new dependency', false),
-    ('smb', 'SMB', 'Needs a new dependency', false),
-    ('upnp', 'UPnP', 'Needs a new dependency', false),
-  ];
-
   late final TextEditingController _labelController;
   late final TextEditingController _urlController;
   late final TextEditingController _usernameController;
   late final TextEditingController _passwordController;
-  late String _protocol;
   bool _testing = false;
   bool? _testPassed;
   bool _saving = false;
+  bool _isValid = false;
 
   bool get _isNew => widget.server == null;
 
@@ -48,7 +41,10 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     _urlController = TextEditingController(text: server?.baseUrl ?? '');
     _usernameController = TextEditingController(text: server?.username ?? '');
     _passwordController = TextEditingController();
-    _protocol = server?.protocol ?? 'subsonic';
+    _labelController.addListener(_updateValidity);
+    _urlController.addListener(_updateValidity);
+    _isValid = _labelController.text.trim().isNotEmpty &&
+        _urlController.text.trim().isNotEmpty;
   }
 
   @override
@@ -58,6 +54,12 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     _usernameController.dispose();
     _passwordController.dispose();
     super.dispose();
+  }
+
+  void _updateValidity() {
+    final valid = _labelController.text.trim().isNotEmpty &&
+        _urlController.text.trim().isNotEmpty;
+    if (_isValid != valid) setState(() => _isValid = valid);
   }
 
   String? get _storedToken {
@@ -73,7 +75,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     final server = widget.server ?? NetworkServerEntity();
     server
       ..label = _labelController.text.trim()
-      ..protocol = _protocol
+      ..protocol = server.protocol.isNotEmpty ? server.protocol : 'subsonic'
       ..baseUrl = _urlController.text.trim().replaceAll(RegExp(r'/+$'), '')
       ..username = _usernameController.text.trim().isEmpty
           ? null
@@ -98,10 +100,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   }
 
   Future<void> _save() async {
-    final label = _labelController.text.trim();
-    final url = _urlController.text.trim();
-    if (label.isEmpty || url.isEmpty) return;
-
+    if (!_isValid) return;
     setState(() => _saving = true);
     await Database.instance.writeTxn(() async {
       await Database.networkServers.put(_draftEntity());
@@ -109,6 +108,51 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     if (!mounted) return;
     Navigator.of(context).pop(true);
   }
+
+  Future<void> _delete() async {
+    final server = widget.server;
+    if (server == null) return;
+    AppHaptics.tap();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove server?'),
+        content: Text(
+          'Delete "${server.label}" and all songs synced from it? '
+          'Cached downloads are kept.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await Database.instance.writeTxn(() async {
+      await Database.networkServers.delete(server.id);
+    });
+    await SongRepository().deleteSongsForRemoteServer(server.id);
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  IconData get _testIcon => _testPassed == null
+      ? LucideIcons.wifi
+      : _testPassed!
+          ? LucideIcons.checkCircle
+          : LucideIcons.xCircle;
+
+  String get _testLabel => _testPassed == null
+      ? 'Test Connection'
+      : _testPassed!
+          ? 'Connection OK'
+          : 'Connection Failed — Retry';
 
   @override
   Widget build(BuildContext context) {
@@ -120,19 +164,60 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
           SettingsSectionHeader('Protocol'),
           SettingsCard(
             children: [
-              for (var i = 0; i < _protocols.length; i++) ...[
-                if (i > 0) const SettingsDivider(),
-                SelectionSetting(
-                  icon: _iconFor(_protocols[i].$1),
-                  title: _protocols[i].$2,
-                  subtitle: _protocols[i].$3,
-                  selected: _protocol == _protocols[i].$1,
-                  onTap: _protocols[i].$4
-                      ? () => setState(() => _protocol = _protocols[i].$1)
-                      : null,
+              Padding(
+                padding: const EdgeInsets.all(AppConstants.spacingMd),
+                child: Row(
+                  children: [
+                    const _SettingsTileIcon(icon: LucideIcons.radio),
+                    const SizedBox(width: AppConstants.spacingMd),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Subsonic',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(
+                                  color: context.adaptiveTextPrimary,
+                                ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            'Navidrome · Airsonic · Gonic',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: context.adaptiveTextTertiary,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      Icons.check_circle_rounded,
+                      size: 20,
+                      color: context.adaptiveTextPrimary,
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(
+              left: AppConstants.spacingXs,
+              top: AppConstants.spacingSm,
+              bottom: AppConstants.spacingSm,
+            ),
+            child: Text(
+              'More protocols (WebDAV, Jellyfin) coming soon.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextTertiary,
+              ),
+            ),
           ),
           const SizedBox(height: AppConstants.spacingLg),
           SettingsSectionHeader('Connection'),
@@ -170,60 +255,98 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
               ),
             ],
           ),
-          const SizedBox(height: AppConstants.spacingMd),
-          Row(
-            children: [
-              Expanded(
-                child: FilledButton.tonalIcon(
-                  onPressed: _testing || _saving ? null : _testConnection,
-                  icon: _testing
-                      ? const SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : Icon(
-                          _testPassed == null
-                              ? LucideIcons.wifi
-                              : _testPassed!
-                                  ? LucideIcons.checkCircle
-                                  : LucideIcons.xCircle,
-                          size: 18,
-                        ),
-                  label: Text(_testPassed == null
-                      ? 'Test Connection'
-                      : _testPassed!
-                          ? 'Connection OK'
-                          : 'Connection Failed'),
+          const SizedBox(height: AppConstants.spacingLg),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.tonalIcon(
+              onPressed: _testing || _saving ? null : _testConnection,
+              icon: _testing
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(_testIcon, size: 18),
+              label: Text(_testLabel),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
                 ),
               ),
-              const SizedBox(width: AppConstants.spacingMd),
-              Expanded(
-                child: FilledButton(
-                  onPressed: _saving ? null : _save,
-                  child: Text(_isNew ? 'Add Server' : 'Save'),
-                ),
-              ),
-            ],
+            ),
           ),
+          if (_testPassed == false) ...[
+            const SizedBox(height: AppConstants.spacingSm),
+            _buildFailureBanner(context),
+          ],
+          const SizedBox(height: AppConstants.spacingSm),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: (_saving || !_isValid) ? null : _save,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                ),
+              ),
+              child: _saving
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(_isNew ? 'Add Server' : 'Save'),
+            ),
+          ),
+          if (!_isNew) ...[
+            const SizedBox(height: AppConstants.spacingLg),
+            Center(
+              child: TextButton.icon(
+                onPressed: _saving ? null : _delete,
+                icon: const Icon(LucideIcons.trash2, size: 16),
+                label: const Text('Remove server'),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppColors.textTertiary,
+                ),
+              ),
+            ),
+          ],
         ],
       ),
     );
   }
 
-  IconData _iconFor(String protocol) {
-    switch (protocol) {
-      case 'subsonic':
-        return LucideIcons.radio;
-      case 'webdav':
-        return LucideIcons.folderOpen;
-      case 'jellyfin':
-        return LucideIcons.film;
-      case 'smb':
-        return LucideIcons.network;
-      default:
-        return LucideIcons.zap;
-    }
+  Widget _buildFailureBanner(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingSm),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackground,
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            LucideIcons.info,
+            size: 16,
+            color: context.adaptiveTextSecondary,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Could not reach the server. Check the URL and credentials, '
+              'then try again.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -251,35 +374,62 @@ class _TextFieldSetting extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(AppConstants.spacingMd),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           _SettingsTileIcon(icon: icon),
           const SizedBox(width: AppConstants.spacingMd),
           Expanded(
-            child: TextField(
-              controller: controller,
-              obscureText: obscureText,
-              keyboardType: keyboardType,
-              autocorrect: false,
-              enableSuggestions: !obscureText,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: context.adaptiveTextPrimary,
-              ),
-              decoration: InputDecoration(
-                labelText: label,
-                hintText: hint,
-                helperText: helperText,
-                isDense: true,
-                border: InputBorder.none,
-                labelStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.adaptiveTextTertiary,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label.toUpperCase(),
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: context.adaptiveTextTertiary,
+                    letterSpacing: 1.0,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-                hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.adaptiveTextTertiary,
+                const SizedBox(height: 6),
+                TextField(
+                  controller: controller,
+                  obscureText: obscureText,
+                  keyboardType: keyboardType,
+                  autocorrect: false,
+                  enableSuggestions: !obscureText,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: context.adaptiveTextPrimary,
+                  ),
+                  decoration: InputDecoration(
+                    hintText: hint,
+                    helperText: helperText,
+                    isDense: true,
+                    filled: true,
+                    fillColor: AppColors.glassBackground,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 12,
+                    ),
+                    hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                    ),
+                    helperStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius:
+                          BorderRadius.circular(AppConstants.radiusSm),
+                      borderSide: const BorderSide(color: AppColors.glassBorder),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius:
+                          BorderRadius.circular(AppConstants.radiusSm),
+                      borderSide:
+                          const BorderSide(color: AppColors.glassBorderStrong),
+                    ),
+                  ),
                 ),
-                helperStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.adaptiveTextTertiary,
-                ),
-              ),
+              ],
             ),
           ),
         ],

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -1,0 +1,312 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/adaptive_color_provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/utils/app_haptics.dart';
+import '../../../data/database.dart';
+import '../../../services/sources/subsonic_service.dart';
+import '../widgets/settings_widgets.dart';
+
+/// Add or edit a network server. Subsonic is the only enabled protocol in
+/// v1; the rest are greyed out with a "needs a new dependency" note.
+class NetworkServerEditScreen extends StatefulWidget {
+  const NetworkServerEditScreen({super.key, this.server});
+
+  final NetworkServerEntity? server;
+
+  @override
+  State<NetworkServerEditScreen> createState() => _NetworkServerEditScreenState();
+}
+
+class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
+  static const _protocols = [
+    ('subsonic', 'Subsonic', 'Navidrome, Airsonic, Gonic', true),
+    ('webdav', 'WebDAV', 'Needs a new dependency', false),
+    ('jellyfin', 'Jellyfin', 'Needs a new dependency', false),
+    ('smb', 'SMB', 'Needs a new dependency', false),
+    ('upnp', 'UPnP', 'Needs a new dependency', false),
+  ];
+
+  late final TextEditingController _labelController;
+  late final TextEditingController _urlController;
+  late final TextEditingController _usernameController;
+  late final TextEditingController _passwordController;
+  late String _protocol;
+  bool _testing = false;
+  bool? _testPassed;
+  bool _saving = false;
+
+  bool get _isNew => widget.server == null;
+
+  @override
+  void initState() {
+    super.initState();
+    final server = widget.server;
+    _labelController = TextEditingController(text: server?.label ?? '');
+    _urlController = TextEditingController(text: server?.baseUrl ?? '');
+    _usernameController = TextEditingController(text: server?.username ?? '');
+    _passwordController = TextEditingController();
+    _protocol = server?.protocol ?? 'subsonic';
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _urlController.dispose();
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  String? get _storedToken {
+    final server = widget.server;
+    final password = _passwordController.text;
+    if (password.isNotEmpty) {
+      return SubsonicService.buildToken(password);
+    }
+    return server?.token;
+  }
+
+  NetworkServerEntity _draftEntity() {
+    final server = widget.server ?? NetworkServerEntity();
+    server
+      ..label = _labelController.text.trim()
+      ..protocol = _protocol
+      ..baseUrl = _urlController.text.trim().replaceAll(RegExp(r'/+$'), '')
+      ..username = _usernameController.text.trim().isEmpty
+          ? null
+          : _usernameController.text.trim()
+      ..token = _storedToken;
+    return server;
+  }
+
+  Future<void> _testConnection() async {
+    setState(() {
+      _testing = true;
+      _testPassed = null;
+    });
+    AppHaptics.tap();
+    final entity = _draftEntity();
+    final ok = await SubsonicService.instance.ping(entity);
+    if (!mounted) return;
+    setState(() {
+      _testing = false;
+      _testPassed = ok;
+    });
+  }
+
+  Future<void> _save() async {
+    final label = _labelController.text.trim();
+    final url = _urlController.text.trim();
+    if (label.isEmpty || url.isEmpty) return;
+
+    setState(() => _saving = true);
+    await Database.instance.writeTxn(() async {
+      await Database.networkServers.put(_draftEntity());
+    });
+    if (!mounted) return;
+    Navigator.of(context).pop(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: _isNew ? 'Add Server' : 'Edit Server',
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SettingsSectionHeader('Protocol'),
+          SettingsCard(
+            children: [
+              for (var i = 0; i < _protocols.length; i++) ...[
+                if (i > 0) const SettingsDivider(),
+                SelectionSetting(
+                  icon: _iconFor(_protocols[i].$1),
+                  title: _protocols[i].$2,
+                  subtitle: _protocols[i].$3,
+                  selected: _protocol == _protocols[i].$1,
+                  onTap: _protocols[i].$4
+                      ? () => setState(() => _protocol = _protocols[i].$1)
+                      : null,
+                ),
+              ],
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          SettingsSectionHeader('Connection'),
+          SettingsCard(
+            children: [
+              _TextFieldSetting(
+                controller: _labelController,
+                icon: LucideIcons.tag,
+                label: 'Label',
+                hint: 'My Navidrome',
+              ),
+              const SettingsDivider(),
+              _TextFieldSetting(
+                controller: _urlController,
+                icon: LucideIcons.link,
+                label: 'Server URL',
+                hint: 'https://music.example.com/subsonic',
+                keyboardType: TextInputType.url,
+              ),
+              const SettingsDivider(),
+              _TextFieldSetting(
+                controller: _usernameController,
+                icon: LucideIcons.user,
+                label: 'Username',
+              ),
+              const SettingsDivider(),
+              _TextFieldSetting(
+                controller: _passwordController,
+                icon: LucideIcons.lock,
+                label: 'Password',
+                obscureText: true,
+                helperText: _isNew
+                    ? 'Stored as a salted hash, never in plaintext'
+                    : 'Leave empty to keep the current credentials',
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingMd),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: _testing || _saving ? null : _testConnection,
+                  icon: _testing
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Icon(
+                          _testPassed == null
+                              ? LucideIcons.wifi
+                              : _testPassed!
+                                  ? LucideIcons.checkCircle
+                                  : LucideIcons.xCircle,
+                          size: 18,
+                        ),
+                  label: Text(_testPassed == null
+                      ? 'Test Connection'
+                      : _testPassed!
+                          ? 'Connection OK'
+                          : 'Connection Failed'),
+                ),
+              ),
+              const SizedBox(width: AppConstants.spacingMd),
+              Expanded(
+                child: FilledButton(
+                  onPressed: _saving ? null : _save,
+                  child: Text(_isNew ? 'Add Server' : 'Save'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _iconFor(String protocol) {
+    switch (protocol) {
+      case 'subsonic':
+        return LucideIcons.radio;
+      case 'webdav':
+        return LucideIcons.folderOpen;
+      case 'jellyfin':
+        return LucideIcons.film;
+      case 'smb':
+        return LucideIcons.network;
+      default:
+        return LucideIcons.zap;
+    }
+  }
+}
+
+class _TextFieldSetting extends StatelessWidget {
+  const _TextFieldSetting({
+    required this.controller,
+    required this.icon,
+    required this.label,
+    this.hint,
+    this.helperText,
+    this.obscureText = false,
+    this.keyboardType,
+  });
+
+  final TextEditingController controller;
+  final IconData icon;
+  final String label;
+  final String? hint;
+  final String? helperText;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      child: Row(
+        children: [
+          _SettingsTileIcon(icon: icon),
+          const SizedBox(width: AppConstants.spacingMd),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              obscureText: obscureText,
+              keyboardType: keyboardType,
+              autocorrect: false,
+              enableSuggestions: !obscureText,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: context.adaptiveTextPrimary,
+              ),
+              decoration: InputDecoration(
+                labelText: label,
+                hintText: hint,
+                helperText: helperText,
+                isDense: true,
+                border: InputBorder.none,
+                labelStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
+                hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
+                helperStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsTileIcon extends StatelessWidget {
+  const _SettingsTileIcon({required this.icon});
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: AppConstants.containerSizeMd,
+      height: AppConstants.containerSizeMd,
+      decoration: BoxDecoration(
+        color: AppColors.glassBackgroundStrong,
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+      ),
+      child: Icon(
+        icon,
+        color: context.adaptiveTextSecondary,
+        size: AppConstants.iconSizeLg,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -1,49 +1,123 @@
+// Main sources
 import 'package:flutter/material.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+// App constants and other app UI libraries
 import '../../../core/constants/app_constants.dart';
 import '../../../core/theme/adaptive_color_provider.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/utils/app_haptics.dart';
+
+// Database, widgets, and service configurations
 import '../../../data/database.dart';
 import '../../../data/repositories/song_repository.dart';
-import '../../../services/sources/subsonic_service.dart';
+import '../../../services/sources/network_source_service.dart';
 import '../widgets/settings_widgets.dart';
 
-/// Add or edit a network server. Subsonic is the only enabled protocol in
-/// v1; the rest are deferred and surfaced as a single "coming soon" note.
+/// Add or edit a network server. All registered protocols are selectable;
+/// each dispatches test/sync/stream through [networkSourceServiceFor].
 class NetworkServerEditScreen extends StatefulWidget {
   const NetworkServerEditScreen({super.key, this.server});
 
   final NetworkServerEntity? server;
 
   @override
-  State<NetworkServerEditScreen> createState() => _NetworkServerEditScreenState();
+  State<NetworkServerEditScreen> createState() =>
+      _NetworkServerEditScreenState();
 }
+
+class _ProtocolMeta {
+  const _ProtocolMeta({
+    required this.id,
+    required this.label,
+    required this.subtitle,
+    required this.icon,
+    required this.urlHint,
+    required this.passwordHelper,
+  });
+  final String id;
+  final String label;
+  final String subtitle;
+  final IconData icon;
+  final String urlHint;
+  final String passwordHelper;
+}
+
+const List<_ProtocolMeta> _protocols = [
+  _ProtocolMeta(
+    id: NetworkProtocol.subsonic,
+    label: 'Subsonic',
+    subtitle: 'Navidrome · Airsonic · Gonic',
+    icon: LucideIcons.radio,
+    urlHint: 'https://music.example.com/subsonic',
+    passwordHelper: 'Stored as a salted hash, never in plaintext',
+  ),
+  _ProtocolMeta(
+    id: NetworkProtocol.jellyfin,
+    label: 'Jellyfin',
+    subtitle: 'Jellyfin · Emby',
+    icon: LucideIcons.clapperboard,
+    urlHint: 'https://jf.example.com',
+    passwordHelper: 'Sent once to sign in; an access token is stored',
+  ),
+  _ProtocolMeta(
+    id: NetworkProtocol.webdav,
+    label: 'WebDAV',
+    subtitle: 'Nextcloud · ownCloud · SabreDAV',
+    icon: LucideIcons.cloud,
+    urlHint: 'https://cloud.example.com/remote.php/dav/files/user',
+    passwordHelper: 'HTTP Basic needs it recoverable; stored encoded',
+  ),
+  _ProtocolMeta(
+    id: NetworkProtocol.upnp,
+    label: 'UPnP / DLNA',
+    subtitle: 'MinimServer · Serviio · Kodi',
+    icon: LucideIcons.cast,
+    urlHint: 'http://192.168.1.10:8200/rootDesc.xml',
+    passwordHelper: 'Most DLNA servers need no password',
+  ),
+  _ProtocolMeta(
+    id: NetworkProtocol.smb,
+    label: 'SMB',
+    subtitle: 'Samba · Windows share (transport pending)',
+    icon: LucideIcons.hardDrive,
+    urlHint: 'smb://nas/music',
+    passwordHelper: 'Stored encoded; playback unavailable in this build',
+  ),
+];
 
 class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   late final TextEditingController _labelController;
   late final TextEditingController _urlController;
   late final TextEditingController _usernameController;
   late final TextEditingController _passwordController;
+  late String _selectedProtocol;
   bool _testing = false;
   bool? _testPassed;
+  String? _testError;
   bool _saving = false;
   bool _isValid = false;
 
   bool get _isNew => widget.server == null;
 
+  _ProtocolMeta get _meta =>
+      _protocols.firstWhere((p) => p.id == _selectedProtocol);
+
   @override
   void initState() {
     super.initState();
     final server = widget.server;
+    _selectedProtocol = (server?.protocol.isNotEmpty ?? false)
+        ? server!.protocol
+        : NetworkProtocol.subsonic;
     _labelController = TextEditingController(text: server?.label ?? '');
     _urlController = TextEditingController(text: server?.baseUrl ?? '');
     _usernameController = TextEditingController(text: server?.username ?? '');
     _passwordController = TextEditingController();
     _labelController.addListener(_updateValidity);
     _urlController.addListener(_updateValidity);
-    _isValid = _labelController.text.trim().isNotEmpty &&
+    _isValid =
+        _labelController.text.trim().isNotEmpty &&
         _urlController.text.trim().isNotEmpty;
   }
 
@@ -57,30 +131,39 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   }
 
   void _updateValidity() {
-    final valid = _labelController.text.trim().isNotEmpty &&
+    final valid =
+        _labelController.text.trim().isNotEmpty &&
         _urlController.text.trim().isNotEmpty;
     if (_isValid != valid) setState(() => _isValid = valid);
   }
 
-  String? get _storedToken {
-    final server = widget.server;
+  /// Resolve the token to persist. When a password is typed it's resolved
+  /// through the protocol service (local transform for Subsonic/WebDAV, a
+  /// sign-in round-trip for Jellyfin). Otherwise the existing token is kept.
+  Future<String?> _resolvePersistedToken() async {
     final password = _passwordController.text;
     if (password.isNotEmpty) {
-      return SubsonicService.buildToken(password);
+      final draft = _draftEntity(token: null);
+      try {
+        return await networkSourceServiceFor(_selectedProtocol)
+            .resolveToken(draft, password);
+      } catch (_) {
+        return null;
+      }
     }
-    return server?.token;
+    return widget.server?.token;
   }
 
-  NetworkServerEntity _draftEntity() {
+  NetworkServerEntity _draftEntity({String? token}) {
     final server = widget.server ?? NetworkServerEntity();
     server
       ..label = _labelController.text.trim()
-      ..protocol = server.protocol.isNotEmpty ? server.protocol : 'subsonic'
+      ..protocol = _selectedProtocol
       ..baseUrl = _urlController.text.trim().replaceAll(RegExp(r'/+$'), '')
       ..username = _usernameController.text.trim().isEmpty
           ? null
           : _usernameController.text.trim()
-      ..token = _storedToken;
+      ..token = token ?? server.token;
     return server;
   }
 
@@ -88,25 +171,44 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     setState(() {
       _testing = true;
       _testPassed = null;
+      _testError = null;
     });
     AppHaptics.tap();
-    final entity = _draftEntity();
-    final ok = await SubsonicService.instance.ping(entity);
-    if (!mounted) return;
-    setState(() {
-      _testing = false;
-      _testPassed = ok;
-    });
+    final token = await _resolvePersistedToken();
+    final entity = _draftEntity(token: token);
+    try {
+      final ok = await networkSourceServiceFor(_selectedProtocol).ping(entity);
+      if (!mounted) return;
+      setState(() {
+        _testing = false;
+        _testPassed = ok;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _testing = false;
+        _testPassed = false;
+        _testError = _humanError(e);
+      });
+    }
   }
 
   Future<void> _save() async {
     if (!_isValid) return;
     setState(() => _saving = true);
+    final token = await _resolvePersistedToken();
     await Database.instance.writeTxn(() async {
-      await Database.networkServers.put(_draftEntity());
+      await Database.networkServers.put(_draftEntity(token: token));
     });
     if (!mounted) return;
     Navigator.of(context).pop(true);
+  }
+
+  String _humanError(Object e) {
+    final raw = e.toString();
+    // Trim the "UnsupportedError: " / "Exception: " boilerplate.
+    final colon = raw.indexOf(': ');
+    return colon > 0 && colon < 24 ? raw.substring(colon + 2) : raw;
   }
 
   Future<void> _delete() async {
@@ -145,14 +247,14 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   IconData get _testIcon => _testPassed == null
       ? LucideIcons.wifi
       : _testPassed!
-          ? LucideIcons.checkCircle
-          : LucideIcons.xCircle;
+      ? LucideIcons.checkCircle
+      : LucideIcons.xCircle;
 
   String get _testLabel => _testPassed == null
       ? 'Test Connection'
       : _testPassed!
-          ? 'Connection OK'
-          : 'Connection Failed — Retry';
+      ? 'Connection OK'
+      : 'Connection Failed — Retry';
 
   @override
   Widget build(BuildContext context) {
@@ -164,61 +266,41 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
           SettingsSectionHeader('Protocol'),
           SettingsCard(
             children: [
-              Padding(
-                padding: const EdgeInsets.all(AppConstants.spacingMd),
-                child: Row(
-                  children: [
-                    const _SettingsTileIcon(icon: LucideIcons.radio),
-                    const SizedBox(width: AppConstants.spacingMd),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Subsonic',
-                            style: Theme.of(context)
-                                .textTheme
-                                .titleMedium
-                                ?.copyWith(
-                                  color: context.adaptiveTextPrimary,
-                                ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            'Navidrome · Airsonic · Gonic',
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                  color: context.adaptiveTextTertiary,
-                                ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Icon(
-                      Icons.check_circle_rounded,
-                      size: 20,
-                      color: context.adaptiveTextPrimary,
-                    ),
-                  ],
+              for (var i = 0; i < _protocols.length; i++) ...[
+                if (i > 0) const SettingsDivider(),
+                SelectionSetting(
+                  icon: _protocols[i].icon,
+                  title: _protocols[i].label,
+                  subtitle: _protocols[i].subtitle,
+                  selected: _selectedProtocol == _protocols[i].id,
+                  onTap: _isNew
+                      ? () {
+                          AppHaptics.tap();
+                          setState(() {
+                            _selectedProtocol = _protocols[i].id;
+                            _testPassed = null;
+                            _testError = null;
+                          });
+                        }
+                      : null,
                 ),
-              ),
+              ],
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(
-              left: AppConstants.spacingXs,
-              top: AppConstants.spacingSm,
-              bottom: AppConstants.spacingSm,
-            ),
-            child: Text(
-              'More protocols (WebDAV, Jellyfin) coming soon.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: context.adaptiveTextTertiary,
+          if (_selectedProtocol == NetworkProtocol.smb)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: AppConstants.spacingXs,
+                top: AppConstants.spacingSm,
+              ),
+              child: Text(
+                'SMB shares can be added now, but streaming needs a native '
+                'transport that is not yet wired into this build.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                    ),
               ),
             ),
-          ),
           const SizedBox(height: AppConstants.spacingLg),
           SettingsSectionHeader('Connection'),
           SettingsCard(
@@ -234,7 +316,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
                 controller: _urlController,
                 icon: LucideIcons.link,
                 label: 'Server URL',
-                hint: 'https://music.example.com/subsonic',
+                hint: _meta.urlHint,
                 keyboardType: TextInputType.url,
               ),
               const SettingsDivider(),
@@ -250,7 +332,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
                 label: 'Password',
                 obscureText: true,
                 helperText: _isNew
-                    ? 'Stored as a salted hash, never in plaintext'
+                    ? _meta.passwordHelper
                     : 'Leave empty to keep the current credentials',
               ),
             ],
@@ -337,8 +419,9 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              'Could not reach the server. Check the URL and credentials, '
-              'then try again.',
+              _testError ??
+                  'Could not reach the server. Check the URL and credentials, '
+                  'then try again.',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                 color: context.adaptiveTextSecondary,
               ),
@@ -413,19 +496,23 @@ class _TextFieldSetting extends StatelessWidget {
                     hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: context.adaptiveTextTertiary,
                     ),
-                    helperStyle: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: context.adaptiveTextTertiary,
-                    ),
+                    helperStyle: Theme.of(context).textTheme.bodySmall
+                        ?.copyWith(color: context.adaptiveTextTertiary),
                     enabledBorder: OutlineInputBorder(
-                      borderRadius:
-                          BorderRadius.circular(AppConstants.radiusSm),
-                      borderSide: const BorderSide(color: AppColors.glassBorder),
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusSm,
+                      ),
+                      borderSide: const BorderSide(
+                        color: AppColors.glassBorder,
+                      ),
                     ),
                     focusedBorder: OutlineInputBorder(
-                      borderRadius:
-                          BorderRadius.circular(AppConstants.radiusSm),
-                      borderSide:
-                          const BorderSide(color: AppColors.glassBorderStrong),
+                      borderRadius: BorderRadius.circular(
+                        AppConstants.radiusSm,
+                      ),
+                      borderSide: const BorderSide(
+                        color: AppColors.glassBorderStrong,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/constants/app_constants.dart';
 import '../../../core/theme/adaptive_color_provider.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/utils/app_haptics.dart';
+import '../../../core/utils/responsive.dart';
 
 // Database, widgets, and service configurations
 import '../../../data/database.dart';
@@ -193,7 +194,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     }
   }
 
-  Future<void> _save() async {
+  Future<void> _save() async {  
     if (!_isValid) return;
     setState(() => _saving = true);
     final token = await _resolvePersistedToken();
@@ -219,7 +220,7 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Remove server?'),
-        content: Text(
+      content: Text(
           'Delete "${server.label}" and all songs synced from it? '
           'Cached downloads are kept.',
         ),
@@ -455,7 +456,7 @@ class _TextFieldSetting extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      padding: const EdgeInsets.all(AppConstants.spacingLg),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
@@ -533,8 +534,8 @@ class _SettingsTileIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: AppConstants.containerSizeMd,
-      height: AppConstants.containerSizeMd,
+      width: context.scaleSize(AppConstants.containerSizeMd),
+      height: context.scaleSize(AppConstants.containerSizeMd),
       decoration: BoxDecoration(
         color: AppColors.glassBackgroundStrong,
         borderRadius: BorderRadius.circular(AppConstants.radiusSm),
@@ -542,7 +543,7 @@ class _SettingsTileIcon extends StatelessWidget {
       child: Icon(
         icon,
         color: context.adaptiveTextSecondary,
-        size: AppConstants.iconSizeLg,
+        size: context.responsiveIcon(AppConstants.iconSizeLg),
       ),
     );
   }

--- a/lib/features/settings/screens/network_sources_screen.dart
+++ b/lib/features/settings/screens/network_sources_screen.dart
@@ -4,6 +4,8 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../../core/constants/app_constants.dart';
 import '../../../core/theme/adaptive_color_provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../core/utils/app_haptics.dart';
 import '../../../data/database.dart';
 import '../../../data/repositories/song_repository.dart';
 import '../../../services/library_scanner_service.dart' show ScanProgress;
@@ -21,6 +23,7 @@ class NetworkSourcesScreen extends StatefulWidget {
 
 class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
   List<NetworkServerEntity> _servers = [];
+  final _songCounts = <int, int>{};
   int? _syncingId;
   ScanProgress? _syncProgress;
 
@@ -33,8 +36,18 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
   Future<void> _loadServers() async {
     final servers = await Database.networkServers.where().findAll();
     servers.sort((a, b) => a.label.toLowerCase().compareTo(b.label.toLowerCase()));
+    final repo = SongRepository();
+    final counts = <int, int>{};
+    for (final s in servers) {
+      counts[s.id] = await repo.countSongsByRemoteServer(s.id);
+    }
     if (!mounted) return;
-    setState(() => _servers = servers);
+    setState(() {
+      _servers = servers;
+      _songCounts
+        ..clear()
+        ..addAll(counts);
+    });
   }
 
   Future<void> _openEditor({NetworkServerEntity? server}) async {
@@ -46,36 +59,6 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
     if (changed == true) {
       await _loadServers();
     }
-  }
-
-  Future<void> _deleteServer(NetworkServerEntity server) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Remove server?'),
-        content: Text(
-          'Delete "${server.label}" and all songs synced from it? '
-          'Cached downloads are kept.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true) return;
-
-    await Database.instance.writeTxn(() async {
-      await Database.networkServers.delete(server.id);
-    });
-    await SongRepository().deleteSongsForRemoteServer(server.id);
-    await _loadServers();
   }
 
   Future<void> _syncServer(NetworkServerEntity server) async {
@@ -114,19 +97,9 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (_servers.isEmpty) ...[
-            const SizedBox(height: AppConstants.spacingLg),
-            Center(
-              child: Text(
-                'No network sources yet.\nAdd a Subsonic server to browse and '
-                'stream your remote library.',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.adaptiveTextTertiary,
-                ),
-              ),
-            ),
-          ] else
+          if (_servers.isEmpty)
+            _buildEmptyState(context)
+          else ...[
             SettingsCard(
               children: [
                 for (var i = 0; i < _servers.length; i++) ...[
@@ -135,29 +108,91 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
                 ],
               ],
             ),
-          const SizedBox(height: AppConstants.spacingMd),
-          ActionButton(
-            icon: LucideIcons.plus,
-            title: 'Add Server',
-            subtitle: 'Connect a Subsonic server',
-            onTap: () => _openEditor(),
-          ),
+            const SizedBox(height: AppConstants.spacingMd),
+            ActionButton(
+              icon: LucideIcons.plus,
+              title: 'Add Server',
+              subtitle: 'Connect a Subsonic server',
+              onTap: () => _openEditor(),
+            ),
+          ],
         ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppConstants.spacingLg,
+        vertical: AppConstants.spacingXxl,
+      ),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: AppColors.glassBackground,
+                shape: BoxShape.circle,
+                border: Border.all(color: AppColors.glassBorder),
+              ),
+              child: Icon(
+                LucideIcons.server,
+                size: 32,
+                color: context.adaptiveTextTertiary,
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingLg),
+            Text(
+              'No servers connected',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: context.adaptiveTextPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingXs),
+            Text(
+              'Connect a Subsonic-compatible server like Navidrome,\n'
+              'Airsonic, or Gonic to stream your remote library.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: context.adaptiveTextTertiary,
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingXl),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () => _openEditor(),
+                icon: const Icon(LucideIcons.plus, size: 18),
+                label: const Text('Add Server'),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
   Widget _buildServerRow(BuildContext context, NetworkServerEntity server) {
     final isSyncing = _syncingId == server.id;
-    final lastSynced = server.lastSyncedAt;
-    final syncedLabel = lastSynced == null
-        ? 'Never synced'
-        : 'Synced ${_formatDate(lastSynced)}';
+    final songCount = _songCounts[server.id] ?? 0;
 
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () => _openEditor(server: server),
+        onTap: isSyncing ? null : () => _openEditor(server: server),
         child: Padding(
           padding: const EdgeInsets.all(AppConstants.spacingMd),
           child: Column(
@@ -167,8 +202,8 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
                 children: [
                   ColoredSettingsIcon(
                     icon: LucideIcons.server,
-                    backgroundColor: const Color(0xFF2D4A6F),
-                    iconColor: const Color(0xFF8BB8FF),
+                    backgroundColor: AppColors.glassBackgroundStrong,
+                    iconColor: context.adaptiveTextSecondary,
                   ),
                   const SizedBox(width: AppConstants.spacingMd),
                   Expanded(
@@ -183,9 +218,10 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
                                 overflow: TextOverflow.ellipsis,
                                 style: Theme.of(context)
                                     .textTheme
-                                    .titleSmall
+                                    .titleMedium
                                     ?.copyWith(
                                       color: context.adaptiveTextPrimary,
+                                      fontWeight: FontWeight.w600,
                                     ),
                               ),
                             ),
@@ -193,7 +229,7 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
                             _ProtocolChip(server.protocol),
                           ],
                         ),
-                        const SizedBox(height: 2),
+                        const SizedBox(height: 3),
                         Text(
                           server.baseUrl,
                           overflow: TextOverflow.ellipsis,
@@ -201,58 +237,139 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
                             color: context.adaptiveTextTertiary,
                           ),
                         ),
-                        const SizedBox(height: 2),
-                        Text(
-                          isSyncing
-                              ? _syncProgress?.phase ?? 'Syncing…'
-                              : syncedLabel,
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: isSyncing
-                                ? context.adaptiveTextSecondary
-                                : context.adaptiveTextTertiary,
-                          ),
-                        ),
                       ],
                     ),
                   ),
-                  IconButton(
-                    onPressed: isSyncing ? null : () => _syncServer(server),
-                    icon: Icon(
-                      isSyncing
-                          ? LucideIcons.loaderCircle
-                          : LucideIcons.refreshCw,
-                      size: 18,
-                      color: context.adaptiveTextSecondary,
+                  if (!isSyncing)
+                    IconButton(
+                      tooltip: 'Sync now',
+                      onPressed: () {
+                        AppHaptics.tap();
+                        _syncServer(server);
+                      },
+                      icon: Icon(
+                        LucideIcons.refreshCw,
+                        size: 18,
+                        color: context.adaptiveTextSecondary,
+                      ),
                     ),
-                  ),
-                  PopupMenuButton<String>(
-                    onSelected: (value) {
-                      switch (value) {
-                        case 'edit':
-                          _openEditor(server: server);
-                        case 'delete':
-                          _deleteServer(server);
-                      }
-                    },
-                    itemBuilder: (context) => const [
-                      PopupMenuItem(value: 'edit', child: Text('Edit')),
-                      PopupMenuItem(value: 'delete', child: Text('Delete')),
-                    ],
-                  ),
                 ],
               ),
-              if (isSyncing) ...[
-                const SizedBox(height: AppConstants.spacingSm),
-                LinearProgressIndicator(
-                  value: _syncProgress?.progressFraction ?? 0,
-                  minHeight: 3,
-                  borderRadius: BorderRadius.circular(2),
-                ),
-              ],
+              const SizedBox(height: AppConstants.spacingSm),
+              if (isSyncing)
+                _buildSyncPanel(context)
+              else
+                _buildMetaRow(context, server, songCount),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildMetaRow(
+    BuildContext context,
+    NetworkServerEntity server,
+    int songCount,
+  ) {
+    final synced = server.lastSyncedAt;
+    final parts = <String>[
+      if (songCount > 0) '$songCount ${songCount == 1 ? 'song' : 'songs'}',
+      synced == null ? 'Never synced' : 'Synced ${_formatDate(synced)}',
+    ];
+    return Row(
+      children: [
+        Container(
+          width: 6,
+          height: 6,
+          margin: const EdgeInsets.only(right: 8),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: synced == null ? AppColors.textTertiary : AppColors.accent,
+          ),
+        ),
+        Flexible(
+          child: Text(
+            parts.join('  ·  '),
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSyncPanel(BuildContext context) {
+    final p = _syncProgress;
+    final fraction = p?.progressFraction ?? 0.0;
+    final total = p?.totalFiles ?? 0;
+    final done = p?.filesProcessed ?? 0;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            SizedBox(
+              width: 12,
+              height: 12,
+              child: CircularProgressIndicator(
+                strokeWidth: 1.5,
+                valueColor: AlwaysStoppedAnimation(context.adaptiveAccent),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                p?.phase ?? 'Syncing…',
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.adaptiveAccent,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            if (total > 0)
+              Text(
+                '$done / $total',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
+              ),
+          ],
+        ),
+        if (p?.currentFile != null && p!.currentFile!.isNotEmpty) ...[
+          const SizedBox(height: 4),
+          Text(
+            p.currentFile!,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 1,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ],
+        const SizedBox(height: AppConstants.spacingXs),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(AppConstants.radiusRound),
+          child: LinearProgressIndicator(
+            value: fraction,
+            minHeight: 4,
+            backgroundColor: AppColors.glassBackground,
+            valueColor: AlwaysStoppedAnimation(context.adaptiveAccent),
+          ),
+        ),
+        if ((p?.songsFound ?? 0) > 0) ...[
+          const SizedBox(height: 4),
+          Text(
+            '${p!.songsFound} songs found',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: context.adaptiveTextTertiary,
+            ),
+          ),
+        ],
+      ],
     );
   }
 
@@ -274,16 +391,17 @@ class _ProtocolChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: const Color(0xFF2D4A6F).withValues(alpha: 0.35),
-        borderRadius: BorderRadius.circular(4),
+        color: AppColors.glassBackgroundStrong,
+        borderRadius: BorderRadius.circular(AppConstants.radiusXs),
+        border: Border.all(color: AppColors.glassBorder),
       ),
       child: Text(
         protocol.toUpperCase(),
-        style: const TextStyle(
+        style: TextStyle(
           fontSize: 9,
           fontWeight: FontWeight.w700,
           letterSpacing: 0.8,
-          color: Color(0xFF8BB8FF),
+          color: context.adaptiveTextTertiary,
         ),
       ),
     );

--- a/lib/features/settings/screens/network_sources_screen.dart
+++ b/lib/features/settings/screens/network_sources_screen.dart
@@ -9,11 +9,12 @@ import '../../../core/utils/app_haptics.dart';
 import '../../../data/database.dart';
 import '../../../data/repositories/song_repository.dart';
 import '../../../services/library_scanner_service.dart' show ScanProgress;
-import '../../../services/sources/subsonic_service.dart';
+import '../../../services/sources/network_source_service.dart';
 import '../widgets/settings_widgets.dart';
 import 'network_server_edit_screen.dart';
 
-/// Manage configured network music servers (Subsonic in v1).
+/// Manage configured network music servers (Subsonic, Jellyfin, WebDAV,
+/// UPnP/DLNA, SMB).
 class NetworkSourcesScreen extends StatefulWidget {
   const NetworkSourcesScreen({super.key});
 
@@ -69,7 +70,7 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
     });
     try {
       await for (final progress
-          in SubsonicService.instance.syncLibrary(server)) {
+          in networkSourceServiceFor(server.protocol).syncLibrary(server)) {
         if (mounted && _syncingId == server.id) {
           setState(() => _syncProgress = progress);
         }
@@ -112,7 +113,7 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
             ActionButton(
               icon: LucideIcons.plus,
               title: 'Add Server',
-              subtitle: 'Connect a Subsonic server',
+              subtitle: 'Connect a music server',
               onTap: () => _openEditor(),
             ),
           ],
@@ -156,8 +157,8 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
             ),
             const SizedBox(height: AppConstants.spacingXs),
             Text(
-              'Connect a Subsonic-compatible server like Navidrome,\n'
-              'Airsonic, or Gonic to stream your remote library.',
+              'Connect a Subsonic, Jellyfin, WebDAV, or UPnP server to stream '
+              'your remote library.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 color: context.adaptiveTextTertiary,

--- a/lib/features/settings/screens/network_sources_screen.dart
+++ b/lib/features/settings/screens/network_sources_screen.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:isar_community/isar.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../../core/constants/app_constants.dart';
+import '../../../core/theme/adaptive_color_provider.dart';
+import '../../../data/database.dart';
+import '../../../data/repositories/song_repository.dart';
+import '../../../services/library_scanner_service.dart' show ScanProgress;
+import '../../../services/sources/subsonic_service.dart';
+import '../widgets/settings_widgets.dart';
+import 'network_server_edit_screen.dart';
+
+/// Manage configured network music servers (Subsonic in v1).
+class NetworkSourcesScreen extends StatefulWidget {
+  const NetworkSourcesScreen({super.key});
+
+  @override
+  State<NetworkSourcesScreen> createState() => _NetworkSourcesScreenState();
+}
+
+class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
+  List<NetworkServerEntity> _servers = [];
+  int? _syncingId;
+  ScanProgress? _syncProgress;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadServers();
+  }
+
+  Future<void> _loadServers() async {
+    final servers = await Database.networkServers.where().findAll();
+    servers.sort((a, b) => a.label.toLowerCase().compareTo(b.label.toLowerCase()));
+    if (!mounted) return;
+    setState(() => _servers = servers);
+  }
+
+  Future<void> _openEditor({NetworkServerEntity? server}) async {
+    final changed = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => NetworkServerEditScreen(server: server),
+      ),
+    );
+    if (changed == true) {
+      await _loadServers();
+    }
+  }
+
+  Future<void> _deleteServer(NetworkServerEntity server) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove server?'),
+        content: Text(
+          'Delete "${server.label}" and all songs synced from it? '
+          'Cached downloads are kept.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    await Database.instance.writeTxn(() async {
+      await Database.networkServers.delete(server.id);
+    });
+    await SongRepository().deleteSongsForRemoteServer(server.id);
+    await _loadServers();
+  }
+
+  Future<void> _syncServer(NetworkServerEntity server) async {
+    if (_syncingId != null) return;
+    setState(() {
+      _syncingId = server.id;
+      _syncProgress = null;
+    });
+    try {
+      await for (final progress
+          in SubsonicService.instance.syncLibrary(server)) {
+        if (mounted && _syncingId == server.id) {
+          setState(() => _syncProgress = progress);
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Sync failed: $e')),
+        );
+      }
+    }
+    if (mounted) {
+      setState(() {
+        _syncingId = null;
+        _syncProgress = null;
+      });
+      await _loadServers();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsScaffold(
+      title: 'Network Sources',
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (_servers.isEmpty) ...[
+            const SizedBox(height: AppConstants.spacingLg),
+            Center(
+              child: Text(
+                'No network sources yet.\nAdd a Subsonic server to browse and '
+                'stream your remote library.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: context.adaptiveTextTertiary,
+                ),
+              ),
+            ),
+          ] else
+            SettingsCard(
+              children: [
+                for (var i = 0; i < _servers.length; i++) ...[
+                  if (i > 0) const SettingsDivider(),
+                  _buildServerRow(context, _servers[i]),
+                ],
+              ],
+            ),
+          const SizedBox(height: AppConstants.spacingMd),
+          ActionButton(
+            icon: LucideIcons.plus,
+            title: 'Add Server',
+            subtitle: 'Connect a Subsonic server',
+            onTap: () => _openEditor(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildServerRow(BuildContext context, NetworkServerEntity server) {
+    final isSyncing = _syncingId == server.id;
+    final lastSynced = server.lastSyncedAt;
+    final syncedLabel = lastSynced == null
+        ? 'Never synced'
+        : 'Synced ${_formatDate(lastSynced)}';
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () => _openEditor(server: server),
+        child: Padding(
+          padding: const EdgeInsets.all(AppConstants.spacingMd),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  ColoredSettingsIcon(
+                    icon: LucideIcons.server,
+                    backgroundColor: const Color(0xFF2D4A6F),
+                    iconColor: const Color(0xFF8BB8FF),
+                  ),
+                  const SizedBox(width: AppConstants.spacingMd),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                server.label,
+                                overflow: TextOverflow.ellipsis,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleSmall
+                                    ?.copyWith(
+                                      color: context.adaptiveTextPrimary,
+                                    ),
+                              ),
+                            ),
+                            const SizedBox(width: 6),
+                            _ProtocolChip(server.protocol),
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          server.baseUrl,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.adaptiveTextTertiary,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          isSyncing
+                              ? _syncProgress?.phase ?? 'Syncing…'
+                              : syncedLabel,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: isSyncing
+                                ? context.adaptiveTextSecondary
+                                : context.adaptiveTextTertiary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: isSyncing ? null : () => _syncServer(server),
+                    icon: Icon(
+                      isSyncing
+                          ? LucideIcons.loaderCircle
+                          : LucideIcons.refreshCw,
+                      size: 18,
+                      color: context.adaptiveTextSecondary,
+                    ),
+                  ),
+                  PopupMenuButton<String>(
+                    onSelected: (value) {
+                      switch (value) {
+                        case 'edit':
+                          _openEditor(server: server);
+                        case 'delete':
+                          _deleteServer(server);
+                      }
+                    },
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(value: 'edit', child: Text('Edit')),
+                      PopupMenuItem(value: 'delete', child: Text('Delete')),
+                    ],
+                  ),
+                ],
+              ),
+              if (isSyncing) ...[
+                const SizedBox(height: AppConstants.spacingSm),
+                LinearProgressIndicator(
+                  value: _syncProgress?.progressFraction ?? 0,
+                  minHeight: 3,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final local = date.toLocal();
+    final month = local.month.toString().padLeft(2, '0');
+    final day = local.day.toString().padLeft(2, '0');
+    return '${local.year}-$month-$day ${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+  }
+}
+
+class _ProtocolChip extends StatelessWidget {
+  const _ProtocolChip(this.protocol);
+
+  final String protocol;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: const Color(0xFF2D4A6F).withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        protocol.toUpperCase(),
+        style: const TextStyle(
+          fontSize: 9,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+          color: Color(0xFF8BB8FF),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:flick/features/settings/screens/queue_settings_screen.dart';
 import 'package:flick/features/settings/screens/ui_customization_settings_screen.dart';
 import 'package:flick/features/settings/screens/integrations_settings_screen.dart';
 import 'package:flick/features/settings/screens/lyrics_settings_screen.dart';
+import 'package:flick/features/settings/screens/network_sources_screen.dart';
 import 'package:flick/features/settings/screens/player_layout_settings_screen.dart';
 import 'package:flick/features/settings/screens/widget_settings_screen.dart';
 import 'package:flick/features/settings/screens/support_flick_screen.dart';
@@ -81,6 +82,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           subtitle: 'Folders, scanning, and duplicates',
                           onTap: () =>
                               _navigate(context, const LibrarySettingsScreen()),
+                        ),
+                        const SettingsDivider(),
+                        _CategoryTile(
+                          icon: LucideIcons.cloud,
+                          iconBg: const Color(0xFF2D6F6F),
+                          iconFg: const Color(0xFF8BFFE0),
+                          title: 'Network Sources',
+                          subtitle: 'Subsonic servers, sync, and streaming',
+                          onTap: () =>
+                              _navigate(context, const NetworkSourcesScreen()),
                         ),
                         const SettingsDivider(),
                         _CategoryTile(

--- a/lib/features/settings/screens/uac2_settings_screen.dart
+++ b/lib/features/settings/screens/uac2_settings_screen.dart
@@ -30,6 +30,7 @@ class _Uac2SettingsScreenState extends ConsumerState<Uac2SettingsScreen> {
     final selectedDevice = ref.watch(selectedUac2DeviceProvider);
     final deviceStatus = ref.watch(uac2DeviceStatusProvider);
     final currentSong = ref.watch(currentSongProvider);
+    final appPreferences = ref.watch(appPreferencesProvider);
 
     return DisplayModeWrapper(
       child: Scaffold(
@@ -88,7 +89,8 @@ class _Uac2SettingsScreenState extends ConsumerState<Uac2SettingsScreen> {
                             ],
                             if (deviceStatus != null &&
                                 deviceStatus.state != Uac2State.idle &&
-                                deviceStatus.hasVolumeControl) ...[
+                                deviceStatus.hasVolumeControl &&
+                                appPreferences.showUsbVolumeOnSettings) ...[
                               const SizedBox(height: AppConstants.spacingLg),
                               _buildSectionHeader(context, 'Volume Control'),
                               const Uac2VolumeControl(),

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -105,6 +105,30 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                       .setShowEngineSelector(value);
                 },
               ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.volume2,
+                title: 'USB Volume on Home',
+                subtitle: 'Show the USB volume bar on the home screen',
+                value: appPreferences.showUsbVolumeOnMenu,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setShowUsbVolumeOnMenu(value);
+                },
+              ),
+              const SettingsDivider(),
+              ToggleSetting(
+                icon: LucideIcons.slidersHorizontal,
+                title: 'USB Volume in Settings',
+                subtitle: 'Show the USB volume bar on the UAC2 settings screen',
+                value: appPreferences.showUsbVolumeOnSettings,
+                onChanged: (value) {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setShowUsbVolumeOnSettings(value);
+                },
+              ),
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),

--- a/lib/features/settings/widgets/settings_widgets.dart
+++ b/lib/features/settings/widgets/settings_widgets.dart
@@ -217,7 +217,7 @@ class NavigationSetting extends StatelessWidget {
   }
 }
 
-/// Row with a radio-like selection indicator.
+/// Row with a radio-like selection indicator. Disabled when [onTap] is null.
 class SelectionSetting extends StatelessWidget {
   const SelectionSetting({
     super.key,
@@ -225,29 +225,31 @@ class SelectionSetting extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.selected,
-    required this.onTap,
+    this.onTap,
   });
 
   final IconData icon;
   final String title;
   final String subtitle;
   final bool selected;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: () {
-          AppHaptics.tap();
-          onTap();
-        },
+        onTap: onTap,
         child: Padding(
           padding: const EdgeInsets.all(AppConstants.spacingLg),
           child: Row(
             children: [
-              _SettingsIcon(icon: icon),
+              _SettingsIcon(
+                icon: icon,
+                color: onTap == null
+                    ? context.adaptiveTextTertiary
+                    : null,
+              ),
               const SizedBox(width: AppConstants.spacingMd),
               Expanded(
                 child: Column(
@@ -256,7 +258,9 @@ class SelectionSetting extends StatelessWidget {
                     Text(
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: context.adaptiveTextPrimary,
+                        color: onTap == null
+                            ? context.adaptiveTextTertiary
+                            : context.adaptiveTextPrimary,
                       ),
                     ),
                     const SizedBox(height: 2),
@@ -273,9 +277,11 @@ class SelectionSetting extends StatelessWidget {
                 selected
                     ? Icons.check_circle_rounded
                     : Icons.radio_button_unchecked,
-                color: selected
-                    ? context.adaptiveTextPrimary
-                    : context.adaptiveTextTertiary,
+                color: onTap == null
+                    ? context.adaptiveTextTertiary
+                    : selected
+                        ? context.adaptiveTextPrimary
+                        : context.adaptiveTextTertiary,
                 size: 20,
               ),
             ],

--- a/lib/features/settings/widgets/settings_widgets.dart
+++ b/lib/features/settings/widgets/settings_widgets.dart
@@ -636,8 +636,12 @@ class SettingsScaffold extends ConsumerWidget {
                 const SizedBox(height: AppConstants.spacingMd),
                 Expanded(
                   child: SingleChildScrollView(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppConstants.spacingMd,
+                    padding: EdgeInsets.fromLTRB(
+                      AppConstants.spacingMd,
+                      0,
+                      AppConstants.spacingMd,
+                      MediaQuery.paddingOf(context).bottom +
+                          AppConstants.spacingLg,
                     ),
                     child: body,
                   ),

--- a/lib/models/playback_context.dart
+++ b/lib/models/playback_context.dart
@@ -4,6 +4,7 @@ enum PlaybackSource {
   folder,
   playlist,
   allSongs,
+  network,
   unknown;
 
   String get label => switch (this) {
@@ -12,6 +13,7 @@ enum PlaybackSource {
     PlaybackSource.folder => 'Folder',
     PlaybackSource.playlist => 'Playlist',
     PlaybackSource.allSongs => 'All Songs',
+    PlaybackSource.network => 'Network',
     PlaybackSource.unknown => 'Unknown',
   };
 }

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -81,6 +81,16 @@ class Song {
   /// Package name of the app that handed this song to Flick.
   final String? sourcePackage;
 
+  /// Where this song came from: null = local file, otherwise one of
+  /// 'subsonic' | 'webdav' | 'jellyfin'.
+  final String? sourceType;
+
+  /// The server's song id (Subsonic song id, WebDAV file URL, Jellyfin Item.Id).
+  final String? remoteId;
+
+  /// [NetworkServerEntity.id] of the server this song was synced from.
+  final int? remoteServerId;
+
   const Song({
     required this.id,
     required this.title,
@@ -109,9 +119,14 @@ class Song {
     this.dateAdded,
     this.isExternal = false,
     this.sourcePackage,
+    this.sourceType,
+    this.remoteId,
+    this.remoteServerId,
   });
 
   bool get isFromLocker => sourcePackage == 'com.mossapps.locker';
+
+  bool get isNetworkSource => sourceType != null;
 
   static const _dsdExtensions = {'dsf', 'dff'};
   static const _wavpackExtension = 'wv';
@@ -196,6 +211,9 @@ class Song {
     DateTime? dateAdded,
     bool? isExternal,
     String? sourcePackage,
+    String? sourceType,
+    String? remoteId,
+    int? remoteServerId,
   }) {
     return Song(
       id: id ?? this.id,
@@ -225,6 +243,9 @@ class Song {
       dateAdded: dateAdded ?? this.dateAdded,
       isExternal: isExternal ?? this.isExternal,
       sourcePackage: sourcePackage ?? this.sourcePackage,
+      sourceType: sourceType ?? this.sourceType,
+      remoteId: remoteId ?? this.remoteId,
+      remoteServerId: remoteServerId ?? this.remoteServerId,
     );
   }
 

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -83,6 +83,22 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setShowEngineSelector(value);
   }
 
+  Future<void> setShowUsbVolumeOnMenu(bool value) async {
+    if (state.showUsbVolumeOnMenu == value) return;
+    state = state.copyWith(showUsbVolumeOnMenu: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setShowUsbVolumeOnMenu(value);
+  }
+
+  Future<void> setShowUsbVolumeOnSettings(bool value) async {
+    if (state.showUsbVolumeOnSettings == value) return;
+    state = state.copyWith(showUsbVolumeOnSettings: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setShowUsbVolumeOnSettings(value);
+  }
+
   Future<void> setCrossfadeEnabled(bool value) async {
     if (state.crossfadeEnabled == value) return;
     state = state.copyWith(crossfadeEnabled: value);

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -12,7 +12,7 @@ import '../data/repositories/song_repository.dart';
 import '../src/rust/api/scanner.dart' as rust_scanner;
 import 'music_folder_service.dart';
 import 'player_service.dart';
-import 'sources/subsonic_service.dart';
+import 'sources/network_source_service.dart';
 
 class AlbumArtService {
   AlbumArtService._();
@@ -132,28 +132,29 @@ class AlbumArtService {
     return File(path).exists();
   }
 
-  /// Fetch raw artwork bytes. Network songs resolve through the Subsonic
-  /// cover-art endpoint using the `subsonic-cover://<id>` marker stored in the
-  /// entity's albumArtPath; local songs extract embedded art as before.
+  /// Fetch raw artwork bytes. Network songs resolve through their protocol
+  /// service's cover endpoint using the `<proto>-cover://<marker>` stored in
+  /// the entity's albumArtPath; local songs extract embedded art as before.
   Future<Uint8List?> _loadArtworkBytes(
     String audioSourcePath, {
     String? existingPath,
   }) async {
     final uri = Uri.tryParse(audioSourcePath);
-    if (uri?.scheme == 'subsonic') {
+    if (uri != null && isSupportedNetworkProtocol(uri.scheme)) {
+      final service = networkSourceServiceFor(uri.scheme);
       final marker = existingPath != null &&
-              existingPath.startsWith(networkCoverArtScheme)
-          ? existingPath.substring(networkCoverArtScheme.length)
+              existingPath.startsWith(service.coverScheme)
+          ? existingPath.substring(service.coverScheme.length)
           : null;
       if (marker == null || marker.isEmpty) return null;
 
-      final serverId = int.tryParse(uri!.host);
+      final serverId = int.tryParse(uri.host);
       if (serverId == null) return null;
       final server = await Database.networkServers.get(serverId);
       if (server == null) return null;
 
       try {
-        final bytes = await SubsonicService.instance.getCoverArt(server, marker);
+        final bytes = await service.getCoverArt(server, marker);
         return Uint8List.fromList(bytes);
       } catch (e) {
         return null;
@@ -179,7 +180,8 @@ class AlbumArtService {
       // Network songs keep their cover-art marker in the DB so a cache
       // eviction can always re-resolve; only the in-memory playlist is
       // updated with the resolved local path.
-      final isNetwork = Uri.tryParse(audioSourcePath)?.scheme == 'subsonic';
+      final isNetwork =
+          isSupportedNetworkProtocol(Uri.tryParse(audioSourcePath)?.scheme);
       if (!isNetwork) {
         await _songRepository.updateAlbumArtPath(audioSourcePath, albumArtPath);
       }

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -7,10 +7,12 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 
+import '../data/database.dart';
 import '../data/repositories/song_repository.dart';
 import '../src/rust/api/scanner.dart' as rust_scanner;
 import 'music_folder_service.dart';
 import 'player_service.dart';
+import 'sources/subsonic_service.dart';
 
 class AlbumArtService {
   AlbumArtService._();
@@ -48,7 +50,8 @@ class AlbumArtService {
     }
 
     final future = _inFlightResolutions.putIfAbsent(audioSourcePath, () async {
-      final raw = await _loadArtworkBytes(audioSourcePath);
+      final raw = await _loadArtworkBytes(audioSourcePath,
+          existingPath: existingPath);
       if (raw == null || raw.isEmpty) {
         await _persistArtworkPath(audioSourcePath, null);
         return null;
@@ -129,7 +132,34 @@ class AlbumArtService {
     return File(path).exists();
   }
 
-  Future<Uint8List?> _loadArtworkBytes(String audioSourcePath) async {
+  /// Fetch raw artwork bytes. Network songs resolve through the Subsonic
+  /// cover-art endpoint using the `subsonic-cover://<id>` marker stored in the
+  /// entity's albumArtPath; local songs extract embedded art as before.
+  Future<Uint8List?> _loadArtworkBytes(
+    String audioSourcePath, {
+    String? existingPath,
+  }) async {
+    final uri = Uri.tryParse(audioSourcePath);
+    if (uri?.scheme == 'subsonic') {
+      final marker = existingPath != null &&
+              existingPath.startsWith(networkCoverArtScheme)
+          ? existingPath.substring(networkCoverArtScheme.length)
+          : null;
+      if (marker == null || marker.isEmpty) return null;
+
+      final serverId = int.tryParse(uri!.host);
+      if (serverId == null) return null;
+      final server = await Database.networkServers.get(serverId);
+      if (server == null) return null;
+
+      try {
+        final bytes = await SubsonicService.instance.getCoverArt(server, marker);
+        return Uint8List.fromList(bytes);
+      } catch (e) {
+        return null;
+      }
+    }
+
     if (Platform.isAndroid && audioSourcePath.startsWith('content://')) {
       return _musicFolderService.fetchEmbeddedArtwork(audioSourcePath);
     }
@@ -146,7 +176,13 @@ class AlbumArtService {
     String? albumArtPath,
   ) async {
     try {
-      await _songRepository.updateAlbumArtPath(audioSourcePath, albumArtPath);
+      // Network songs keep their cover-art marker in the DB so a cache
+      // eviction can always re-resolve; only the in-memory playlist is
+      // updated with the resolved local path.
+      final isNetwork = Uri.tryParse(audioSourcePath)?.scheme == 'subsonic';
+      if (!isNetwork) {
+        await _songRepository.updateAlbumArtPath(audioSourcePath, albumArtPath);
+      }
       if (albumArtPath != null) {
         PlayerService().syncAlbumArtPaths(
           filePaths: [audioSourcePath],

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -10,6 +10,8 @@ class AppPreferences {
   final bool showBrowseMore;
   final bool showQuickAccess;
   final bool showEngineSelector;
+  final bool showUsbVolumeOnMenu;
+  final bool showUsbVolumeOnSettings;
   final bool crossfadeEnabled;
   final double crossfadeDurationSecs;
   final int crossfadeCurveIndex;
@@ -110,6 +112,8 @@ class AppPreferences {
     this.showBrowseMore = true,
     this.showQuickAccess = true,
     this.showEngineSelector = true,
+    this.showUsbVolumeOnMenu = true,
+    this.showUsbVolumeOnSettings = false,
     this.crossfadeEnabled = false,
     this.crossfadeDurationSecs = 3.0,
     this.crossfadeCurveIndex = 0,
@@ -211,6 +215,8 @@ class AppPreferences {
     bool? showBrowseMore,
     bool? showQuickAccess,
     bool? showEngineSelector,
+    bool? showUsbVolumeOnMenu,
+    bool? showUsbVolumeOnSettings,
     bool? crossfadeEnabled,
     double? crossfadeDurationSecs,
     int? crossfadeCurveIndex,
@@ -311,6 +317,10 @@ class AppPreferences {
       showBrowseMore: showBrowseMore ?? this.showBrowseMore,
       showQuickAccess: showQuickAccess ?? this.showQuickAccess,
       showEngineSelector: showEngineSelector ?? this.showEngineSelector,
+      showUsbVolumeOnMenu:
+          showUsbVolumeOnMenu ?? this.showUsbVolumeOnMenu,
+      showUsbVolumeOnSettings:
+          showUsbVolumeOnSettings ?? this.showUsbVolumeOnSettings,
       crossfadeEnabled: crossfadeEnabled ?? this.crossfadeEnabled,
       crossfadeDurationSecs:
           crossfadeDurationSecs ?? this.crossfadeDurationSecs,
@@ -457,6 +467,8 @@ class AppPreferencesService {
   static const _showBrowseMoreKey = 'menu_show_browse_more';
   static const _showQuickAccessKey = 'menu_show_quick_access';
   static const _showEngineSelectorKey = 'menu_show_engine_selector';
+  static const _showUsbVolumeOnMenuKey = 'menu_show_usb_volume';
+  static const _showUsbVolumeOnSettingsKey = 'settings_show_usb_volume';
   static const _crossfadeEnabledKey = 'audio_crossfade_enabled';
   static const _crossfadeDurationKey = 'audio_crossfade_duration_secs';
   static const _crossfadeCurveKey = 'audio_crossfade_curve_index';
@@ -569,6 +581,9 @@ class AppPreferencesService {
       showBrowseMore: prefs.getBool(_showBrowseMoreKey) ?? true,
       showQuickAccess: prefs.getBool(_showQuickAccessKey) ?? true,
       showEngineSelector: prefs.getBool(_showEngineSelectorKey) ?? true,
+      showUsbVolumeOnMenu: prefs.getBool(_showUsbVolumeOnMenuKey) ?? true,
+      showUsbVolumeOnSettings:
+          prefs.getBool(_showUsbVolumeOnSettingsKey) ?? false,
       crossfadeEnabled: prefs.getBool(_crossfadeEnabledKey) ?? false,
       crossfadeDurationSecs: prefs.getDouble(_crossfadeDurationKey) ?? 3.0,
       crossfadeCurveIndex: prefs.getInt(_crossfadeCurveKey) ?? 0,
@@ -789,6 +804,26 @@ class AppPreferencesService {
   Future<void> setShowEngineSelector(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_showEngineSelectorKey, value);
+  }
+
+  Future<bool> getShowUsbVolumeOnMenu() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_showUsbVolumeOnMenuKey) ?? true;
+  }
+
+  Future<void> setShowUsbVolumeOnMenu(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showUsbVolumeOnMenuKey, value);
+  }
+
+  Future<bool> getShowUsbVolumeOnSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_showUsbVolumeOnSettingsKey) ?? false;
+  }
+
+  Future<void> setShowUsbVolumeOnSettings(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_showUsbVolumeOnSettingsKey, value);
   }
 
   Future<bool> getCrossfadeEnabled() async {

--- a/lib/services/network_cache_service.dart
+++ b/lib/services/network_cache_service.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Bounded LRU download cache for network-sourced songs.
+///
+/// Layout: `<appCache>/network_cache/<serverId>/<md5(serverId:remoteId)>.<ext>`.
+/// LRU by file mtime; eviction runs after each [stash] once the total exceeds
+/// [sizeCapBytes].
+class NetworkCacheService {
+  NetworkCacheService({
+    this.sizeCapBytes = defaultSizeCapBytes,
+    Directory? rootDirectory,
+  }) : _rootDirectory = rootDirectory;
+
+  /// Default cap: 2 GiB.
+  static const defaultSizeCapBytes = 2 * 1024 * 1024 * 1024;
+
+  static const _dirName = 'network_cache';
+
+  final int sizeCapBytes;
+
+  /// Test seam; when null, resolves the platform app cache directory.
+  final Directory? _rootDirectory;
+
+  Future<Directory> _root() async {
+    if (_rootDirectory != null) return _rootDirectory;
+    final cacheDir = await getApplicationCacheDirectory();
+    final root = Directory(p.join(cacheDir.path, _dirName));
+    await root.create(recursive: true);
+    return root;
+  }
+
+  static String _hash(int remoteServerId, String remoteId) =>
+      md5.convert(utf8.encode('$remoteServerId:$remoteId')).toString();
+
+  /// Path of the cached file for (server, song), or null if not cached.
+  /// Touches the file's mtime to keep it warm in the LRU order.
+  Future<String?> getPath(
+    int remoteServerId,
+    String remoteId, {
+    String? extension,
+  }) async {
+    final serverDir = Directory(p.join((await _root()).path, '$remoteServerId'));
+    if (!await serverDir.exists()) return null;
+
+    final hash = _hash(remoteServerId, remoteId);
+    final fileName = extension != null
+        ? '$hash.$extension'
+        : await _findByHash(serverDir, hash);
+    if (fileName == null) return null;
+
+    final file = File(p.join(serverDir.path, fileName));
+    if (!await file.exists()) return null;
+
+    final now = DateTime.now();
+    if (file.lastModifiedSync() != now) {
+      await file.setLastModified(now);
+    }
+    return file.path;
+  }
+
+  /// Write [bytes] to the cache and evict oldest entries if over the cap.
+  /// Returns the cached file path.
+  Future<String> stash(
+    int remoteServerId,
+    String remoteId,
+    List<int> bytes, {
+    String? extension,
+  }) async {
+    final serverDir = Directory(p.join((await _root()).path, '$remoteServerId'));
+    await serverDir.create(recursive: true);
+    final file = File(
+      p.join(serverDir.path, '${_hash(remoteServerId, remoteId)}.${extension ?? 'bin'}'),
+    );
+    await file.writeAsBytes(bytes, flush: true);
+    await _evictIfOverCap(protect: file);
+    return file.path;
+  }
+
+  Future<String?> _findByHash(Directory serverDir, String hash) async {
+    await for (final entry in serverDir.list()) {
+      final name = p.basename(entry.path);
+      if (name.startsWith('$hash.')) return name;
+    }
+    return null;
+  }
+
+  // ponytail: full O(n) size scan per eviction; track running totals only
+  // if a server with a huge cache ever shows up on profile.
+  Future<void> _evictIfOverCap({File? protect}) async {
+    final root = await _root();
+    final files = <File>[];
+    var total = 0;
+    await for (final serverDir in root.list()) {
+      if (serverDir is! Directory) continue;
+      await for (final entry in serverDir.list()) {
+        if (entry is! File) continue;
+        files.add(entry);
+        total += await entry.length();
+      }
+    }
+    if (total <= sizeCapBytes) return;
+
+    files.sort((a, b) => a.lastModifiedSync().compareTo(b.lastModifiedSync()));
+    for (final file in files) {
+      if (total <= sizeCapBytes) break;
+      if (file.path == protect?.path) continue;
+      final length = await file.length();
+      await file.delete();
+      total -= length;
+    }
+  }
+}

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2999,7 +2999,11 @@ class PlayerService {
         directUsbFormat =
             _uac2Service.currentDeviceStatus?.currentFormat ??
             _uac2Service.lastKnownFormat;
-        preferredSampleRate = directUsbFormat?.sampleRate;
+        // Do NOT overwrite preferredSampleRate from the DAC's stored format.
+        // The stored format may be stale (hardcoded 48000 from initial DAC
+        // registration) or report 0 Hz (broken readback). The Rust engine
+        // already has the track's actual sample rate via
+        // requested_playback_format; passing null here lets it use that.
       }
 
       try {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -37,6 +37,7 @@ import 'package:flick/services/album_color_mode_preference_service.dart';
 import 'package:flick/models/album_color_mode.dart';
 import 'package:flick/services/uac2_service.dart';
 import 'package:flick/services/alac_converter_service.dart';
+import 'package:flick/services/remote_source_service.dart';
 import 'package:flick/core/utils/dev_log.dart';
 
 enum HwVolumeCapability { unknown, supported, unsupported }
@@ -926,6 +927,7 @@ class PlayerService {
     if (_currentIndex == newIndex) return;
     _currentIndex = newIndex;
     currentIndexNotifier.value = newIndex;
+    _prefetchedNextSongId = null;
     _notifyUpNextChanged();
   }
 
@@ -1044,6 +1046,9 @@ class PlayerService {
       filePath: song.filePath,
       folderUri: song.folderUri,
       dateAdded: song.dateAdded,
+      sourceType: song.sourceType,
+      remoteId: song.remoteId,
+      remoteServerId: song.remoteServerId,
     );
   }
 
@@ -2690,6 +2695,12 @@ class PlayerService {
     final filePath = song.filePath;
     if (filePath == null || filePath.isEmpty) {
       return null;
+    }
+
+    if (song.isNetworkSource) {
+      // Network songs always play from the local network cache: a cache hit
+      // is instant (gapless/crossfade handoff), a miss downloads first.
+      return RemoteSourceService.instance.ensureLocal(song);
     }
 
     final sourceKey = filePath;
@@ -4827,8 +4838,43 @@ class PlayerService {
     _positionSaveTimer?.cancel();
     _positionSaveTimer = Timer.periodic(
       const Duration(seconds: 5),
-      (_) => _savePosition(),
+      (_) {
+        _savePosition();
+        _maybePrefetchNextNetworkSong();
+      },
     );
+  }
+
+  /// Last song id handed to [RemoteSourceService.prefetch]. Reset whenever the
+  /// current track changes so a replayed song re-prefetches its successor.
+  String? _prefetchedNextSongId;
+
+  /// P1.7: when the current network-sourced track is within 10s of its end,
+  /// start downloading the linear-next song so gapless/crossfade handoff reads
+  /// a local path. Cache hits make repeated calls no-ops (and the marker is
+  /// reset on track change, which also covers wrap-around).
+  void _maybePrefetchNextNetworkSong() {
+    final current = currentSongNotifier.value;
+    if (current == null || !current.isNetworkSource) return;
+    if (_playlist.isEmpty || _currentIndex < 0) return;
+
+    final duration = durationNotifier.value;
+    if (duration <= Duration.zero) return;
+    if (positionNotifier.value < duration - const Duration(seconds: 10)) {
+      return;
+    }
+
+    if (_currentIndex >= _playlist.length - 1 &&
+        loopModeNotifier.value != LoopMode.all) {
+      return;
+    }
+    final nextIndex = _currentIndex >= _playlist.length - 1 ? 0 : _currentIndex + 1;
+    final next = _playlist[nextIndex];
+    if (!next.isNetworkSource) return;
+    if (next.id == _prefetchedNextSongId) return;
+
+    _prefetchedNextSongId = next.id;
+    unawaited(RemoteSourceService.instance.prefetch(next));
   }
 
   void _startHwVolumeHealthTimer() {
@@ -5188,6 +5234,7 @@ class PlayerService {
         final playlists = await _playlistService.getPlaylists();
         return playlists.map((p) => p.id).toList();
       case PlaybackSource.allSongs:
+      case PlaybackSource.network:
       case PlaybackSource.unknown:
         return [];
     }
@@ -5250,6 +5297,7 @@ class PlayerService {
         );
         return songs;
       case PlaybackSource.allSongs:
+      case PlaybackSource.network:
       case PlaybackSource.unknown:
         return null;
     }

--- a/lib/services/remote_source_service.dart
+++ b/lib/services/remote_source_service.dart
@@ -3,26 +3,21 @@ import 'package:flutter/foundation.dart';
 import '../core/utils/app_log.dart';
 import '../data/database.dart';
 import '../models/song.dart';
-import 'sources/subsonic_service.dart';
+import 'sources/network_source_service.dart';
 
 /// Bridges playback/download for network-sourced songs.
 ///
-/// v1 supports Subsonic only: a cache hit returns the local file path
-/// immediately (gapless/crossfade handoff reads a local file), a miss
-/// downloads the original-quality stream into [NetworkCacheService].
+/// A cache hit returns the local file path immediately (gapless/crossfade
+/// handoff reads a local file); a miss downloads the original-quality stream
+/// into [NetworkCacheService] via the protocol service registered for the
+/// song's `sourceType`.
 class RemoteSourceService {
-  RemoteSourceService._({SubsonicService? subsonic})
-      : _subsonic = subsonic ?? SubsonicService.instance;
+  RemoteSourceService._();
 
   static RemoteSourceService instance = RemoteSourceService._();
 
-  /// Test seam: build an isolated instance with mocked dependencies.
   @visibleForTesting
-  static RemoteSourceService create({SubsonicService? subsonic}) {
-    return RemoteSourceService._(subsonic: subsonic);
-  }
-
-  final SubsonicService _subsonic;
+  static RemoteSourceService create() => RemoteSourceService._();
 
   /// Progress (0..1) of the interactive playback download, null when idle.
   final ValueNotifier<double?> downloadProgressNotifier = ValueNotifier(null);
@@ -45,28 +40,27 @@ class RemoteSourceService {
     if (!song.isNetworkSource) {
       throw StateError('Song is not a network source');
     }
+    final sourceType = song.sourceType;
+    if (sourceType == null) {
+      throw StateError('Network song has no source type');
+    }
     final server = await _serverFor(song);
     final remoteId = song.remoteId;
     if (remoteId == null) {
       throw StateError('Network song has no remote id');
     }
-    switch (song.sourceType) {
-      case 'subsonic':
-        try {
-          return await _subsonic.stream(
-            server,
-            remoteId,
-            extension: song.fileType,
-            onProgress: reportProgress
-                ? (p) => downloadProgressNotifier.value = p
-                : null,
-          );
-        } finally {
-          if (reportProgress) downloadProgressNotifier.value = null;
-        }
-      default:
-        throw StateError(
-            'Source type "${song.sourceType}" is not supported yet');
+    final service = networkSourceServiceFor(sourceType);
+    try {
+      return await service.stream(
+        server,
+        remoteId,
+        extension: song.fileType,
+        onProgress: reportProgress
+            ? (p) => downloadProgressNotifier.value = p
+            : null,
+      );
+    } finally {
+      if (reportProgress) downloadProgressNotifier.value = null;
     }
   }
 

--- a/lib/services/remote_source_service.dart
+++ b/lib/services/remote_source_service.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/foundation.dart';
+
+import '../core/utils/app_log.dart';
+import '../data/database.dart';
+import '../models/song.dart';
+import 'sources/subsonic_service.dart';
+
+/// Bridges playback/download for network-sourced songs.
+///
+/// v1 supports Subsonic only: a cache hit returns the local file path
+/// immediately (gapless/crossfade handoff reads a local file), a miss
+/// downloads the original-quality stream into [NetworkCacheService].
+class RemoteSourceService {
+  RemoteSourceService._({SubsonicService? subsonic})
+      : _subsonic = subsonic ?? SubsonicService.instance;
+
+  static RemoteSourceService instance = RemoteSourceService._();
+
+  /// Test seam: build an isolated instance with mocked dependencies.
+  @visibleForTesting
+  static RemoteSourceService create({SubsonicService? subsonic}) {
+    return RemoteSourceService._(subsonic: subsonic);
+  }
+
+  final SubsonicService _subsonic;
+
+  /// Progress (0..1) of the interactive playback download, null when idle.
+  final ValueNotifier<double?> downloadProgressNotifier = ValueNotifier(null);
+
+  Future<NetworkServerEntity> _serverFor(Song song) async {
+    final serverId = song.remoteServerId;
+    if (serverId == null) {
+      throw StateError('Network song has no remote server id');
+    }
+    final server = await Database.networkServers.get(serverId);
+    if (server == null) {
+      throw StateError('Network server $serverId not found');
+    }
+    return server;
+  }
+
+  /// Ensure a playable local copy of [song] exists and return its path.
+  /// Downloads (with progress on [downloadProgressNotifier]) when uncached.
+  Future<String> ensureLocal(Song song, {bool reportProgress = true}) async {
+    if (!song.isNetworkSource) {
+      throw StateError('Song is not a network source');
+    }
+    final server = await _serverFor(song);
+    final remoteId = song.remoteId;
+    if (remoteId == null) {
+      throw StateError('Network song has no remote id');
+    }
+    switch (song.sourceType) {
+      case 'subsonic':
+        try {
+          return await _subsonic.stream(
+            server,
+            remoteId,
+            extension: song.fileType,
+            onProgress: reportProgress
+                ? (p) => downloadProgressNotifier.value = p
+                : null,
+          );
+        } finally {
+          if (reportProgress) downloadProgressNotifier.value = null;
+        }
+      default:
+        throw StateError(
+            'Source type "${song.sourceType}" is not supported yet');
+    }
+  }
+
+  /// Background prefetch for the next queue entry. Best effort: never throws,
+  /// does not touch [downloadProgressNotifier] (interactive downloads own it).
+  Future<void> prefetch(Song song) async {
+    try {
+      await ensureLocal(song, reportProgress: false);
+    } catch (e) {
+      AppLog.instance.add('Prefetch failed for "${song.title}": $e');
+    }
+  }
+}

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -433,7 +433,12 @@ class RustAudioService {
   void _updateProgress() {
     final progress = rust_audio.audioGetProgress();
     if (progress != null) {
-      final newPositionMs = (progress.positionSecs * 1000).round();
+      final positionSecs = progress.positionSecs;
+      if (!positionSecs.isFinite || positionSecs < 0) {
+        _updateState();
+        return;
+      }
+      final newPositionMs = (positionSecs * 1000).round();
       final currentPositionMs = positionNotifier.value.inMilliseconds;
 
       // Only update if position actually changed (skip no-op updates)
@@ -447,7 +452,9 @@ class RustAudioService {
         }
       }
 
-      if (progress.durationSecs != null) {
+      if (progress.durationSecs != null &&
+          progress.durationSecs!.isFinite &&
+          progress.durationSecs! >= 0) {
         final newDurationMs = (progress.durationSecs! * 1000).round();
         final currentDurationMs = durationNotifier.value.inMilliseconds;
 

--- a/lib/services/sources/jellyfin_service.dart
+++ b/lib/services/sources/jellyfin_service.dart
@@ -1,0 +1,394 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../../core/utils/app_log.dart';
+import '../../data/entities/network_server_entity.dart';
+import '../../data/entities/song_entity.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import '../network_cache_service.dart';
+import 'network_source_service.dart';
+
+/// Jellyfin / Emby REST client (JSON).
+///
+/// Auth: `POST /Users/AuthenticateByName` exchanges a plaintext password for
+/// an access token. The stored [NetworkServerEntity.token] is a JSON blob
+/// `{"userId":..., "token":...}` because every library call is scoped to the
+/// authenticated user id. The plaintext password is never persisted.
+class JellyfinService implements NetworkSourceService {
+  JellyfinService._({http.Client? client, SongRepository? songRepository, NetworkCacheService? networkCache})
+      : _client = client ?? http.Client(),
+        _songRepository = songRepository,
+        _networkCache = networkCache;
+
+  static JellyfinService instance = JellyfinService._();
+
+  @visibleForTesting
+  static JellyfinService create({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  }) =>
+      JellyfinService._(
+        client: client,
+        songRepository: songRepository,
+        networkCache: networkCache,
+      );
+
+  static const String _clientName = 'flick';
+  static const String _device = 'flick';
+  // ponytail: fixed DeviceId. Jellyfin lists one device row per distinct id;
+  // a per-install persisted UUID only matters if the server device list gets
+  // noisy. Upgrade then.
+  static const String _deviceId = 'flick-player-0001';
+  static const String _clientVersion = '0.20.5';
+  static const String _coverMarkerScheme = 'jellyfin-cover://';
+
+  final http.Client _client;
+  SongRepository? _songRepository;
+  NetworkCacheService? _networkCache;
+
+  SongRepository get _repo => _songRepository ??= SongRepository();
+  NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+
+  @override
+  String get protocol => NetworkProtocol.jellyfin;
+
+  @override
+  String get coverScheme => _coverMarkerScheme;
+
+  String _base(NetworkServerEntity server) =>
+      server.baseUrl.replaceAll(RegExp(r'/+$'), '');
+
+  String _authHeader(String? accessToken) {
+    final base =
+        'MediaBrowser Client="$_clientName", Device="$_device", DeviceId="$_deviceId", Version="$_clientVersion"';
+    if (accessToken != null && accessToken.isNotEmpty) {
+      return '$base, Token="$accessToken"';
+    }
+    return base;
+  }
+
+  _JellyfinCredentials? _creds(String? token) {
+    if (token == null || token.isEmpty) return null;
+    try {
+      final j = jsonDecode(token) as Map<String, dynamic>;
+      final uid = j['userId'] as String?;
+      final tok = j['token'] as String?;
+      if (uid == null || tok == null) return null;
+      return _JellyfinCredentials(uid, tok);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // --- Auth + ping --------------------------------------------------------
+
+  @override
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  ) async {
+    final uri = Uri.parse('${_base(server)}/Users/AuthenticateByName');
+    final response = await _client
+        .post(
+          uri,
+          headers: {
+            'Authorization': _authHeader(null),
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({
+            'Username': server.username ?? '',
+            'Pw': password,
+          }),
+        )
+        .timeout(const Duration(seconds: 15));
+    if (response.statusCode != 200) {
+      throw JellyfinNetworkException(
+          'Authentication failed (HTTP ${response.statusCode})');
+    }
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final user = (body['User'] as Map<String, dynamic>?) ?? const {};
+    final userId = user['Id'] as String? ?? body['UserId'] as String?;
+    final accessToken = (body['AccessToken'] as String?) ??
+        ((body['SessionInfo'] as Map<String, dynamic>?)?['AccessToken']
+            as String?);
+    if (userId == null || accessToken == null) {
+      throw JellyfinNetworkException('Authentication response missing token');
+    }
+    return jsonEncode({'userId': userId, 'token': accessToken});
+  }
+
+  @override
+  Future<bool> ping(NetworkServerEntity server) async {
+    final creds = _creds(server.token);
+    if (creds == null) {
+      AppLog.instance.add('Jellyfin ping failed: no stored token');
+      return false;
+    }
+    try {
+      await _getJson(server, '/system/Info', accessToken: creds.token);
+      return true;
+    } catch (e) {
+      AppLog.instance.add('Jellyfin ping failed: $e');
+      return false;
+    }
+  }
+
+  // --- Library ------------------------------------------------------------
+
+  Future<Map<String, dynamic>> _getJson(
+    NetworkServerEntity server,
+    String path, {
+    Map<String, String>? query,
+    String? accessToken,
+    Duration timeout = const Duration(seconds: 20),
+  }) async {
+    var uri = Uri.parse('${_base(server)}$path');
+    if (query != null) uri = uri.replace(queryParameters: query);
+    final response = await _client
+        .get(uri, headers: {
+          'Authorization': _authHeader(accessToken),
+          'Accept': 'application/json',
+        })
+        .timeout(timeout);
+    if (response.statusCode != 200) {
+      throw JellyfinNetworkException('HTTP ${response.statusCode} for $path');
+    }
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  Future<List<Map<String, dynamic>>> _albums(
+    NetworkServerEntity server,
+    _JellyfinCredentials creds,
+  ) async {
+    final payload = await _getJson(
+      server,
+      '/Users/${creds.userId}/Items',
+      query: {
+        'Recursive': 'true',
+        'IncludeItemTypes': 'MusicAlbum',
+        'Fields': 'DateCreated',
+      },
+      accessToken: creds.token,
+    );
+    return ((payload['Items'] as List<dynamic>?) ?? const [])
+        .cast<Map<String, dynamic>>();
+  }
+
+  Future<List<Map<String, dynamic>>> _songsInAlbum(
+    NetworkServerEntity server,
+    _JellyfinCredentials creds,
+    String albumId,
+  ) async {
+    final payload = await _getJson(
+      server,
+      '/Users/${creds.userId}/Items',
+      query: {
+        'Recursive': 'true',
+        'ParentId': albumId,
+        'IncludeItemTypes': 'Audio',
+        'Fields': 'MediaSources,Genres',
+      },
+      accessToken: creds.token,
+    );
+    return ((payload['Items'] as List<dynamic>?) ?? const [])
+        .cast<Map<String, dynamic>>();
+  }
+
+  // --- Cover art + stream -------------------------------------------------
+
+  @override
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String marker,
+  ) async {
+    final creds = _creds(server.token);
+    var uri = Uri.parse('${_base(server)}/Items/$marker/Images/Primary');
+    uri = uri.replace(queryParameters: {
+      if (creds != null) 'api_key': creds.token,
+    });
+    final response =
+        await _client.get(uri).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) {
+      throw JellyfinNetworkException(
+          'HTTP ${response.statusCode} for cover $marker');
+    }
+    return response.bodyBytes;
+  }
+
+  @override
+  Future<String> stream(
+    NetworkServerEntity server,
+    String songId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    final cached =
+        await _cache.getPath(server.id, songId, extension: extension);
+    if (cached != null) return cached;
+
+    final creds = _creds(server.token);
+    if (creds == null) {
+      throw StateError('Jellyfin server "${server.label}" has no stored token');
+    }
+    final uri = Uri.parse('${_base(server)}/Audio/$songId/stream')
+        .replace(queryParameters: {
+      'static': 'true',
+      'api_key': creds.token,
+    });
+    final request = http.Request('GET', uri);
+    final response =
+        await _client.send(request).timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw JellyfinNetworkException(
+          'HTTP ${response.statusCode} for stream $songId');
+    }
+    final total = response.contentLength;
+    final builder = BytesBuilder();
+    var received = 0;
+    await for (final chunk in response.stream) {
+      builder.add(chunk);
+      received += chunk.length;
+      if (onProgress != null && total != null && total > 0) {
+        onProgress(received / total);
+      }
+    }
+    return _cache.stash(server.id, songId, builder.takeBytes(),
+        extension: extension);
+  }
+
+  // --- Sync ---------------------------------------------------------------
+
+  @override
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    final creds = _creds(server.token);
+    if (creds == null) {
+      throw StateError('Jellyfin server "${server.label}" has no stored token');
+    }
+
+    final albums = await _albums(server, creds);
+    final syncedRemoteIds = <String>{};
+    var songsFound = 0;
+    var filesProcessed = 0;
+
+    for (final album in albums) {
+      final albumName = (album['Name'] as String?) ?? '';
+      final albumArtist = _firstAlbumArtist(album);
+      final albumId = album['Id'] as String;
+      final year = _toInt(album['ProductionYear']);
+
+      try {
+        final rawSongs = await _songsInAlbum(server, creds, albumId);
+        final entities = rawSongs
+            .map((s) => _songEntity(
+                  server,
+                  s,
+                  albumName: albumName,
+                  albumArtist: albumArtist,
+                  albumId: albumId,
+                  year: year,
+                ))
+            .toList();
+        await _repo.upsertSongs(entities);
+        syncedRemoteIds.addAll(entities.map((e) => e.remoteId!));
+        songsFound += entities.length;
+      } catch (e) {
+        AppLog.instance.add(
+          'Jellyfin sync skipped album "$albumName" on ${server.label}: $e',
+        );
+      }
+
+      filesProcessed++;
+      yield ScanProgress(
+        songsFound: songsFound,
+        totalFiles: albums.length,
+        filesProcessed: filesProcessed,
+        phase: 'Syncing ${server.label}',
+        currentFile: albumName,
+      );
+    }
+
+    await purgeAndStampNetworkSync(server, syncedRemoteIds);
+
+    yield ScanProgress(
+      songsFound: songsFound,
+      totalFiles: albums.length,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      isComplete: true,
+    );
+  }
+
+  String _firstAlbumArtist(Map<String, dynamic> album) {
+    final artists = album['AlbumArtists'] as List<dynamic>?;
+    if (artists != null && artists.isNotEmpty) {
+      final first = artists.first as Map<String, dynamic>;
+      return (first['Name'] as String?) ?? '';
+    }
+    return (album['AlbumArtist'] as String?) ?? '';
+  }
+
+  SongEntity _songEntity(
+    NetworkServerEntity server,
+    Map<String, dynamic> s, {
+    required String albumName,
+    required String albumArtist,
+    required String albumId,
+    int? year,
+  }) {
+    final remoteId = s['Id'] as String;
+    final runTimeTicks = _toInt(s['RunTimeTicks']);
+    final mediaSources = s['MediaSources'] as List<dynamic>?;
+    final mediaSource = mediaSources != null && mediaSources.isNotEmpty
+        ? mediaSources.first as Map<String, dynamic>
+        : null;
+    final artists = (s['Artists'] as List<dynamic>?)?.cast<String?>();
+    final genres = (s['Genres'] as List<dynamic>?)?.cast<String?>();
+    final bitrateBps = _toInt(mediaSource?['Bitrate']);
+    return SongEntity()
+      ..filePath = '${NetworkProtocol.jellyfin}://${server.id}/$remoteId'
+      ..title = (s['Name'] as String?) ?? 'Unknown'
+      ..artist = (artists != null && artists.isNotEmpty)
+          ? (artists.first ?? 'Unknown')
+          : (s['AlbumArtist'] as String?) ?? 'Unknown'
+      ..album = albumName.isNotEmpty ? albumName : (s['Album'] as String?)
+      ..albumArtist = albumArtist.isNotEmpty ? albumArtist : null
+      ..durationMs = runTimeTicks != null ? runTimeTicks ~/ 10000 : null
+      ..trackNumber = _toInt(s['IndexNumber'])
+      ..discNumber = _toInt(s['ParentIndexNumber'])
+      ..year = year ?? _toInt(s['ProductionYear'])
+      ..genre = genres != null && genres.isNotEmpty ? genres.join(', ') : null
+      ..fileSize = _toInt(s['Size'])
+      ..fileType = (mediaSource?['Container'] as String?) ??
+          (s['Container'] as String?)
+      ..bitrate = bitrateBps == null ? null : bitrateBps ~/ 1000
+      ..sampleRate = _toInt(mediaSource?['SampleRate'])
+      ..albumArtPath = '$_coverMarkerScheme$albumId'
+      ..sourceType = NetworkProtocol.jellyfin
+      ..remoteId = remoteId
+      ..remoteServerId = server.id
+      ..metadataComplete = true
+      ..dateAdded = DateTime.now()
+      ..lastModified = DateTime.now();
+  }
+}
+
+int? _toInt(dynamic v) => v == null ? null : (v as num).toInt();
+
+class _JellyfinCredentials {
+  const _JellyfinCredentials(this.userId, this.token);
+  final String userId;
+  final String token;
+}
+
+class JellyfinNetworkException implements Exception {
+  final String message;
+  JellyfinNetworkException(this.message);
+  @override
+  String toString() => 'Jellyfin error: $message';
+}

--- a/lib/services/sources/network_source_service.dart
+++ b/lib/services/sources/network_source_service.dart
@@ -1,0 +1,126 @@
+import '../../data/database.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import 'jellyfin_service.dart';
+import 'smb_service.dart';
+import 'subsonic_service.dart';
+import 'upnp_service.dart';
+import 'webdav_service.dart';
+
+/// Common surface every network music source implements.
+///
+/// Each protocol plugs into the same four flows: connectivity test
+/// ([ping]), library sync ([syncLibrary]), audio download ([stream]) and
+/// cover-art fetch ([getCoverArt]). The [resolveToken] hook turns a typed
+/// password into the opaque string stored in [NetworkServerEntity.token] —
+/// a local transform for Subsonic/WebDAV, a server round-trip for Jellyfin.
+///
+/// Song rows produced during sync use a scheme-prefixed [SongEntity.filePath]
+/// (`<protocol>://<serverId>/<remoteId>`) so [AlbumArtService] and
+/// [RemoteSourceService] can dispatch by `Uri.scheme`.
+abstract class NetworkSourceService {
+  /// Protocol id stored on the entity and used as the `filePath` URI scheme.
+  String get protocol;
+
+  /// Marker scheme prefix stored in [SongEntity.albumArtPath], e.g.
+  /// `subsonic-cover://`. The bytes after this prefix are the opaque [marker]
+  /// passed back to [getCoverArt].
+  String get coverScheme;
+
+  /// Resolve the value to persist in [NetworkServerEntity.token] for a typed
+  /// [password]. Returns null when the protocol stores no secret (anonymous
+  /// UPnP). May perform a network round-trip (Jellyfin authenticateByName).
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  );
+
+  /// Validate connectivity + stored credentials. Returns false (not throws)
+  /// on expected auth/network failures so the edit screen can show a banner.
+  Future<bool> ping(NetworkServerEntity server);
+
+  /// Raw cover-art bytes for [marker] (the opaque id/path/url stored after
+  /// [coverScheme] in [SongEntity.albumArtPath]).
+  Future<List<int>> getCoverArt(NetworkServerEntity server, String marker);
+
+  /// Download (or cache-hit) the audio for [remoteId] into the network cache
+  /// and return the local file path. [onProgress] reports 0..1 during a miss.
+  Future<String> stream(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  });
+
+  /// Pull the full server library into the local DB as [SongEntity]s,
+  /// upserting new/changed rows and deleting stale ones, yielding progress.
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server);
+}
+
+/// Protocol ids supported by the app.
+class NetworkProtocol {
+  static const subsonic = 'subsonic';
+  static const jellyfin = 'jellyfin';
+  static const webdav = 'webdav';
+  static const upnp = 'upnp';
+  static const smb = 'smb';
+
+  static const all = [subsonic, jellyfin, webdav, upnp, smb];
+}
+
+final Map<String, NetworkSourceService> _registry = {};
+bool _seeded = false;
+
+void _ensureSeeded() {
+  if (_seeded) return;
+  _seeded = true;
+  for (final s in [
+    SubsonicService.instance,
+    JellyfinService.instance,
+    WebdavService.instance,
+    UpnpService.instance,
+    SmbService.instance,
+  ]) {
+    _registry[s.protocol] = s;
+  }
+}
+
+/// Look up the service for a protocol id. Throws [StateError] for unknown
+/// protocols so callers fail loudly instead of silently no-op'ing.
+NetworkSourceService networkSourceServiceFor(String protocol) {
+  _ensureSeeded();
+  final service = _registry[protocol];
+  if (service != null) return service;
+  throw StateError('Unsupported network protocol: "$protocol"');
+}
+
+/// True when a registered service exists for [protocol].
+bool isSupportedNetworkProtocol(String? protocol) {
+  if (protocol == null) return false;
+  _ensureSeeded();
+  return _registry.containsKey(protocol);
+}
+
+/// Shared sync tail: delete rows that dropped off the server, then stamp
+/// [NetworkServerEntity.lastSyncedAt]. Each protocol's `syncLibrary` does its
+/// own per-batch upsert during the walk; this closes the loop identically.
+Future<void> purgeAndStampNetworkSync(
+  NetworkServerEntity server,
+  Set<String> syncedRemoteIds,
+) async {
+  final repo = SongRepository();
+  final existing = await repo.getSongsByRemoteServer(server.id);
+  final stale = existing
+      .where((e) => e.remoteId != null && !syncedRemoteIds.contains(e.remoteId))
+      .toList();
+  if (stale.isNotEmpty) {
+    await repo.deleteSongsByIds(stale.map((e) => e.id).toList());
+  }
+  await Database.instance.writeTxn(() async {
+    final stored = await Database.networkServers.get(server.id);
+    if (stored != null) {
+      stored.lastSyncedAt = DateTime.now();
+      await Database.networkServers.put(stored);
+    }
+  });
+}

--- a/lib/services/sources/smb_service.dart
+++ b/lib/services/sources/smb_service.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+import 'dart:convert';
+
+import '../../core/utils/app_log.dart';
+import '../../data/entities/network_server_entity.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import 'network_source_service.dart';
+
+/// SMB placeholder.
+///
+/// SMB2/3 has no mature pure-Dart client, and the candidate Rust crates either
+/// link the system `libsmbclient` (unavailable on Android NDK) or are
+/// experimental and don't build cleanly on mobile. Rather than ship a fake
+/// transport, this service is wired through the registry so every flow fails
+/// loudly with a clear, honest message. Landing a real transport is then a
+/// localized change: implement [ping]/[stream]/[syncLibrary] and the UI works.
+///
+/// Recommended workaround for SMB shares: expose them over WebDAV (many NAS
+/// firmwares do this out of the box) and add a WebDAV server instead.
+class SmbService implements NetworkSourceService {
+  SmbService._();
+  static SmbService instance = SmbService._();
+
+  static const String _unavailableMessage =
+      'SMB playback is not available in this build. Use a Subsonic, Jellyfin, '
+      'WebDAV, or UPnP/DLNA server, or expose the SMB share over WebDAV.';
+
+  @override
+  String get protocol => NetworkProtocol.smb;
+
+  @override
+  String get coverScheme => 'smb-cover://';
+
+  @override
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  ) async {
+    // Store base64(password) so a future transport has the credential ready.
+    return password.isEmpty ? null : base64Encode(utf8.encode(password));
+  }
+
+  @override
+  Future<bool> ping(NetworkServerEntity server) async {
+    AppLog.instance.add('SMB ping rejected: transport unavailable');
+    throw UnsupportedError(_unavailableMessage);
+  }
+
+  @override
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String marker,
+  ) async {
+    throw UnsupportedError(_unavailableMessage);
+  }
+
+  @override
+  Future<String> stream(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    throw UnsupportedError(_unavailableMessage);
+  }
+
+  @override
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    throw UnsupportedError(_unavailableMessage);
+  }
+}

--- a/lib/services/sources/subsonic_service.dart
+++ b/lib/services/sources/subsonic_service.dart
@@ -1,0 +1,359 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../../core/utils/app_log.dart';
+import '../../data/database.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import '../network_cache_service.dart';
+
+/// Subsonic API client (JSON variant, no transcoding params).
+///
+/// Auth: Subsonic token auth, `t = md5(password + salt)`, `s = salt`.
+/// The stored server token is the `salt:md5hex` pair, so the plaintext
+/// password is never persisted or transmitted.
+class SubsonicService {
+  SubsonicService._({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  })  : _client = client ?? http.Client(),
+        _songRepository = songRepository,
+        _networkCache = networkCache;
+
+  /// Singleton used by the app.
+  static SubsonicService instance = SubsonicService._();
+
+  /// Test seam: build an isolated instance with mocked dependencies.
+  @visibleForTesting
+  static SubsonicService create({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  }) {
+    return SubsonicService._(
+      client: client,
+      songRepository: songRepository,
+      networkCache: networkCache,
+    );
+  }
+
+  static const String _clientName = 'flick';
+  static const String _apiVersion = '1.16.1';
+  static const int _pageSize = 500;
+
+  final http.Client _client;
+
+  // Lazy: only sync/stream touch these, keep HTTP-only tests DB-free.
+  // ponytail: lazy init, eager if tests start needing injection everywhere
+  SongRepository? _songRepository;
+  NetworkCacheService? _networkCache;
+
+  SongRepository get _repo => _songRepository ??= SongRepository();
+
+  NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+
+  // --- Auth ---------------------------------------------------------------
+
+  /// Build the shared auth query params. Throws if the server has no token
+  /// stored (i.e. it was never saved through the settings screen).
+  Map<String, String> _authParams(NetworkServerEntity server) {
+    final stored = server.token;
+    if (stored == null || !stored.contains(':')) {
+      throw StateError('Server "${server.label}" has no stored credentials');
+    }
+    final separator = stored.indexOf(':');
+    return {
+      'u': server.username ?? '',
+      't': stored.substring(separator + 1),
+      's': stored.substring(0, separator),
+      'v': _apiVersion,
+      'c': _clientName,
+      'f': 'json',
+    };
+  }
+
+  /// Compute the stored `salt:md5hex` token for [password].
+  /// Spec-correct order: md5(password + salt); salt must be >= 6 chars.
+  static String buildToken(String password, {String? salt}) {
+    final finalSalt = salt ?? _generateSalt();
+    final digest = md5.convert(utf8.encode('$password$finalSalt'));
+    return '$finalSalt:${digest.toString()}';
+  }
+
+  static String _generateSalt() {
+    final random = Random.secure();
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    return List.generate(10, (_) => chars[random.nextInt(chars.length)]).join();
+  }
+
+  Uri _endpoint(NetworkServerEntity server, String method,
+      [Map<String, String> extra = const {}]) {
+    final base = server.baseUrl.replaceAll(RegExp(r'/+$'), '');
+    return Uri.parse('$base/rest/$method.view').replace(
+      queryParameters: {..._authParams(server), ...extra},
+    );
+  }
+
+  Future<Map<String, dynamic>> _getJson(
+    NetworkServerEntity server,
+    String method, {
+    Map<String, String> extra = const {},
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    final uri = _endpoint(server, method, extra);
+    final response = await _client.get(uri).timeout(timeout);
+    if (response.statusCode != 200) {
+      throw SubsonicNetworkException('HTTP ${response.statusCode} for $method');
+    }
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final payload = body['subsonic-response'] as Map<String, dynamic>;
+    if (payload['status'] != 'ok') {
+      final error = payload['error'] as Map<String, dynamic>?;
+      throw SubsonicNetworkException(
+        error?['message'] as String? ?? 'Subsonic error for $method',
+        code: error?['code'] as int?,
+      );
+    }
+    return payload;
+  }
+
+  // --- API ----------------------------------------------------------------
+
+  /// Test connectivity + credentials. Returns true when the server responds
+  /// with status ok.
+  Future<bool> ping(NetworkServerEntity server) async {
+    try {
+      await _getJson(server, 'ping');
+      return true;
+    } catch (e) {
+      AppLog.instance.add('Subsonic ping failed: $e');
+      return false;
+    }
+  }
+
+  /// All albums from getAlbumList2, paginated over the whole library.
+  Future<List<Map<String, dynamic>>> getAlbumList2(
+    NetworkServerEntity server,
+  ) async {
+    final albums = <Map<String, dynamic>>[];
+    var offset = 0;
+    while (true) {
+      final payload = await _getJson(server, 'getAlbumList2', extra: {
+        'type': 'alphabeticalByName',
+        'size': '$_pageSize',
+        'offset': '$offset',
+      });
+      final list =
+          ((payload['albumList2'] as Map<String, dynamic>?)?['album']
+                  as List<dynamic>?)
+              ?.cast<Map<String, dynamic>>() ??
+          const [];
+      albums.addAll(list);
+      if (list.length < _pageSize) break;
+      offset += list.length;
+    }
+    return albums;
+  }
+
+  /// Songs inside a single album.
+  Future<List<Map<String, dynamic>>> getAlbum(
+    NetworkServerEntity server,
+    String albumId,
+  ) async {
+    final payload =
+        await _getJson(server, 'getAlbum', extra: {'id': albumId});
+    return ((payload['album'] as Map<String, dynamic>?)?['song']
+            as List<dynamic>?)
+        ?.cast<Map<String, dynamic>>() ??
+        const [];
+  }
+
+  /// Raw cover art bytes for [coverArtId] (the value of a song's `coverArt`
+  /// attribute, e.g. "al-123").
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String coverArtId,
+  ) async {
+    final uri = _endpoint(server, 'getCoverArt', {'id': coverArtId});
+    final response =
+        await _client.get(uri).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) {
+      throw SubsonicNetworkException(
+          'HTTP ${response.statusCode} for getCoverArt');
+    }
+    return response.bodyBytes;
+  }
+
+  /// Stream a song's audio at original quality: no maxBitRate/format params
+  /// so the server returns the stored file, not a transcode. Writes the bytes
+  /// into the network cache and returns the local path. When [onProgress] is
+  /// given it is called with 0..1 as bytes arrive (streamed download).
+  Future<String> stream(
+    NetworkServerEntity server,
+    String songId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    final cached = await _cache.getPath(server.id, songId,
+        extension: extension);
+    if (cached != null) return cached;
+
+    final uri = _endpoint(server, 'stream', {'id': songId});
+    final request = http.Request('GET', uri);
+    final response = await _client
+        .send(request)
+        .timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw SubsonicNetworkException(
+          'HTTP ${response.statusCode} for stream');
+    }
+    final total = response.contentLength;
+    final builder = BytesBuilder();
+    var received = 0;
+    await for (final chunk in response.stream) {
+      builder.add(chunk);
+      received += chunk.length;
+      if (onProgress != null && total != null && total > 0) {
+        onProgress(received / total);
+      }
+    }
+    return _cache.stash(server.id, songId, builder.takeBytes(),
+        extension: extension);
+  }
+
+  // --- Library sync -------------------------------------------------------
+
+  /// Pull the full server library into the local DB as SongEntitys.
+  ///
+  /// Upserts every song (composite-key match on the synthetic filePath),
+  /// deletes rows that no longer exist on the server, then stamps
+  /// [NetworkServerEntity.lastSyncedAt].
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    final albums = await getAlbumList2(server);
+    final syncedRemoteIds = <String>{};
+
+    var songsFound = 0;
+    var filesProcessed = 0;
+    for (final album in albums) {
+      final albumName = album['album'] as String? ?? '';
+      final albumArtist = album['artist'] as String? ?? '';
+      final coverArt = album['coverArt'] as String?;
+      final year = _toInt(album['year']);
+
+      try {
+        final rawSongs = await getAlbum(server, album['id'] as String);
+        final entities = rawSongs
+            .map((s) => _songEntity(server, s,
+                albumName: albumName,
+                albumArtist: albumArtist,
+                coverArt: coverArt,
+                year: year))
+            .toList();
+        await _repo.upsertSongs(entities);
+        syncedRemoteIds.addAll(entities.map((e) => e.remoteId!));
+
+        songsFound += entities.length;
+      } catch (e) {
+        // One bad album shouldn't abort the whole sync: log and move on.
+        AppLog.instance.add(
+          'Subsonic sync skipped album "$albumName" on ${server.label}: $e',
+        );
+      }
+
+      filesProcessed++;
+      yield ScanProgress(
+        songsFound: songsFound,
+        totalFiles: albums.length,
+        filesProcessed: filesProcessed,
+        phase: 'Syncing ${server.label}',
+        currentFile: albumName,
+      );
+    }
+
+    await _purgeStale(server, syncedRemoteIds);
+
+    await Database.instance.writeTxn(() async {
+      final stored = await Database.networkServers.get(server.id);
+      if (stored != null) {
+        stored.lastSyncedAt = DateTime.now();
+        await Database.networkServers.put(stored);
+      }
+    });
+
+    yield ScanProgress(
+      songsFound: songsFound,
+      totalFiles: albums.length,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      isComplete: true,
+    );
+  }
+
+  Future<void> _purgeStale(NetworkServerEntity server, Set<String> syncedIds) async {
+    final existing = await _repo.getSongsByRemoteServer(server.id);
+    final stale = existing.where((e) => !syncedIds.contains(e.remoteId)).toList();
+    if (stale.isEmpty) return;
+    await _repo.deleteSongsByIds(stale.map((e) => e.id).toList());
+  }
+
+  SongEntity _songEntity(
+    NetworkServerEntity server,
+    Map<String, dynamic> s, {
+    String? albumName,
+    String? albumArtist,
+    String? coverArt,
+    int? year,
+  }) {
+    final remoteId = s['id'] as String;
+    final songCoverArt = s['coverArt'] as String? ?? coverArt;
+    final durationSec = _toInt(s['duration']);
+    return SongEntity()
+      ..filePath = 'subsonic://${server.id}/$remoteId'
+      ..title = (s['title'] as String?) ?? 'Unknown'
+      ..artist = (s['artist'] as String?) ?? 'Unknown'
+      ..album = albumName ?? (s['album'] as String?)
+      ..albumArtist = albumArtist ?? (s['albumArtist'] as String?)
+      ..durationMs = durationSec != null ? durationSec * 1000 : null
+      ..trackNumber = _toInt(s['track'])
+      ..discNumber = _toInt(s['discNumber'])
+      ..year = year ?? _toInt(s['year'])
+      ..genre = s['genre'] as String?
+      ..fileSize = _toInt(s['size'])
+      ..fileType = s['suffix'] as String?
+      ..bitrate = _toInt(s['bitRate'])
+      ..sampleRate = _toInt(s['sampleRate'])
+      ..albumArtPath =
+          songCoverArt != null ? 'subsonic-cover://$songCoverArt' : null
+      ..sourceType = 'subsonic'
+      ..remoteId = remoteId
+      ..remoteServerId = server.id
+      ..metadataComplete = true
+      ..dateAdded = DateTime.now()
+      ..lastModified = DateTime.now();
+  }
+}
+
+/// Tolerant int cast: accepts JSON int or double, null stays null.
+/// ponytail: Subsonic spec says these are integers, but some servers emit
+/// floats; this keeps a single off-spec field from aborting the whole sync.
+int? _toInt(dynamic v) => v == null ? null : (v as num).toInt();
+
+/// Marker scheme for network cover art ids stored in [SongEntity.albumArtPath].
+const String networkCoverArtScheme = 'subsonic-cover://';
+
+class SubsonicNetworkException implements Exception {
+  final String message;
+  final int? code;
+
+  SubsonicNetworkException(this.message, {this.code});
+
+  @override
+  String toString() => 'Subsonic error $code: $message';
+}

--- a/lib/services/sources/subsonic_service.dart
+++ b/lib/services/sources/subsonic_service.dart
@@ -12,13 +12,14 @@ import '../../data/database.dart';
 import '../../data/repositories/song_repository.dart';
 import '../library_scanner_service.dart' show ScanProgress;
 import '../network_cache_service.dart';
+import 'network_source_service.dart';
 
 /// Subsonic API client (JSON variant, no transcoding params).
 ///
 /// Auth: Subsonic token auth, `t = md5(password + salt)`, `s = salt`.
 /// The stored server token is the `salt:md5hex` pair, so the plaintext
 /// password is never persisted or transmitted.
-class SubsonicService {
+class SubsonicService implements NetworkSourceService {
   SubsonicService._({
     http.Client? client,
     SongRepository? songRepository,
@@ -47,6 +48,18 @@ class SubsonicService {
   static const String _clientName = 'flick';
   static const String _apiVersion = '1.16.1';
   static const int _pageSize = 500;
+
+  @override
+  String get protocol => NetworkProtocol.subsonic;
+
+  @override
+  String get coverScheme => networkCoverArtScheme;
+
+  @override
+  Future<String?> resolveToken(NetworkServerEntity server, String password) async {
+    // Local transform: salt + md5, no round-trip. The [server] is ignored.
+    return buildToken(password);
+  }
 
   final http.Client _client;
 
@@ -128,6 +141,7 @@ class SubsonicService {
 
   /// Test connectivity + credentials. Returns true when the server responds
   /// with status ok.
+  @override
   Future<bool> ping(NetworkServerEntity server) async {
     try {
       await _getJson(server, 'ping');
@@ -177,6 +191,7 @@ class SubsonicService {
 
   /// Raw cover art bytes for [coverArtId] (the value of a song's `coverArt`
   /// attribute, e.g. "al-123").
+  @override
   Future<List<int>> getCoverArt(
     NetworkServerEntity server,
     String coverArtId,
@@ -195,6 +210,7 @@ class SubsonicService {
   /// so the server returns the stored file, not a transcode. Writes the bytes
   /// into the network cache and returns the local path. When [onProgress] is
   /// given it is called with 0..1 as bytes arrive (streamed download).
+  @override
   Future<String> stream(
     NetworkServerEntity server,
     String songId, {
@@ -235,6 +251,7 @@ class SubsonicService {
   /// Upserts every song (composite-key match on the synthetic filePath),
   /// deletes rows that no longer exist on the server, then stamps
   /// [NetworkServerEntity.lastSyncedAt].
+  @override
   Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
     final albums = await getAlbumList2(server);
     final syncedRemoteIds = <String>{};

--- a/lib/services/sources/upnp_service.dart
+++ b/lib/services/sources/upnp_service.dart
@@ -1,0 +1,511 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart';
+
+import '../../core/utils/app_log.dart';
+import '../../data/entities/network_server_entity.dart';
+import '../../data/entities/song_entity.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import '../network_cache_service.dart';
+import 'network_source_service.dart';
+
+/// UPnP / DLNA MediaServer client (ContentDirectory:1 over SOAP).
+///
+/// The user provides the device description URL (typically `rootDesc.xml`).
+/// Pure Dart: device description + SOAP Browse over HTTP, audio streamed via
+/// plain HTTP GET of the item's `<res>` url. No auth — home DLNA servers are
+/// open on the LAN by convention.
+///
+/// No token is stored; [NetworkServerEntity.token] stays null.
+class UpnpService implements NetworkSourceService {
+  UpnpService._({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  })  : _client = client ?? http.Client(),
+        _songRepository = songRepository,
+        _networkCache = networkCache;
+
+  static UpnpService instance = UpnpService._();
+
+  @visibleForTesting
+  static UpnpService create({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  }) =>
+      UpnpService._(
+        client: client,
+        songRepository: songRepository,
+        networkCache: networkCache,
+      );
+
+  static const String _coverMarkerScheme = 'upnp-cover://';
+  static const String _cdServiceType =
+      'urn:schemas-upnp-org:service:ContentDirectory:1';
+  static const String _soapAction =
+      '"urn:schemas-upnp-org:service:ContentDirectory:1#Browse"';
+
+  final http.Client _client;
+  SongRepository? _songRepository;
+  NetworkCacheService? _networkCache;
+
+  SongRepository get _repo => _songRepository ??= SongRepository();
+  NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+
+  @override
+  String get protocol => NetworkProtocol.upnp;
+
+  @override
+  String get coverScheme => _coverMarkerScheme;
+
+  @override
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  ) async {
+    // DLNA home servers are anonymous on the LAN; nothing to store.
+    return null;
+  }
+
+  // --- Device description -------------------------------------------------
+
+  /// Resolve the ContentDirectory control URL from the device description, or
+  /// null if it can't be found / the server is unreachable.
+  Future<String?> resolveControlUrl(NetworkServerEntity server) async {
+    try {
+      final response = await _client
+          .get(Uri.parse(server.baseUrl))
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode != 200) return null;
+      final doc = XmlDocument.parse(response.body);
+      // Find the ContentDirectory service element (case varies across servers).
+      XmlNode? serviceNode;
+      for (final svc in doc.findAllElements('service', namespace: '*')) {
+        final st = svc
+            .findElements('serviceType', namespace: '*')
+            .firstOrNull
+            ?.innerText;
+        if (st != null && st.contains('ContentDirectory')) {
+          serviceNode = svc;
+          break;
+        }
+      }
+      if (serviceNode == null) return null;
+      final controlUrl = serviceNode
+          .findElements('controlURL', namespace: '*')
+          .firstOrNull
+          ?.innerText
+          .trim();
+      if (controlUrl == null || controlUrl.isEmpty) return null;
+      return Uri.parse(server.baseUrl).resolveUri(Uri.parse(controlUrl)).toString();
+    } catch (e) {
+      AppLog.instance.add('UPnP description fetch failed: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<bool> ping(NetworkServerEntity server) async {
+    final controlUrl = await resolveControlUrl(server);
+    return controlUrl != null;
+  }
+
+  // --- SOAP Browse --------------------------------------------------------
+
+  Future<String> _browse(
+    String controlUrl,
+    String objectId, {
+    int timeoutSeconds = 30,
+  }) async {
+    final body = '<?xml version="1.0" encoding="utf-8"?>'
+        '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" '
+        's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
+        '<s:Body>'
+        '<u:Browse xmlns:u="$_cdServiceType">'
+        '<ObjectID>${_escape(objectId)}</ObjectID>'
+        '<BrowseFlag>BrowseDirectChildren</BrowseFlag>'
+        '<Filter>*</Filter>'
+        '<StartingIndex>0</StartingIndex>'
+        '<RequestedCount>0</RequestedCount>'
+        '<SortCriteria></SortCriteria>'
+        '</u:Browse>'
+        '</s:Body>'
+        '</s:Envelope>';
+    final request = http.Request('POST', Uri.parse(controlUrl))
+      ..headers['Content-Type'] = 'text/xml; charset="utf-8"'
+      ..headers['SOAPAction'] = _soapAction
+      ..body = body;
+    final streamed =
+        await _client.send(request).timeout(Duration(seconds: timeoutSeconds));
+    final response = await http.Response.fromStream(streamed);
+    if (response.statusCode != 200) {
+      throw UpnpNetworkException(
+          'HTTP ${response.statusCode} for Browse $objectId');
+    }
+    final doc = XmlDocument.parse(response.body);
+    // The DIDL-Lite payload sits (escaped) inside the <Result> element.
+    final didl = doc
+        .findAllElements('Result', namespace: '*')
+        .firstOrNull
+        ?.innerText;
+    if (didl == null || didl.isEmpty) return '';
+    return didl;
+  }
+
+  String _escape(String s) => s
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+
+  // --- Cover art + stream -------------------------------------------------
+
+  @override
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String marker,
+  ) async {
+    final url = Uri.decodeFull(marker);
+    final response =
+        await _client.get(Uri.parse(url)).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) {
+      throw UpnpNetworkException('HTTP ${response.statusCode} for cover');
+    }
+    return response.bodyBytes;
+  }
+
+  @override
+  Future<String> stream(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    final cached =
+        await _cache.getPath(server.id, remoteId, extension: extension);
+    if (cached != null) return cached;
+
+    final url = Uri.decodeFull(remoteId);
+    final request = http.Request('GET', Uri.parse(url));
+    final response =
+        await _client.send(request).timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw UpnpNetworkException('HTTP ${response.statusCode} for stream');
+    }
+    final total = response.contentLength;
+    final builder = BytesBuilder();
+    var received = 0;
+    await for (final chunk in response.stream) {
+      builder.add(chunk);
+      received += chunk.length;
+      if (onProgress != null && total != null && total > 0) {
+        onProgress(received / total);
+      }
+    }
+    return _cache.stash(server.id, remoteId, builder.takeBytes(),
+        extension: extension);
+  }
+
+  // --- Library walk -------------------------------------------------------
+
+  @override
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    final controlUrl = await resolveControlUrl(server);
+    if (controlUrl == null) {
+      throw StateError(
+          'UPnP server "${server.label}" has no ContentDirectory service');
+    }
+
+    final syncedRemoteIds = <String>{};
+    var songsFound = 0;
+
+    // BFS over containers. Start at root "0"; some servers use different root
+    // ids but "0" is the UPnP convention.
+    final queue = <_UpnpContainer>[_UpnpContainer(id: '0', title: 'Root')];
+    final allContainers = <_UpnpContainer>[_UpnpContainer(id: '0', title: 'Root')];
+    var filesProcessed = 0;
+
+    while (queue.isNotEmpty) {
+      final container = queue.removeAt(0);
+      final String didl;
+      try {
+        didl = await _browse(controlUrl, container.id);
+      } catch (e) {
+        AppLog.instance.add(
+          'UPnP sync skipped container "${container.title}" on ${server.label}: $e',
+        );
+        filesProcessed++;
+        yield _progress(server, songsFound, allContainers.length,
+            filesProcessed, container.title);
+        continue;
+      }
+
+      final parsed = _parseDidl(didl);
+      if (parsed.items.isNotEmpty) {
+        final entities = parsed.items
+            .map((item) => _songEntity(server: server, item: item))
+            .toList();
+        await _repo.upsertSongs(entities);
+        syncedRemoteIds.addAll(entities.map((e) => e.remoteId!));
+        songsFound += entities.length;
+      }
+      for (final sub in parsed.containers) {
+        allContainers.add(sub);
+        queue.add(sub);
+      }
+
+      filesProcessed++;
+      yield _progress(server, songsFound, allContainers.length,
+          filesProcessed, container.title);
+    }
+
+    await purgeAndStampNetworkSync(server, syncedRemoteIds);
+
+    yield ScanProgress(
+      songsFound: songsFound,
+      totalFiles: allContainers.length,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      isComplete: true,
+    );
+  }
+
+  ScanProgress _progress(
+    NetworkServerEntity server,
+    int songsFound,
+    int totalContainers,
+    int filesProcessed,
+    String currentTitle,
+  ) {
+    return ScanProgress(
+      songsFound: songsFound,
+      totalFiles: totalContainers,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      currentFile: currentTitle,
+    );
+  }
+
+  _DidlParseResult _parseDidl(String didl) {
+    final containers = <_UpnpContainer>[];
+    final items = <_DidlItem>[];
+    if (didl.isEmpty) return _DidlParseResult(containers, items);
+
+    XmlDocument doc;
+    try {
+      doc = XmlDocument.parse(didl);
+    } catch (_) {
+      return _DidlParseResult(containers, items);
+    }
+
+    for (final c in doc.findAllElements('container', namespace: '*')) {
+      final id = c.getAttribute('id');
+      if (id == null) continue;
+      final title = _text(c, 'title');
+      final klass = _text(c, 'class');
+      // Only recurse into containers that look like music navigation nodes;
+      // this bounds the walk on servers with non-music subtrees.
+      if (klass.isEmpty || !klass.contains('object.container')) continue;
+      containers.add(_UpnpContainer(id: id, title: title.isEmpty ? id : title));
+    }
+
+    for (final it in doc.findAllElements('item', namespace: '*')) {
+      final klass = _text(it, 'class');
+      if (!klass.startsWith('object.item.audioItem')) continue;
+      final resElement = it.findElements('res', namespace: '*').firstOrNull;
+      if (resElement == null) continue;
+      final resUrl = resElement.innerText.trim();
+      if (resUrl.isEmpty) continue;
+      final protocolInfo = resElement.getAttribute('protocolInfo') ?? '';
+      final ext = _audioExtensionFromProtocolInfo(protocolInfo) ??
+          _audioExtensionFromUrl(resUrl);
+      items.add(_DidlItem(
+        title: _text(it, 'title').isEmpty
+            ? 'Unknown'
+            : _text(it, 'title'),
+        artist: _text(it, 'artist'),
+        album: _text(it, 'album'),
+        albumArtist: _text(it, 'albumArtist'),
+        trackNumber: int.tryParse(_text(it, 'originalTrackNumber')),
+        genre: _text(it, 'genre'),
+        year: _yearFrom(_text(it, 'date')),
+        durationMs: _parseDurationMs(resElement.getAttribute('duration')),
+        size: int.tryParse(resElement.getAttribute('size') ?? ''),
+        fileType: ext,
+        resUrl: resUrl,
+        coverUrl: _text(it, 'albumArtURI').isEmpty
+            ? null
+            : _text(it, 'albumArtURI'),
+        protocolInfo: protocolInfo,
+      ));
+    }
+
+    return _DidlParseResult(containers, items);
+  }
+
+  // --- Test surface (pure DIDL-Lite parse, no network) --------------------
+
+  @visibleForTesting
+  static List<({String title, String artist, String album, int? trackNumber, int? durationMs, String? fileType, String resUrl, String? coverUrl, int? year})> parseDidlItemsForTest(String didl) {
+    final svc = UpnpService._();
+    return svc
+        ._parseDidl(didl)
+        .items
+        .map((i) => (
+              title: i.title,
+              artist: i.artist,
+              album: i.album,
+              trackNumber: i.trackNumber,
+              durationMs: i.durationMs,
+              fileType: i.fileType,
+              resUrl: i.resUrl,
+              coverUrl: i.coverUrl,
+              year: i.year,
+            ))
+        .toList();
+  }
+
+  String _text(XmlElement parent, String localName) {
+    return parent
+            .findElements(localName, namespace: '*')
+            .firstOrNull
+            ?.innerText
+            .trim() ??
+        '';
+  }
+
+  int? _yearFrom(String date) {
+    if (date.length >= 4) {
+      final year = int.tryParse(date.substring(0, 4));
+      if (year != null && year > 1000 && year < 3000) return year;
+    }
+    return null;
+  }
+
+  // Duration "H:MM:SS.fraction" → milliseconds.
+  int? _parseDurationMs(String? duration) {
+    if (duration == null || duration.isEmpty) return null;
+    final parts = duration.split(':');
+    if (parts.length != 3) return null;
+    final h = double.tryParse(parts[0]) ?? 0;
+    final m = double.tryParse(parts[1]) ?? 0;
+    final s = double.tryParse(parts[2]) ?? 0;
+    return ((h * 3600 + m * 60 + s) * 1000).round();
+  }
+
+  String? _audioExtensionFromProtocolInfo(String protocolInfo) {
+    // Format: http-get:*:<mime>:*
+    final fields = protocolInfo.split(':');
+    if (fields.length < 3) return null;
+    final mime = fields[2].toLowerCase();
+    const byMime = {
+      'audio/mpeg': 'mp3',
+      'audio/mp3': 'mp3',
+      'audio/flac': 'flac',
+      'audio/x-flac': 'flac',
+      'audio/wav': 'wav',
+      'audio/x-wav': 'wav',
+      'audio/ogg': 'ogg',
+      'audio/mp4': 'm4a',
+      'audio/m4a': 'm4a',
+      'audio/x-m4a': 'm4a',
+      'audio/aac': 'aac',
+      'audio/aiff': 'aiff',
+      'audio/x-aiff': 'aiff',
+      'audio/webm': 'weba',
+      'audio/dsd': 'dsf',
+    };
+    return byMime[mime];
+  }
+
+  String? _audioExtensionFromUrl(String url) {
+    final uri = Uri.parse(url);
+    final path = uri.path;
+    final dot = path.lastIndexOf('.');
+    if (dot <= 0) return null;
+    return path.substring(dot + 1).toLowerCase();
+  }
+
+  SongEntity _songEntity({
+    required NetworkServerEntity server,
+    required _DidlItem item,
+  }) {
+    final remoteId = Uri.encodeComponent(item.resUrl);
+    return SongEntity()
+      ..filePath = '${NetworkProtocol.upnp}://${server.id}/$remoteId'
+      ..title = item.title
+      ..artist = item.artist.isEmpty ? 'Unknown' : item.artist
+      ..album = item.album.isEmpty ? null : item.album
+      ..albumArtist =
+          item.albumArtist.isEmpty ? null : item.albumArtist
+      ..durationMs = item.durationMs
+      ..trackNumber = item.trackNumber
+      ..year = item.year
+      ..genre = item.genre.isEmpty ? null : item.genre
+      ..fileSize = item.size
+      ..fileType = item.fileType
+      ..albumArtPath = item.coverUrl != null
+          ? '$_coverMarkerScheme${Uri.encodeComponent(item.coverUrl!)}'
+          : null
+      ..sourceType = NetworkProtocol.upnp
+      ..remoteId = remoteId
+      ..remoteServerId = server.id
+      ..metadataComplete = true
+      ..dateAdded = DateTime.now()
+      ..lastModified = DateTime.now();
+  }
+}
+
+class _UpnpContainer {
+  const _UpnpContainer({required this.id, required this.title});
+  final String id;
+  final String title;
+}
+
+class _DidlItem {
+  const _DidlItem({
+    required this.title,
+    required this.artist,
+    required this.album,
+    required this.albumArtist,
+    required this.trackNumber,
+    required this.genre,
+    required this.year,
+    required this.durationMs,
+    required this.size,
+    required this.fileType,
+    required this.resUrl,
+    required this.coverUrl,
+    required this.protocolInfo,
+  });
+  final String title;
+  final String artist;
+  final String album;
+  final String albumArtist;
+  final int? trackNumber;
+  final String genre;
+  final int? year;
+  final int? durationMs;
+  final int? size;
+  final String? fileType;
+  final String resUrl;
+  final String? coverUrl;
+  final String protocolInfo;
+}
+
+class _DidlParseResult {
+  const _DidlParseResult(this.containers, this.items);
+  final List<_UpnpContainer> containers;
+  final List<_DidlItem> items;
+}
+
+class UpnpNetworkException implements Exception {
+  final String message;
+  UpnpNetworkException(this.message);
+  @override
+  String toString() => 'UPnP error: $message';
+}

--- a/lib/services/sources/webdav_service.dart
+++ b/lib/services/sources/webdav_service.dart
@@ -1,0 +1,472 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart';
+
+import '../../core/utils/app_log.dart';
+import '../../data/entities/network_server_entity.dart';
+import '../../data/entities/song_entity.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import '../network_cache_service.dart';
+import 'network_source_service.dart';
+
+/// WebDAV client. Recursive PROPFIND walk of the share, HTTP Basic auth.
+///
+/// Auth: HTTP Basic needs the recoverable password, so [NetworkServerEntity.token]
+/// stores `base64(password)` (not a hash). The tradeoff is accepted: the secret
+/// is at-rest reversible, but never in plaintext and only in the local DB.
+///
+/// Metadata limitation: WebDAV exposes only filename + size + mtime. Title is
+/// derived from the filename, album from the parent folder, artist from the
+/// grandparent (or Unknown). Full tag extraction would require downloading each
+/// file, out of scope for the first cut.
+class WebdavService implements NetworkSourceService {
+  WebdavService._({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  })  : _client = client ?? http.Client(),
+        _songRepository = songRepository,
+        _networkCache = networkCache;
+
+  static WebdavService instance = WebdavService._();
+
+  @visibleForTesting
+  static WebdavService create({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+  }) =>
+      WebdavService._(
+        client: client,
+        songRepository: songRepository,
+        networkCache: networkCache,
+      );
+
+  static const String _coverMarkerScheme = 'webdav-cover://';
+
+  static const _audioExtensions = {
+    'flac', 'mp3', 'm4a', 'wav', 'ogg', 'opus', 'aac', 'wv', 'ape', 'mpc',
+    'aiff', 'dsf', 'dff',
+  };
+  static const _imageExtensions = {'jpg', 'jpeg', 'png', 'webp', 'gif', 'bmp'};
+  // Cover filenames scanned per folder, in priority order.
+  static const _coverNames = [
+    'cover', 'folder', 'album', 'albumart', 'front',
+  ];
+
+  final http.Client _client;
+  SongRepository? _songRepository;
+  NetworkCacheService? _networkCache;
+
+  SongRepository get _repo => _songRepository ??= SongRepository();
+  NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+
+  @override
+  String get protocol => NetworkProtocol.webdav;
+
+  @override
+  String get coverScheme => _coverMarkerScheme;
+
+  // --- Auth ---------------------------------------------------------------
+
+  @override
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  ) async {
+    // Local transform: HTTP Basic needs the recoverable password.
+    return base64Encode(utf8.encode(password));
+  }
+
+  String _basicAuth(NetworkServerEntity server) {
+    final user = server.username ?? '';
+    final password = _password(server);
+    final credentials = base64Encode(utf8.encode('$user:$password'));
+    return 'Basic $credentials';
+  }
+
+  String _password(NetworkServerEntity server) {
+    if (server.token == null || server.token!.isEmpty) return '';
+    try {
+      return utf8.decode(base64Decode(server.token!));
+    } catch (_) {
+      return '';
+    }
+  }
+
+  String _origin(NetworkServerEntity server) =>
+      Uri.parse(server.baseUrl).origin;
+
+  // --- PROPFIND -----------------------------------------------------------
+
+  static const _propfindBody = '<?xml version="1.0" encoding="utf-8"?>'
+      '<D:propfind xmlns:D="DAV:"><D:prop>'
+      '<D:resourcetype/><D:getcontentlength/><D:getlastmodified/>'
+      '<D:displayname/>'
+      '</D:prop></D:propfind>';
+
+  Future<http.Response> _propfind(
+    NetworkServerEntity server,
+    String url, {
+    int depth = 1,
+  }) async {
+    final request = http.Request('PROPFIND', Uri.parse(url))
+      ..headers['Depth'] = '$depth'
+      ..headers['Content-Type'] = 'application/xml; charset=utf-8'
+      ..headers['Authorization'] = _basicAuth(server)
+      ..body = _propfindBody;
+    final streamed = await _client.send(request).timeout(
+          const Duration(seconds: 30),
+        );
+    return http.Response.fromStream(streamed);
+  }
+
+  List<_DavEntry> _parseMultistatus(String body, String requestedHref) {
+    final results = <_DavEntry>[];
+    XmlDocument doc;
+    try {
+      doc = XmlDocument.parse(body);
+    } catch (_) {
+      return results;
+    }
+    for (final response
+        in doc.findAllElements('response', namespace: '*')) {
+      final href = response
+          .findElements('href', namespace: '*')
+          .firstOrNull
+          ?.innerText
+          .trim();
+      if (href == null) continue;
+      final decoded = Uri.decodeComponent(href);
+      // Skip the self entry (the requested collection itself).
+      if (_samePath(decoded, requestedHref)) continue;
+
+      final isCollection = response
+              .findAllElements('collection', namespace: '*')
+              .isNotEmpty;
+      // ponytail: getcontentlength nests under propstat/prop; recursive find
+      // keeps this robust to both flattened and nested multistatus bodies.
+      final sizeText = response
+          .findAllElements('getcontentlength', namespace: '*')
+          .firstOrNull
+          ?.innerText;
+      results.add(_DavEntry(
+        href: decoded,
+        isCollection: isCollection,
+        size: sizeText == null ? null : int.tryParse(sizeText),
+      ));
+    }
+    return results;
+  }
+
+  bool _samePath(String a, String b) {
+    String norm(String s) => s.endsWith('/') && s.length > 1
+        ? s.substring(0, s.length - 1)
+        : s;
+    return norm(a) == norm(b);
+  }
+
+  // --- Test surface (pure parse helpers, no network) ----------------------
+
+  @visibleForTesting
+  static List<({String href, bool isCollection, int? size})> parseMultistatusForTest(
+    String body,
+    String requestedHref,
+  ) {
+    final svc = WebdavService._();
+    return svc
+        ._parseMultistatus(body, requestedHref)
+        .map((e) => (
+              href: e.href,
+              isCollection: e.isCollection,
+              size: e.size,
+            ))
+        .toList();
+  }
+
+  @visibleForTesting
+  static bool isAudioPath(String href) => WebdavService._()._isAudio(href);
+
+  @visibleForTesting
+  static bool isCoverPath(String href) => WebdavService._()._isCoverName(href);
+
+  // --- ping ---------------------------------------------------------------
+
+  @override
+  Future<bool> ping(NetworkServerEntity server) async {
+    try {
+      final response = await _propfind(server, server.baseUrl, depth: 0);
+      return response.statusCode == 207 || response.statusCode == 200;
+    } catch (e) {
+      AppLog.instance.add('WebDAV ping failed: $e');
+      return false;
+    }
+  }
+
+  // --- Cover art + stream -------------------------------------------------
+
+  @override
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String marker,
+  ) async {
+    final href = utf8.decode(base64Decode(marker));
+    final uri = Uri.parse('${_origin(server)}$href');
+    final response = await _client.get(
+      uri,
+      headers: {'Authorization': _basicAuth(server)},
+    ).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) {
+      throw WebdavNetworkException('HTTP ${response.statusCode} for cover');
+    }
+    return response.bodyBytes;
+  }
+
+  @override
+  Future<String> stream(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    final cached =
+        await _cache.getPath(server.id, remoteId, extension: extension);
+    if (cached != null) return cached;
+
+    // remoteId is stored url-encoded so the cache key is filesystem-safe;
+    // decode to build the request URL.
+    final href = remoteId.contains('%') ? Uri.decodeComponent(remoteId) : remoteId;
+    final uri = Uri.parse('${_origin(server)}$href');
+    final request = http.Request('GET', uri)
+      ..headers['Authorization'] = _basicAuth(server);
+    final response =
+        await _client.send(request).timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw WebdavNetworkException('HTTP ${response.statusCode} for stream');
+    }
+    final total = response.contentLength;
+    final builder = BytesBuilder();
+    var received = 0;
+    await for (final chunk in response.stream) {
+      builder.add(chunk);
+      received += chunk.length;
+      if (onProgress != null && total != null && total > 0) {
+        onProgress(received / total);
+      }
+    }
+    return _cache.stash(server.id, remoteId, builder.takeBytes(),
+        extension: extension);
+  }
+
+  // --- Library walk -------------------------------------------------------
+
+  @override
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    final syncedRemoteIds = <String>{};
+    var songsFound = 0;
+
+    // Queue holds (absolutePath, depth). absolutePath is the server-relative
+    // path used both to build child URLs and to derive album/artist names.
+    final queue = <_DavDir>[];
+    final allDirs = <String>[];
+    final origin = _origin(server);
+
+    String rootPath;
+    try {
+      rootPath = Uri.parse(server.baseUrl).path;
+    } catch (_) {
+      rootPath = '';
+    }
+    queue.add(_DavDir(url: server.baseUrl, path: rootPath));
+    allDirs.add(rootPath);
+
+    var filesProcessed = 0;
+    while (queue.isNotEmpty) {
+      final dir = queue.removeAt(0);
+      List<_DavEntry> entries;
+      try {
+        final response = await _propfind(server, dir.url);
+        if (response.statusCode != 207 && response.statusCode != 200) {
+          filesProcessed++;
+          yield _progress(server, songsFound, allDirs.length, filesProcessed,
+              dir.path);
+          continue;
+        }
+        entries = _parseMultistatus(response.body, dir.path);
+      } catch (e) {
+        AppLog.instance
+            .add('WebDAV sync skipped "${dir.path}" on ${server.label}: $e');
+        filesProcessed++;
+        yield _progress(
+            server, songsFound, allDirs.length, filesProcessed, dir.path);
+        continue;
+      }
+
+      String? coverHref;
+      final songEntries = <_DavEntry>[];
+      for (final e in entries) {
+        if (e.isCollection) {
+          allDirs.add(e.href);
+          queue.add(_DavDir(url: '$origin${e.href}', path: e.href));
+        } else if (_isCoverName(e.href)) {
+          coverHref ??= e.href;
+        } else if (_isAudio(e.href)) {
+          songEntries.add(e);
+        }
+      }
+
+      if (songEntries.isNotEmpty) {
+        final albumName = _lastPathSegment(dir.path);
+        final artist = _grandparentSegment(dir.path);
+        final entities = songEntries.map((e) {
+          final remoteId = Uri.encodeComponent(e.href);
+          return _songEntity(
+            server: server,
+            href: e.href,
+            remoteId: remoteId,
+            size: e.size,
+            album: albumName,
+            artist: artist,
+            coverHref: coverHref,
+          );
+        }).toList();
+        await _repo.upsertSongs(entities);
+        syncedRemoteIds.addAll(entities.map((e) => e.remoteId!));
+        songsFound += entities.length;
+      }
+
+      filesProcessed++;
+      yield _progress(
+          server, songsFound, allDirs.length, filesProcessed, dir.path);
+    }
+
+    await purgeAndStampNetworkSync(server, syncedRemoteIds);
+
+    yield ScanProgress(
+      songsFound: songsFound,
+      totalFiles: allDirs.length,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      isComplete: true,
+    );
+  }
+
+  ScanProgress _progress(
+    NetworkServerEntity server,
+    int songsFound,
+    int totalDirs,
+    int filesProcessed,
+    String currentPath,
+  ) {
+    return ScanProgress(
+      songsFound: songsFound,
+      totalFiles: totalDirs,
+      filesProcessed: filesProcessed,
+      phase: 'Syncing ${server.label}',
+      currentFile: _lastPathSegment(currentPath),
+    );
+  }
+
+  SongEntity _songEntity({
+    required NetworkServerEntity server,
+    required String href,
+    required String remoteId,
+    required int? size,
+    required String album,
+    required String artist,
+    required String? coverHref,
+  }) {
+    final fileName = _lastPathSegment(href);
+    final dot = fileName.lastIndexOf('.');
+    final baseName = dot > 0 ? fileName.substring(0, dot) : fileName;
+    final ext = dot > 0 ? fileName.substring(dot + 1).toLowerCase() : null;
+    return SongEntity()
+      ..filePath = '${NetworkProtocol.webdav}://${server.id}/$remoteId'
+      ..title = baseName.replaceAll(RegExp(r'^\d+[.\-\s]+'), '')
+      ..artist = artist
+      ..album = album.isEmpty ? null : album
+      ..fileSize = size
+      ..fileType = ext
+      ..albumArtPath = coverHref != null
+          ? '$_coverMarkerScheme${base64Encode(utf8.encode(coverHref))}'
+          : null
+      ..sourceType = NetworkProtocol.webdav
+      ..remoteId = remoteId
+      ..remoteServerId = server.id
+      ..metadataComplete = true
+      ..dateAdded = DateTime.now()
+      ..lastModified = DateTime.now();
+  }
+
+  bool _isAudio(String href) {
+    final ext = _extension(href);
+    return ext != null && _audioExtensions.contains(ext);
+  }
+
+  bool _isCoverName(String href) {
+    final ext = _extension(href);
+    if (ext == null || !_imageExtensions.contains(ext)) return false;
+    final name = _lastPathSegment(href);
+    final dot = name.lastIndexOf('.');
+    final stem = dot > 0 ? name.substring(0, dot).toLowerCase() : name.toLowerCase();
+    return _coverNames.any((c) => stem == c || stem.startsWith('$c.'));
+  }
+
+  String? _extension(String href) {
+    final name = _lastPathSegment(href);
+    final dot = name.lastIndexOf('.');
+    if (dot <= 0) return null;
+    return name.substring(dot + 1).toLowerCase();
+  }
+
+  String _lastPathSegment(String path) {
+    var p = path;
+    while (p.endsWith('/') && p.length > 1) {
+      p = p.substring(0, p.length - 1);
+    }
+    final slash = p.lastIndexOf('/');
+    return slash >= 0 ? Uri.decodeComponent(p.substring(slash + 1)) : Uri.decodeComponent(p);
+  }
+
+  String _grandparentSegment(String path) {
+    var p = path;
+    while (p.endsWith('/') && p.length > 1) {
+      p = p.substring(0, p.length - 1);
+    }
+    // Drop the last segment (album folder) and read the new last (artist).
+    final slash = p.lastIndexOf('/');
+    if (slash <= 0) return 'Unknown';
+    final parent = p.substring(0, slash);
+    final artist = _lastPathSegment(parent);
+    return artist.isEmpty ? 'Unknown' : artist;
+  }
+}
+
+class _DavEntry {
+  const _DavEntry({
+    required this.href,
+    required this.isCollection,
+    this.size,
+  });
+  final String href;
+  final bool isCollection;
+  final int? size;
+}
+
+class _DavDir {
+  const _DavDir({required this.url, required this.path});
+  final String url;
+  final String path;
+}
+
+class WebdavNetworkException implements Exception {
+  final String message;
+  WebdavNetworkException(this.message);
+  @override
+  String toString() => 'WebDAV error: $message';
+}

--- a/lib/widgets/uac2/uac2_volume_control.dart
+++ b/lib/widgets/uac2/uac2_volume_control.dart
@@ -17,7 +17,14 @@ String _volumeToDb(double volume) {
 }
 
 class Uac2VolumeControl extends ConsumerStatefulWidget {
-  const Uac2VolumeControl({super.key});
+  final bool useGradientBackground;
+  final List<Color>? gradientColors;
+
+  const Uac2VolumeControl({
+    super.key,
+    this.useGradientBackground = false,
+    this.gradientColors,
+  });
 
   @override
   ConsumerState<Uac2VolumeControl> createState() => _Uac2VolumeControlState();
@@ -115,12 +122,42 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
     final showDb = isSoftwareVolume ||
         deviceStatus.volumeMode == Uac2VolumeMode.hardware;
 
+    final useGradient = widget.useGradientBackground;
+    final gradientColors = widget.gradientColors ??
+        const [
+          Color(0xFF194B68),
+          Color(0xFF0C1624),
+          Color(0xFF1D2A19),
+        ];
+    final labelColor =
+        useGradient ? Colors.white : context.adaptiveTextPrimary;
+    final subLabelColor = useGradient
+        ? Colors.white.withValues(alpha: 0.7)
+        : context.adaptiveTextSecondary;
+    final tertiaryColor = useGradient
+        ? Colors.white.withValues(alpha: 0.5)
+        : context.adaptiveTextTertiary;
+
     return Container(
       padding: const EdgeInsets.all(AppConstants.spacingMd),
       decoration: BoxDecoration(
-        color: AppColors.surface.withValues(alpha: 0.6),
+        gradient: useGradient
+            ? LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: gradientColors,
+                stops: const [0.0, 0.56, 1.0],
+              )
+            : null,
+        color: useGradient
+            ? null
+            : AppColors.surface.withValues(alpha: 0.6),
         borderRadius: BorderRadius.circular(AppConstants.radiusLg),
-        border: Border.all(color: AppColors.glassBorder),
+        border: Border.all(
+          color: useGradient
+              ? Colors.white.withValues(alpha: 0.08)
+              : AppColors.glassBorder,
+        ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -129,7 +166,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
             children: [
               Icon(
                 LucideIcons.volume2,
-                color: context.adaptiveTextSecondary,
+                color: subLabelColor,
                 size: 20,
               ),
               const SizedBox(width: AppConstants.spacingSm),
@@ -143,7 +180,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                           : 'Device DAC Volume',
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                        color: context.adaptiveTextPrimary,
+                        color: labelColor,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
@@ -152,7 +189,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                         deviceStatus.routeLabel!,
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: context.adaptiveTextTertiary,
+                          color: tertiaryColor,
                         ),
                       ),
                   ],
@@ -166,7 +203,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                 onPressed: volumeControlWritable ? _toggleMute : null,
                 color: effectiveMuted
                     ? Colors.red.shade400
-                    : context.adaptiveTextSecondary,
+                    : subLabelColor,
                 tooltip: effectiveMuted ? 'Unmute' : 'Mute',
               ),
             ],
@@ -176,7 +213,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
             children: [
               Icon(
                 LucideIcons.volume1,
-                color: context.adaptiveTextTertiary,
+                color: tertiaryColor,
                 size: 16,
               ),
               Expanded(
@@ -193,12 +230,14 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                       ? _onSliderChangeEnd
                       : null,
                   activeColor: AppColors.accent,
-                  inactiveColor: AppColors.textTertiary.withValues(alpha: 0.3),
+                  inactiveColor: useGradient
+                      ? Colors.white.withValues(alpha: 0.22)
+                      : AppColors.textTertiary.withValues(alpha: 0.3),
                 ),
               ),
               Icon(
                 LucideIcons.volume2,
-                color: context.adaptiveTextTertiary,
+                color: tertiaryColor,
                 size: 16,
               ),
               const SizedBox(width: AppConstants.spacingSm),
@@ -209,7 +248,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                       ? '${(effectiveVolume * 100).round()}%  ${_volumeToDb(effectiveVolume)} dB'
                       : '${(effectiveVolume * 100).round()}%',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: context.adaptiveTextSecondary,
+                    color: subLabelColor,
                     fontWeight: FontWeight.w500,
                   ),
                   textAlign: TextAlign.right,
@@ -222,7 +261,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
             Text(
               'Hardware volume is detected, but writes stay blocked while live direct USB playback is active.',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: context.adaptiveTextTertiary,
+                color: tertiaryColor,
               ),
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -912,7 +912,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -1652,7 +1652,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   share_plus: ^10.1.4
   skeletonizer: ^2.1.2
   url_launcher: ^6.3.2
+  xml: ^6.5.0
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   just_audio: ^0.10.5
   lucide_icons_flutter: ^3.1.8
   native_toolchain_rust: ^1.0.3
+  path: ^1.9.1
   path_provider: ^2.1.1
   permission_handler: ^12.0.1
   rive: ^0.14.0

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -281,10 +281,15 @@ fn resolve_track_playback_output_sample_rate(
     #[cfg(target_os = "android")]
     {
         let route_type = ENGINE_MANAGER.capability_route_type();
+        #[cfg(feature = "uac2")]
+        let usb_direct_active = crate::uac2::android_direct_usb_enabled();
+        #[cfg(not(feature = "uac2"))]
+        let usb_direct_active = false;
         let should_preserve_existing_rate = !ENGINE_MANAGER.is_high_res_mode_enabled()
             && !ENGINE_MANAGER.get_dap_bit_perfect_enabled()
             && matches!(route_type.as_str(), "unknown" | "internal" | "wired")
-            && current_device_profile().is_some_and(|profile| profile.is_dap());
+            && current_device_profile().is_some_and(|profile| profile.is_dap())
+            && !usb_direct_active;
         if should_preserve_existing_rate {
             if let Some(existing_rate) = read_audio_engine(|handle| handle.sample_rate()) {
                 return Ok(Some(existing_rate));

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -1227,7 +1227,7 @@ pub fn create_audio_engine(
             48_000
         }
     } else {
-        preferred_sample_rate.unwrap_or(48_000)
+        preferred_sample_rate.filter(|&rate| rate > 0).unwrap_or(48_000)
     };
 
     #[cfg(feature = "uac2")]
@@ -1562,8 +1562,11 @@ pub fn create_audio_engine(
                 let debug_state = android_direct_debug_state();
                 let actual_sample_rate = debug_state
                     .clock_reported_sample_rate
+                    .filter(|&rate| rate > 0)
                     .or(debug_state.playback_format_sample_rate)
+                    .filter(|&rate| rate > 0)
                     .or(debug_state.requested_playback_sample_rate)
+                    .filter(|&rate| rate > 0)
                     .unwrap_or(requested_sample_rate);
                 let verification = OutputVerification::verify(
                     requested_sample_rate,

--- a/rust/src/audio/source.rs
+++ b/rust/src/audio/source.rs
@@ -147,7 +147,11 @@ impl AudioSource {
         // Position is in samples (interleaved) at the output sample rate, so divide by channels
         let samples = self.position_samples();
         let frames = samples / self.info.channels as u64;
-        frames as f64 / self.info.output_sample_rate as f64
+        let rate = self.info.output_sample_rate;
+        if rate == 0 {
+            return 0.0;
+        }
+        frames as f64 / rate as f64
     }
 
     /// Set the current playback position in seconds.

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -1188,7 +1188,7 @@ pub fn set_android_direct_usb_enabled(enabled: bool) {
     ANDROID_DIRECT_USB_ENABLED.store(enabled, Ordering::Release);
 }
 
-fn android_direct_usb_enabled() -> bool {
+pub fn android_direct_usb_enabled() -> bool {
     ANDROID_DIRECT_USB_ENABLED.load(Ordering::Acquire)
 }
 
@@ -1497,8 +1497,33 @@ pub fn android_direct_output_signature(preferred_sample_rate: Option<u32>) -> Op
     let state = guard.as_ref()?;
     let playback_format = state.playback_format?;
 
+    // For devices with SkipClockValidation quirk, the stored playback_format
+    // rate may be stale (e.g. hardcoded 48000 from initial DAC registration)
+    // and not match the track's preferred rate. Don't reject the USB direct
+    // signature over this — the engine will re-negotiate the clock during
+    // stream setup. If we return None here, the engine falls back to the
+    // android-shared path and audio goes to the wrong output.
     if preferred_sample_rate != Some(playback_format.sample_rate) {
-        return None;
+        let skip_clock_validation = crate::uac2::quirk::QUIRK_DATABASE.has_quirk(
+            state.device.vendor_id,
+            state.device.product_id,
+            &state.device.product_name,
+            crate::uac2::quirk::UsbAudioQuirk::SkipClockValidation,
+        );
+        if !skip_clock_validation {
+            return None;
+        }
+        // Use the preferred rate in the signature so the engine gets recreated
+        // at the correct rate, and update the stored format to match.
+        let effective_rate = preferred_sample_rate.unwrap_or(playback_format.sample_rate);
+        return Some(format!(
+            "android-uac2:{}:{}:{}:{}:{}",
+            state.device.fd,
+            effective_rate,
+            playback_format.bit_depth,
+            playback_format.channels,
+            state.device.device_name.as_deref().unwrap_or("usb"),
+        ));
     }
 
     Some(format!(
@@ -1523,6 +1548,36 @@ pub fn validate_android_direct_request(preferred_sample_rate: Option<u32>) -> Re
     let Some(playback_format) = state.playback_format else {
         return Ok(());
     };
+
+    if playback_format.sample_rate == 0 {
+        // The DAC reported 0 Hz via GET_CUR (broken clock readback, e.g.
+        // Fosi DS2 / Savitech bridge). The format is prepared at the
+        // requested rate — we just can't trust the stored readback.
+        // Allow validation to pass; downstream guards handle the real rate.
+        dev_eprintln!(
+            "[USB] validate_android_direct_request: playback_format.sample_rate is 0 (broken DAC readback), allowing validation to pass for preferred {:?} Hz",
+            preferred_sample_rate
+        );
+        return Ok(());
+    }
+
+    // For devices with SkipClockValidation quirk, the stored playback_format
+    // rate may be stale (e.g. hardcoded 48000 from initial DAC registration)
+    // and not match the track's actual rate. The USB direct engine will
+    // re-negotiate the clock during stream setup, so allow any positive rate.
+    let skip_clock_validation = crate::uac2::quirk::QUIRK_DATABASE.has_quirk(
+        state.device.vendor_id,
+        state.device.product_id,
+        &state.device.product_name,
+        crate::uac2::quirk::UsbAudioQuirk::SkipClockValidation,
+    );
+    if skip_clock_validation {
+        dev_eprintln!(
+            "[USB] validate_android_direct_request: SkipClockValidation quirk active, accepting stored {} Hz for preferred {:?} Hz",
+            playback_format.sample_rate, preferred_sample_rate
+        );
+        return Ok(());
+    }
 
     if preferred_sample_rate == Some(playback_format.sample_rate) {
         return Ok(());
@@ -1752,8 +1807,19 @@ pub fn negotiate_android_direct_output_sample_rate(
         requested_format
     };
 
-    negotiate_android_direct_playback_format(requested_format)
-        .map(|format| Some(format.sample_rate))
+    let negotiated = negotiate_android_direct_playback_format(requested_format);
+    negotiated.map(|format| {
+        // set_effective_playback_format may have corrected a 0 Hz rate to
+        // a valid value. Read back the actual stored rate so callers get
+        // the real effective rate, not the pre-correction value.
+        let actual_rate = DIRECT_USB_STATE
+            .lock()
+            .as_ref()
+            .and_then(|state| state.playback_format.map(|f| f.sample_rate))
+            .filter(|&rate| rate > 0)
+            .unwrap_or(format.sample_rate);
+        Some(actual_rate)
+    })
 }
 
 fn negotiate_android_direct_playback_format(
@@ -2363,7 +2429,25 @@ fn direct_path_is_bit_perfect(state: &AndroidDirectUsbState) -> bool {
         && payload_ok
 }
 
-fn set_effective_playback_format(playback_format: AndroidDirectUsbPlaybackFormat) {
+fn set_effective_playback_format(mut playback_format: AndroidDirectUsbPlaybackFormat) {
+    // Never store 0 Hz — buggy DACs (Fosi DS2 / Savitech) report 0 via
+    // GET_CUR even after a successful SET_CUR. If the requested format has
+    // a valid rate, use it instead. This stops the 0 from poisoning every
+    // downstream consumer (validate_android_direct_request, format
+    // selection, engine sample rate resolution, position calculation).
+    if playback_format.sample_rate == 0 {
+        if let Some(state) = DIRECT_USB_STATE.lock().as_ref() {
+            if let Some(req) = state.requested_playback_format {
+                if req.sample_rate > 0 {
+                    dev_eprintln!(
+                        "[USB] set_effective_playback_format: refusing to store 0 Hz, using requested {} Hz instead",
+                        req.sample_rate
+                    );
+                    playback_format.sample_rate = req.sample_rate;
+                }
+            }
+        }
+    }
     if let Some(state) = DIRECT_USB_STATE.lock().as_mut() {
         state.playback_format = Some(playback_format);
     }
@@ -3383,9 +3467,29 @@ pub fn create_android_usb_backend(
 fn create_android_usb_backend_inner(
     callback_data: Arc<AudioCallbackData>,
     event_tx: Sender<AudioEvent>,
-    preferred_sample_rate: u32,
+    mut preferred_sample_rate: u32,
 ) -> Result<Option<AndroidDirectUsbBackend>, String> {
-    let (state, playback_format, use_requested_playback_format) = {
+    // Some buggy DACs report 0 Hz via GET_CUR, and Dart passes this as
+    // preferred_sample_rate = 0. Use the requested playback format's rate
+    // instead of 0, which would cause a 0 == 0 format match and select a
+    // zero-Hz stream configuration.
+    if preferred_sample_rate == 0 {
+        if let Some(guard) = DIRECT_USB_STATE.lock().as_ref() {
+            if let Some(req_fmt) = guard.requested_playback_format {
+                preferred_sample_rate = req_fmt.sample_rate;
+            } else if let Some(eff_fmt) = guard.playback_format {
+                preferred_sample_rate = eff_fmt.sample_rate;
+            }
+        }
+        if preferred_sample_rate == 0 {
+            preferred_sample_rate = 44_100;
+        }
+        dev_eprintln!(
+            "[USB] preferred_sample_rate was 0, using {} Hz instead",
+            preferred_sample_rate
+        );
+    }
+    let (state, mut playback_format, use_requested_playback_format) = {
         let guard = DIRECT_USB_STATE.lock();
         let Some(state) = guard.as_ref() else {
             dev_eprintln!(
@@ -3427,6 +3531,27 @@ fn create_android_usb_backend_inner(
                     effective_playback_format.sample_rate,
                 );
             (requested_playback_format, true)
+        } else if effective_playback_format.sample_rate == 0
+            && requested_playback_format.sample_rate > 0
+        {
+            // The effective format has 0 Hz (broken DAC readback), but the
+            // requested format has a valid rate. Use the requested format.
+            dev_eprintln!(
+                    "Android USB direct backend: effective format had 0 Hz (broken DAC readback), using requested format at {} Hz for '{}'",
+                    requested_playback_format.sample_rate,
+                    state.device.product_name,
+                );
+            (requested_playback_format, true)
+        } else if effective_playback_format.sample_rate > 0
+            && requested_playback_format.sample_rate == 0
+        {
+            // The requested format has 0 Hz, but the effective format is valid.
+            dev_eprintln!(
+                    "Android USB direct backend: requested format had 0 Hz, using effective format at {} Hz for '{}'",
+                    effective_playback_format.sample_rate,
+                    state.device.product_name,
+                );
+            (effective_playback_format, false)
         } else {
             dev_eprintln!(
                     "Android USB direct backend skipped: preferred {} Hz did not match effective {} Hz or requested {} Hz for '{}'",
@@ -3934,73 +4059,86 @@ fn create_android_usb_backend_inner(
     // Some DACs reset their clock when the alt setting changes. Re-read
     // GET_CUR after switching to the streaming alt setting and if the
     // rate is wrong, try one more SET_CUR + verify cycle.
+    // Skip for devices with broken clock readback (SkipClockValidation quirk).
     if let Some(clock) = clock {
-        match get_sampling_frequency(
-            &claimed_handle.handle,
-            clock.interface_number,
-            clock.clock_id,
-        ) {
-            Ok(post_alt_rate) => {
-                dev_eprintln!(
-                    "[USB] GET_CUR (post-alt): clock {} reports {}Hz (expected {}Hz)",
-                    clock.clock_id, post_alt_rate, playback_format.sample_rate,
-                );
-                if post_alt_rate != playback_format.sample_rate {
+        let skip_clock_validation = crate::uac2::quirk::QUIRK_DATABASE.has_quirk(
+            state.device.vendor_id,
+            state.device.product_id,
+            &state.device.product_name,
+            crate::uac2::quirk::UsbAudioQuirk::SkipClockValidation,
+        );
+        if skip_clock_validation {
+            dev_eprintln!(
+                "[USB] Skipping post-alt GET_CUR re-verification (SkipClockValidation quirk)",
+            );
+        } else {
+            match get_sampling_frequency(
+                &claimed_handle.handle,
+                clock.interface_number,
+                clock.clock_id,
+            ) {
+                Ok(post_alt_rate) => {
                     dev_eprintln!(
-                        "[USB] DAC clock drifted after alt-setting change ({} -> {}Hz); re-issuing SET_CUR",
-                        playback_format.sample_rate, post_alt_rate,
+                        "[USB] GET_CUR (post-alt): clock {} reports {}Hz (expected {}Hz)",
+                        clock.clock_id, post_alt_rate, playback_format.sample_rate,
                     );
-                    let retry = apply_sampling_frequency(
-                        &claimed_handle.handle,
-                        clock.interface_number,
-                        clock.clock_id,
-                        playback_format.sample_rate,
-                        clock_settle_delay_ms,
-                    );
-                    clock_control_attempted = true;
-                    clock_control_succeeded = retry.clock_ok;
-                    reported_sample_rate = retry.reported_sample_rate;
-                    clock_verification_passed = retry.rate_verified
-                        && retry.reported_sample_rate == Some(playback_format.sample_rate);
-                    set_clock_verification(
-                        clock_control_attempted,
-                        clock_control_succeeded,
-                        clock_verification_passed,
-                        reported_sample_rate,
-                    );
-                    dev_eprintln!(
-                        "[USB] Re-SET_CUR result: clockOk={}, verified={}, reported={}Hz",
-                        retry.clock_ok,
-                        clock_verification_passed,
-                        retry.reported_sample_rate.unwrap_or(0),
-                    );
-
-                    if retry.set_cur_succeeded
-                        && !clock_verification_passed
-                        && !retry.known_mismatch
-                    {
-                        clock_verification_passed = true;
-                        reported_sample_rate = Some(playback_format.sample_rate);
+                    if post_alt_rate != playback_format.sample_rate {
+                        dev_eprintln!(
+                            "[USB] DAC clock drifted after alt-setting change ({} -> {}Hz); re-issuing SET_CUR",
+                            playback_format.sample_rate, post_alt_rate,
+                        );
+                        let retry = apply_sampling_frequency(
+                            &claimed_handle.handle,
+                            clock.interface_number,
+                            clock.clock_id,
+                            playback_format.sample_rate,
+                            clock_settle_delay_ms,
+                        );
+                        clock_control_attempted = true;
+                        clock_control_succeeded = retry.clock_ok;
+                        reported_sample_rate = retry.reported_sample_rate;
+                        clock_verification_passed = retry.rate_verified
+                            && retry.reported_sample_rate == Some(playback_format.sample_rate);
                         set_clock_verification(
                             clock_control_attempted,
-                            true,
-                            true,
+                            clock_control_succeeded,
+                            clock_verification_passed,
                             reported_sample_rate,
                         );
                         dev_eprintln!(
-                            "[USB] Re-SET_CUR accepted {}Hz on clock {} but readback unavailable (write-only clock); trusting SET_CUR",
-                            playback_format.sample_rate, clock.clock_id,
+                            "[USB] Re-SET_CUR result: clockOk={}, verified={}, reported={}Hz",
+                            retry.clock_ok,
+                            clock_verification_passed,
+                            retry.reported_sample_rate.unwrap_or(0),
                         );
+
+                        if retry.set_cur_succeeded
+                            && !clock_verification_passed
+                            && !retry.known_mismatch
+                        {
+                            clock_verification_passed = true;
+                            reported_sample_rate = Some(playback_format.sample_rate);
+                            set_clock_verification(
+                                clock_control_attempted,
+                                true,
+                                true,
+                                reported_sample_rate,
+                            );
+                            dev_eprintln!(
+                                "[USB] Re-SET_CUR accepted {}Hz on clock {} but readback unavailable (write-only clock); trusting SET_CUR",
+                                playback_format.sample_rate, clock.clock_id,
+                            );
+                        }
                     }
                 }
+                Err(error) => {
+                    dev_eprintln!(
+                        "[USB] GET_CUR (post-alt): failed for clock {}: {}",
+                        clock.clock_id, error,
+                    );
+                }
             }
-            Err(error) => {
-                dev_eprintln!(
-                    "[USB] GET_CUR (post-alt): failed for clock {}: {}",
-                    clock.clock_id, error,
-                );
-            }
-        }
+        } // end of else (not skip_clock_validation)
     }
 
     dev_eprintln!(
@@ -4022,38 +4160,45 @@ fn create_android_usb_backend_inner(
     // stream. Sending audio at the wrong sample rate causes chipmunk /
     // distorted playback.  There is NO "continue anyway" path.
     if !clock_verification_passed {
-        reported_sample_rate = reported_sample_rate.or(Some(playback_format.sample_rate));
-        set_clock_verification(
-            clock_control_attempted,
-            clock_control_succeeded,
-            false,
-            reported_sample_rate,
+        // Check if this device has the SkipClockValidation quirk.
+        // Some DACs (e.g. Fosi DS2 / Savitech bridge) have broken UAC2 clock
+        // control — GET_RANGE and GET_CUR always return 0. SET_CUR is accepted
+        // silently. Skip verification and trust the SET_CUR.
+        let skip_clock_validation = crate::uac2::quirk::QUIRK_DATABASE.has_quirk(
+            state.device.vendor_id,
+            state.device.product_id,
+            &state.device.product_name,
+            crate::uac2::quirk::UsbAudioQuirk::SkipClockValidation,
         );
 
-        let refusal = format!(
-            "USB direct refused: DAC clock not verified at {}Hz (reported={}Hz, attempted={}, succeeded={})",
-            playback_format.sample_rate,
-            reported_sample_rate.unwrap_or(0),
-            clock_control_attempted,
-            clock_control_succeeded,
-        );
-        dev_eprintln!("[USB] {}", refusal);
-        set_last_error(Some(refusal.clone()));
-        set_direct_mode_refusal_reason(Some(refusal.clone()));
-        set_android_usb_engine_state(AndroidDirectUsbEngineState::Error, Some(refusal.clone()));
-        cleanup_claimed_handle(
-            claimed_handle,
-            Some(candidate.interface_number),
-            lock_requested,
-        );
-        return Err(refusal);
-    }
+        if skip_clock_validation {
+            dev_eprintln!(
+                "[USB] Clock verification failed but SkipClockValidation quirk is active — trusting SET_CUR for {}Hz",
+                playback_format.sample_rate,
+            );
+            clock_verification_passed = true;
+            reported_sample_rate = Some(playback_format.sample_rate);
+            set_clock_verification(
+                clock_control_attempted,
+                clock_control_succeeded,
+                true,
+                reported_sample_rate,
+            );
+        } else {
+            reported_sample_rate = reported_sample_rate.or(Some(playback_format.sample_rate));
+            set_clock_verification(
+                clock_control_attempted,
+                clock_control_succeeded,
+                false,
+                reported_sample_rate,
+            );
 
-    if let Some(rate) = reported_sample_rate {
-        if rate != playback_format.sample_rate {
             let refusal = format!(
-                "USB direct refused: DAC clock mismatch (requested {}Hz, reported {}Hz)",
-                playback_format.sample_rate, rate,
+                "USB direct refused: DAC clock not verified at {}Hz (reported={}Hz, attempted={}, succeeded={})",
+                playback_format.sample_rate,
+                reported_sample_rate.unwrap_or(0),
+                clock_control_attempted,
+                clock_control_succeeded,
             );
             dev_eprintln!("[USB] {}", refusal);
             set_last_error(Some(refusal.clone()));
@@ -4065,6 +4210,43 @@ fn create_android_usb_backend_inner(
                 lock_requested,
             );
             return Err(refusal);
+        }
+    }
+
+    if let Some(rate) = reported_sample_rate {
+        if rate != playback_format.sample_rate {
+            // Check if this device has the IgnoreInvalidSampleRate quirk.
+            // Some DACs (e.g. Fosi DS2) always report 0Hz via GET_CUR even
+            // when operating correctly at the requested rate.
+            let ignore_invalid_rate = crate::uac2::quirk::QUIRK_DATABASE.has_quirk(
+                state.device.vendor_id,
+                state.device.product_id,
+                &state.device.product_name,
+                crate::uac2::quirk::UsbAudioQuirk::IgnoreInvalidSampleRate,
+            );
+
+            if ignore_invalid_rate {
+                dev_eprintln!(
+                    "[USB] DAC reported {}Hz (expected {}Hz) but IgnoreInvalidSampleRate quirk is active — continuing",
+                    rate, playback_format.sample_rate,
+                );
+                reported_sample_rate = Some(playback_format.sample_rate);
+            } else {
+                let refusal = format!(
+                    "USB direct refused: DAC clock mismatch (requested {}Hz, reported {}Hz)",
+                    playback_format.sample_rate, rate,
+                );
+                dev_eprintln!("[USB] {}", refusal);
+                set_last_error(Some(refusal.clone()));
+                set_direct_mode_refusal_reason(Some(refusal.clone()));
+                set_android_usb_engine_state(AndroidDirectUsbEngineState::Error, Some(refusal.clone()));
+                cleanup_claimed_handle(
+                    claimed_handle,
+                    Some(candidate.interface_number),
+                    lock_requested,
+                );
+                return Err(refusal);
+            }
         }
     }
 
@@ -6177,7 +6359,17 @@ fn apply_sampling_frequency(
         }
     }
 
-    if let Some(reported_sample_rate) = last_reported_rate {
+    if let Some(mut reported_sample_rate) = last_reported_rate {
+        // Some DACs (e.g. Fosi DS2 / Savitech bridge) report 0 Hz via GET_CUR
+        // even after a successful SET_CUR. Replace the bogus 0 with the
+        // requested rate so it doesn't poison downstream code paths.
+        if reported_sample_rate == 0 {
+            dev_eprintln!(
+                "[USB] DAC reports 0 Hz after SET_CUR on clock {} / interface {}; falling back to requested {} Hz",
+                clock_id, interface_number, sample_rate
+            );
+            reported_sample_rate = sample_rate;
+        }
         return AndroidDirectUsbClockApplyOutcome {
             clock_ok: false,
             rate_verified: false,

--- a/rust/src/uac2/mod.rs
+++ b/rust/src/uac2/mod.rs
@@ -72,7 +72,7 @@ pub use android_direct::{
     android_direct_debug_state, android_direct_has_hardware_volume_control,
     android_direct_output_signature, android_direct_preferred_sample_rate,
     android_direct_set_hardware_mute, android_direct_set_hardware_volume,
-    android_direct_verify_hardware_volume_health, clear_android_usb_device,
+    android_direct_usb_enabled, android_direct_verify_hardware_volume_health, clear_android_usb_device,
     create_android_usb_backend, force_release_usb_session, is_usb_session_active,
     mark_android_usb_fallback, negotiate_android_direct_output_sample_rate,
     register_android_usb_device, set_android_direct_usb_enabled, set_android_usb_dop_mode,

--- a/rust/src/uac2/quirk.rs
+++ b/rust/src/uac2/quirk.rs
@@ -118,6 +118,21 @@ pub static QUIRK_DATABASE: Lazy<QuirkDatabase> = Lazy::new(|| {
         ],
     );
 
+    // Fosi Audio DS2: Savitech USB bridge with broken UAC2 clock control.
+    // GET_RANGE returns zero subranges (I/O error), GET_CUR always returns 0Hz
+    // even after a successful SET_CUR. The DAC operates correctly at the
+    // requested rate — it just doesn't report it back via standard controls.
+    // Trust SET_CUR and skip all clock validation/readback.
+    db.add(
+        9770, // vendor_id 0x262A (Savitech)
+        1,    // product_id 0x0001
+        "",   // match any product name with this VID/PID
+        &[
+            UsbAudioQuirk::SkipClockValidation,
+            UsbAudioQuirk::IgnoreInvalidSampleRate,
+        ],
+    );
+
     db
 });
 
@@ -137,6 +152,13 @@ mod tests {
     fn unknown_device_returns_empty() {
         let quirks = QUIRK_DATABASE.lookup(0x0000, 0x0000, "Unknown");
         assert!(quirks.is_empty());
+    }
+
+    #[test]
+    fn fosi_ds2_quirks_registered() {
+        let quirks = QUIRK_DATABASE.lookup(9770, 1, "Fosi Audio DS2");
+        assert!(quirks.contains(&UsbAudioQuirk::SkipClockValidation));
+        assert!(quirks.contains(&UsbAudioQuirk::IgnoreInvalidSampleRate));
     }
 
     #[test]

--- a/test/services/jellyfin_service_test.dart
+++ b/test/services/jellyfin_service_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:flick/data/entities/network_server_entity.dart';
+import 'package:flick/services/sources/jellyfin_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+NetworkServerEntity _server({String? token}) {
+  final entity = NetworkServerEntity()
+    ..id = 3
+    ..label = 'Jf'
+    ..protocol = 'jellyfin'
+    ..baseUrl = 'https://jf.example.com'
+    ..username = 'demo'
+    ..token = token;
+  return entity;
+}
+
+void main() {
+  group('auth', () {
+    test('resolveToken posts AuthenticateByName and stores JSON credentials',
+        () async {
+      late String capturedBody;
+      late Map<String, String> capturedHeaders;
+      late Uri capturedUri;
+      final client = MockClient((request) async {
+        capturedBody = request.body;
+        capturedHeaders = request.headers;
+        capturedUri = request.url;
+        return http.Response(
+          jsonEncode({
+            'User': {'Id': 'user-1', 'Name': 'demo'},
+            'AccessToken': 'tok-xyz',
+          }),
+          200,
+        );
+      });
+      final service = JellyfinService.create(client: client);
+
+      final token = await service.resolveToken(_server(), 'hunter2');
+
+      expect(token, isNotNull);
+      final decoded = jsonDecode(token!) as Map<String, dynamic>;
+      expect(decoded['userId'], 'user-1');
+      expect(decoded['token'], 'tok-xyz');
+
+      expect(capturedUri.path, '/Users/AuthenticateByName');
+      expect(capturedUri.toString(), startsWith('https://jf.example.com'));
+      final sent = jsonDecode(capturedBody) as Map<String, dynamic>;
+      expect(sent['Username'], 'demo');
+      expect(sent['Pw'], 'hunter2');
+      final auth = capturedHeaders['Authorization']!;
+      expect(auth, contains('MediaBrowser'));
+      expect(auth, contains('Client="flick"'));
+      // The auth-exchange request must NOT carry an access token.
+      expect(auth, isNot(contains('Token=')));
+    });
+
+    test('ping sends stored access token and returns true on 200', () async {
+      late String capturedAuth;
+      final client = MockClient((request) async {
+        capturedAuth = request.headers['Authorization'] ?? '';
+        expect(request.url.path, '/system/Info');
+        return http.Response('{}', 200);
+      });
+      final service = JellyfinService.create(client: client);
+
+      final ok = await service.ping(_server(
+        token: jsonEncode({'userId': 'user-1', 'token': 'tok-xyz'}),
+      ));
+
+      expect(ok, isTrue);
+      expect(capturedAuth, contains('Token="tok-xyz"'));
+    });
+
+    test('ping returns false when no token is stored', () async {
+      final client = MockClient((request) async => http.Response('{}', 200));
+      final service = JellyfinService.create(client: client);
+      expect(await service.ping(_server(token: null)), isFalse);
+    });
+  });
+}

--- a/test/services/network_cache_service_test.dart
+++ b/test/services/network_cache_service_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:flick/services/network_cache_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory root;
+  late NetworkCacheService service;
+
+  // FS mtime granularity can be 1s, so LRU order is controlled explicitly.
+  final base = DateTime(2020, 1, 1, 12);
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('network_cache_test');
+    service = NetworkCacheService(
+      sizeCapBytes: 100,
+      rootDirectory: Directory('${root.path}/network_cache'),
+    );
+  });
+
+  tearDown(() async {
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  test('stash then getPath returns the same file', () async {
+    final path = await service.stash(1, 'songA', [1, 2, 3], extension: 'flac');
+    final cached = await service.getPath(1, 'songA', extension: 'flac');
+    expect(cached, path);
+    expect(await File(path).readAsBytes(), [1, 2, 3]);
+  });
+
+  test('getPath returns null when not cached or for another server', () async {
+    await service.stash(1, 'songA', [1, 2, 3], extension: 'flac');
+    expect(await service.getPath(1, 'songB', extension: 'flac'), isNull);
+    expect(await service.getPath(2, 'songA', extension: 'flac'), isNull);
+  });
+
+  test('cap is enforced and oldest entry is evicted first', () async {
+    final p1 = await service.stash(1, 'old', List.filled(40, 0), extension: 'flac');
+    await File(p1).setLastModified(base);
+    final p2 = await service.stash(1, 'mid', List.filled(40, 0), extension: 'flac');
+    await File(p2).setLastModified(base.add(const Duration(seconds: 1)));
+    final p3 = await service.stash(1, 'new', List.filled(40, 0), extension: 'flac');
+    await File(p3).setLastModified(base.add(const Duration(seconds: 2)));
+
+    await service.stash(1, 'trigger', [1], extension: 'flac');
+
+    expect(await service.getPath(1, 'old', extension: 'flac'), isNull);
+    expect(await service.getPath(1, 'mid', extension: 'flac'), isNotNull);
+    expect(await service.getPath(1, 'new', extension: 'flac'), isNotNull);
+  });
+
+  test('recently accessed entries survive eviction', () async {
+    final p1 = await service.stash(1, 'old', List.filled(40, 0), extension: 'flac');
+    await File(p1).setLastModified(base);
+    final p2 = await service.stash(1, 'fresh', List.filled(40, 0), extension: 'flac');
+    await File(p2).setLastModified(base.add(const Duration(seconds: 1)));
+
+    expect(await service.getPath(1, 'old', extension: 'flac'), isNotNull);
+    await File(p1).setLastModified(base.add(const Duration(seconds: 10)));
+
+    await service.stash(1, 'new', List.filled(40, 0), extension: 'flac');
+
+    expect(await service.getPath(1, 'old', extension: 'flac'), isNotNull);
+    expect(await service.getPath(1, 'fresh', extension: 'flac'), isNull);
+  });
+
+  test('a single file exceeding the cap is still playable', () async {
+    final path = await service.stash(
+      1,
+      'huge',
+      List.filled(200, 0),
+      extension: 'flac',
+    );
+    expect(await File(path).exists(), isTrue);
+    expect(await service.getPath(1, 'huge', extension: 'flac'), path);
+  });
+}

--- a/test/services/subsonic_service_test.dart
+++ b/test/services/subsonic_service_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:flick/data/entities/network_server_entity.dart';
+import 'package:flick/services/sources/subsonic_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+NetworkServerEntity _server({String? token}) {
+  final entity = NetworkServerEntity()
+    ..id = 7
+    ..label = 'Test'
+    ..protocol = 'subsonic'
+    ..baseUrl = 'https://music.example.com/subsonic'
+    ..username = 'demo'
+    ..token = token;
+  return entity;
+}
+
+void main() {
+  group('auth', () {
+    test('buildToken matches the spec known-answer vector', () {
+      // subsonic.org: password "sesame", salt "c19b2d"
+      // t = md5(password + salt) = md5("sesamec19b2d")
+      expect(
+        SubsonicService.buildToken('sesame', salt: 'c19b2d'),
+        'c19b2d:26719a1196d2a940705a59634eb18eab',
+      );
+    });
+
+    test('request carries u/t/s/v/c/f params', () async {
+      late Uri captured;
+      final client = MockClient((request) async {
+        captured = request.url;
+        return http.Response(
+          jsonEncode({'subsonic-response': {'status': 'ok'}}),
+          200,
+        );
+      });
+      final service = SubsonicService.create(client: client);
+
+      final ok = await service.ping(_server(
+        token: 'c19b2d:26719a1196d2a940705a59634eb18eab',
+      ));
+
+      expect(ok, isTrue);
+      expect(captured.path, '/subsonic/rest/ping.view');
+      expect(captured.queryParameters['u'], 'demo');
+      expect(captured.queryParameters['t'], '26719a1196d2a940705a59634eb18eab');
+      expect(captured.queryParameters['s'], 'c19b2d');
+      expect(captured.queryParameters['v'], isNotEmpty);
+      expect(captured.queryParameters['c'], 'flick');
+      expect(captured.queryParameters['f'], 'json');
+    });
+
+    test('ping returns false on error status', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'subsonic-response': {
+              'status': 'failed',
+              'error': {'code': 40, 'message': 'Wrong username or password'},
+            },
+          }),
+          200,
+        );
+      });
+      final service = SubsonicService.create(client: client);
+
+      expect(
+        await service.ping(_server(token: 'c19b2d:26719a1196d2a940705a59634eb18eab')),
+        isFalse,
+      );
+    });
+  });
+
+  group('library', () {
+    test('getAlbum maps song fields to an entity', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'subsonic-response': {
+              'status': 'ok',
+              'album': {
+                'song': [
+                  {
+                    'id': 'song-42',
+                    'title': 'Midnight',
+                    'artist': 'The Moths',
+                    'album': 'Nightshift',
+                    'albumArtist': 'The Moths',
+                    'track': 3,
+                    'duration': 245,
+                    'size': 12345678,
+                    'suffix': 'flac',
+                    'bitRate': 954,
+                    'sampleRate': 44100,
+                    'coverArt': 'al-9',
+                  },
+                ],
+              },
+            },
+          }),
+          200,
+        );
+      });
+      final service = SubsonicService.create(client: client);
+
+      final songs = await service.getAlbum(_server(
+        token: 'c19b2d:26719a1196d2a940705a59634eb18eab',
+      ), 'al-9');
+
+      expect(songs, hasLength(1));
+      final song = songs.first;
+      expect(song['id'], 'song-42');
+      expect(song['title'], 'Midnight');
+      expect(song['duration'], 245);
+      expect(song['suffix'], 'flac');
+    });
+
+    test('getAlbumList2 paginates until a short page', () async {
+      var calls = 0;
+      final client = MockClient((request) async {
+        calls++;
+        final offset = int.parse(request.url.queryParameters['offset']!);
+        final count = offset == 0 ? 500 : 2;
+        final albums = List.generate(count, (i) {
+          final n = offset + i;
+          return {'id': 'al-$n', 'album': 'Album $n', 'artist': 'Artist $n'};
+        });
+        return http.Response(
+          jsonEncode({
+            'subsonic-response': {
+              'status': 'ok',
+              'albumList2': {'album': albums},
+            },
+          }),
+          200,
+        );
+      });
+      final service = SubsonicService.create(client: client);
+
+      final albums = await service.getAlbumList2(_server(
+        token: 'c19b2d:26719a1196d2a940705a59634eb18eab',
+      ));
+
+      expect(calls, 2);
+      expect(albums, hasLength(502));
+      expect(albums.last['id'], 'al-501');
+    });
+
+    test('getAlbum tolerates double-valued numeric fields', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'subsonic-response': {
+              'status': 'ok',
+              'album': {
+                'song': [
+                  {
+                    'id': 'song-99',
+                    'title': 'Drift',
+                    'duration': 245.0,
+                    'track': 7.0,
+                    'size': 9999999.0,
+                    'suffix': 'flac',
+                    'bitRate': 954.0,
+                    'sampleRate': 44100.0,
+                  },
+                ],
+              },
+            },
+          }),
+          200,
+        );
+      });
+      final service = SubsonicService.create(client: client);
+
+      // No throw — doubles are accepted and mapped to ints downstream.
+      final songs = await service.getAlbum(_server(
+        token: 'c19b2d:26719a1196d2a940705a59634eb18eab',
+      ), 'al-1');
+
+      expect(songs, hasLength(1));
+      expect(songs.first['duration'], 245.0);
+    });
+  });
+}

--- a/test/services/upnp_service_test.dart
+++ b/test/services/upnp_service_test.dart
@@ -1,0 +1,47 @@
+import 'package:flick/services/sources/upnp_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _didl = '<?xml version="1.0"?>'
+    '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+    'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+    'xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">'
+    '<item id="i1" parentID="p1">'
+    '<dc:title>Lullaby</dc:title>'
+    '<upnp:class>object.item.audioItem.musicTrack</upnp:class>'
+    '<upnp:artist>The Singers</upnp:artist>'
+    '<upnp:album>Dreams</upnp:album>'
+    '<upnp:originalTrackNumber>2</upnp:originalTrackNumber>'
+    '<dc:date>2019-06-01</dc:date>'
+    '<upnp:albumArtURI>http://host/cover.jpg</upnp:albumArtURI>'
+    '<res protocolInfo="http-get:*:audio/mpeg:*" size="5000" '
+    'duration="0:03:21.5">http://host/track.mp3</res>'
+    '</item>'
+    '<item id="i2" parentID="p1">'
+    '<dc:title>booklet</dc:title>'
+    '<upnp:class>object.item.imageItem.photo</upnp:class>'
+    '<res protocolInfo="http-get:*:image/jpeg:*" size="100">'
+    'http://host/booklet.jpg</res>'
+    '</item>'
+    '</DIDL-Lite>';
+
+void main() {
+  group('parse', () {
+    test('DIDL-Lite maps audio fields and skips non-audio items', () {
+      final items = UpnpService.parseDidlItemsForTest(_didl);
+
+      expect(items, hasLength(1));
+      final song = items.single;
+      expect(song.title, 'Lullaby');
+      expect(song.artist, 'The Singers');
+      expect(song.album, 'Dreams');
+      expect(song.trackNumber, 2);
+      expect(song.year, 2019);
+      expect(song.resUrl, 'http://host/track.mp3');
+      expect(song.coverUrl, 'http://host/cover.jpg');
+      // audio/mpeg -> mp3
+      expect(song.fileType, 'mp3');
+      // 0:03:21.5 -> 201500 ms
+      expect(song.durationMs, 201500);
+    });
+  });
+}

--- a/test/services/webdav_service_test.dart
+++ b/test/services/webdav_service_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:flick/data/entities/network_server_entity.dart';
+import 'package:flick/services/sources/webdav_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _multistatus = '<?xml version="1.0"?>'
+    '<D:multistatus xmlns:D="DAV:">'
+    '<D:response>'
+    '<D:href>/music/</D:href>'
+    '<D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop></D:propstat>'
+    '</D:response>'
+    '<D:response>'
+    '<D:href>/music/Album%20One/</D:href>'
+    '<D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop></D:propstat>'
+    '</D:response>'
+    '<D:response>'
+    '<D:href>/music/song.flac</D:href>'
+    '<D:propstat><D:prop><D:resourcetype/><D:getcontentlength>9876</D:getcontentlength></D:prop></D:propstat>'
+    '</D:response>'
+    '</D:multistatus>';
+
+NetworkServerEntity _server({String? token}) {
+  final entity = NetworkServerEntity()
+    ..id = 5
+    ..label = 'Dav'
+    ..protocol = 'webdav'
+    ..baseUrl = 'https://dav.example.com/music'
+    ..username = 'alice'
+    ..token = token;
+  return entity;
+}
+
+void main() {
+  group('auth', () {
+    test('resolveToken stores base64(password)', () async {
+      final client = MockClient((request) async => http.Response('', 200));
+      final service = WebdavService.create(client: client);
+
+      final token = await service.resolveToken(_server(), 'secret');
+
+      expect(token, base64Encode(utf8.encode('secret')));
+      expect(utf8.decode(base64Decode(token!)), 'secret');
+    });
+
+    test('ping sends HTTP Basic over PROPFIND and accepts 207', () async {
+      late String capturedAuth;
+      late String capturedDepth;
+      late String capturedMethod;
+      final client = MockClient((request) async {
+        capturedAuth = request.headers['Authorization'] ?? '';
+        capturedDepth = request.headers['Depth'] ?? '';
+        capturedMethod = request.method;
+        return http.Response(_multistatus, 207);
+      });
+      final service = WebdavService.create(client: client);
+
+      // token = base64('secret'); expected Basic = base64('alice:secret')
+      final server = _server(token: base64Encode(utf8.encode('secret')));
+      final ok = await service.ping(server);
+
+      expect(ok, isTrue);
+      expect(capturedMethod, 'PROPFIND');
+      expect(capturedDepth, '0');
+      expect(
+        capturedAuth,
+        'Basic ${base64Encode(utf8.encode('alice:secret'))}',
+      );
+    });
+  });
+
+  group('parse', () {
+    test('multistatus splits collections from files and skips self', () {
+      final entries =
+          WebdavService.parseMultistatusForTest(_multistatus, '/music/');
+
+      expect(entries, hasLength(2));
+      expect(entries[0].href, '/music/Album One/');
+      expect(entries[0].isCollection, isTrue);
+      expect(entries[1].href, '/music/song.flac');
+      expect(entries[1].isCollection, isFalse);
+      expect(entries[1].size, 9876);
+    });
+
+    test('isAudioPath detects audio extensions', () {
+      expect(WebdavService.isAudioPath('/a/b.flac'), isTrue);
+      expect(WebdavService.isAudioPath('/a/b.mp3'), isTrue);
+      expect(WebdavService.isAudioPath('/a/b.M4A'), isTrue);
+      expect(WebdavService.isAudioPath('/a/cover.jpg'), isFalse);
+      expect(WebdavService.isAudioPath('/a/notes.txt'), isFalse);
+    });
+
+    test('isCoverPath matches known cover stems with image extensions', () {
+      expect(WebdavService.isCoverPath('/a/cover.jpg'), isTrue);
+      expect(WebdavService.isCoverPath('/a/folder.png'), isTrue);
+      expect(WebdavService.isCoverPath('/a/album.large.jpeg'), isTrue);
+      // Image ext but not a cover stem.
+      expect(WebdavService.isCoverPath('/a/track.jpg'), isFalse);
+      // Cover stem but not an image ext.
+      expect(WebdavService.isCoverPath('/a/cover.flac'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Add network source system with Subsonic, Jellyfin/Emby, UPnP/DLNA, and WebDAV protocol support plus SMB placeholder
- Add bounded LRU network download cache and remote playback source with prefetch for gapless playback
- Add `NetworkServerEntity` Isar collection with server management screens (list, edit, validation, failure banner)
- Add `sourceType`, `remoteId`, `remoteServerId` to song model with remote server sync support
- Add USB volume menu/settings visibility preferences and gradient styling option
- Fix audio engine issues: Fosi Audio DS2 quirk, zero sample rate division, non-finite position guards, DAC clock readback, wake lock
- Add ambient background to equalizer screen and remove `BlurredSongBackground` from list screens

# Changes

## Network Music Sources

- Add `NetworkSourceService` abstraction (126 lines) with generic interface
- Add `SubsonicService` (359 lines) implementing Subsonic API integration
- Add `JellyfinService` (394 lines) for Jellyfin/Emby servers with auth and ping
- Add UPnP/DLNA MediaServer source service (511 lines) with DIDL-Lite parsing
- Add `WebDAVService` (472 lines) for WebDAV network music access
- Add SMB service placeholder (71 lines) that fails loudly
- Add `NetworkCacheService` (117 lines) for bounded LRU download caching
- Add `RemoteSourceService` (82 lines) for network song playback
- Add network-source prefetch for gapless playback
- Add `sourceType`, `remoteId`, `remoteServerId` fields to `Song` model and recently played entity
- Add `countSongsByRemoteServer` to `SongRepository`
- Add remote server sync support to `SongRepository`
- Generalize album art fetching for network protocols (Subsonic album art resolution)
- Add `NetworkServerEntity` Isar collection (1405 lines generated) with schema registration

## Network Source Management

- Add network sources screen (291 lines) with server list and management
- Add network server edit screen (312 lines) with multi-protocol config
- Add server validation, delete, and failure banner
- Add Network Sources category to settings screen
- Add path dependency and mark Phase 1 network sources as done in plan doc

## Tests

- Add Subsonic service tests (188 lines)
- Add WebDAV service tests (105 lines)
- Add UPnP DIDL-Lite metadata parsing tests (47 lines)
- Add Jellyfin auth and ping tests (83 lines)
- Add `NetworkCacheService` tests (78 lines)

## USB Volume Controls

- Add USB volume menu/settings visibility preferences with provider/service
- Conditionally show USB volume control based on preference
- Add gradient styling option to USB volume control widget
- Add responsive scaling to settings icons and USB volume toggles
- Add USB volume control to menu screen

## Audio Engine Fixes

- Add Fosi Audio DS2 quirk for broken clock control
- Guard against division by zero when `output_sample_rate` is 0
- Filter out zero sample rates in audio engine
- Preserve existing sample rate only when USB direct audio is inactive
- Guard against non-finite and negative position/duration values in audio progress updates
- Stop overwriting `preferredSampleRate` from DAC stored format
- Fix 0Hz DAC readback and `SkipClockValidation` quirk
- Add `android_direct_usb_enabled` to public exports

## Playback

- Add wake lock to keep CPU awake during audio playback (41 lines in `MusicNotificationService`)

## UI

- Add ambient background to equalizer screen
- Remove `BlurredSongBackground` from list screens and add USB volume control to menu
- Adjust settings scaffold padding to account for bottom safe area
- Make `SelectionSetting` optionally disabled when `onTap` is null

## Files Changed

- `lib/services/sources/network_source_service.dart`
- `lib/services/sources/subsonic_service.dart`
- `lib/services/sources/jellyfin_service.dart`
- `lib/services/sources/upnp_service.dart`
- `lib/services/sources/webdav_service.dart`
- `lib/services/sources/smb_service.dart`
- `lib/services/remote_source_service.dart`
- `lib/services/network_cache_service.dart`
- `lib/services/album_art_service.dart`
- `lib/services/player_service.dart`
- `lib/services/rust_audio_service.dart`
- `lib/data/entities/network_server_entity.dart`
- `lib/data/entities/network_server_entity.g.dart`
- `lib/data/database.dart`
- `lib/data/repositories/song_repository.dart`
- `lib/data/repositories/recently_played_repository.dart`
- `lib/models/song.dart`
- `lib/models/playback_context.dart`
- `lib/features/settings/screens/network_sources_screen.dart`
- `lib/features/settings/screens/network_server_edit_screen.dart`
- `lib/features/settings/screens/settings_screen.dart`
- `lib/features/settings/screens/uac2_settings_screen.dart`
- `lib/features/settings/screens/equalizer_screen.dart`
- `lib/features/settings/widgets/settings_widgets.dart`
- `lib/features/albums/screens/albums_screen.dart`
- `lib/features/artists/screens/artists_screen.dart`
- `lib/features/favorites/screens/favorites_screen.dart`
- `lib/features/folders/screens/folders_screen.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/features/playlists/screens/playlists_screen.dart`
- `lib/widgets/uac2/uac2_volume_control.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/services/app_preferences_service.dart`
- `rust/src/uac2/mod.rs`
- `rust/src/uac2/quirk.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/audio/source.rs`
- `rust/src/audio/engine.rs`
- `rust/src/api/audio_api.rs`
- `android/app/src/main/kotlin/com/mossapps/flick/MusicNotificationService.kt`
- `docs/NETWORK_SOURCES_PLAN.md`
- `pubspec.yaml`
- `pubspec.lock`
- `test/services/subsonic_service_test.dart`
- `test/services/webdav_service_test.dart`
- `test/services/upnp_service_test.dart`
- `test/services/jellyfin_service_test.dart`
- `test/services/network_cache_service_test.dart`