### PR TITLE
Refactor player action buttons to top/bottom pairs, add bit-perfect passthrough API, and volume tier system

### DIFF
--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -494,11 +494,14 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                       playerScreenMode: mode,
                       albumColor: albumColor,
                       albumColorMode: colorMode,
+                      leftTopAction: PlayerActionButtonX.fromStorageValue(
+                        appPrefs.leftTopActionButton,
+                      ),
                       leftAction: PlayerActionButtonX.fromStorageValue(
                         appPrefs.leftActionButton,
                       ),
-                      centerAction: PlayerActionButtonX.fromStorageValue(
-                        appPrefs.centerActionButton,
+                      rightTopAction: PlayerActionButtonX.fromStorageValue(
+                        appPrefs.rightTopActionButton,
                       ),
                       rightAction: PlayerActionButtonX.fromStorageValue(
                         appPrefs.rightActionButton,
@@ -536,11 +539,15 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                             ) ==
                             PlayerActionButton.queue ||
                         PlayerActionButtonX.fromStorageValue(
-                              appPrefs.centerActionButton,
+                              appPrefs.rightActionButton,
                             ) ==
                             PlayerActionButton.queue ||
                         PlayerActionButtonX.fromStorageValue(
-                              appPrefs.rightActionButton,
+                              appPrefs.leftTopActionButton,
+                            ) ==
+                            PlayerActionButton.queue ||
+                        PlayerActionButtonX.fromStorageValue(
+                              appPrefs.rightTopActionButton,
                             ) ==
                             PlayerActionButton.queue,
                     onRotationEnabledChanged: (enabled) {

--- a/lib/features/player/widgets/player_action_button_row.dart
+++ b/lib/features/player/widgets/player_action_button_row.dart
@@ -28,8 +28,9 @@ class PlayerActionButtonRow extends ConsumerStatefulWidget {
   final PlayerScreenMode playerScreenMode;
   final Color? albumColor;
   final AlbumColorMode albumColorMode;
+  final PlayerActionButton leftTopAction;
   final PlayerActionButton leftAction;
-  final PlayerActionButton centerAction;
+  final PlayerActionButton rightTopAction;
   final PlayerActionButton rightAction;
   final PlayerService playerService;
   final FavoritesService favoritesService;
@@ -47,8 +48,9 @@ class PlayerActionButtonRow extends ConsumerStatefulWidget {
     required this.playerScreenMode,
     required this.albumColor,
     required this.albumColorMode,
+    required this.leftTopAction,
     required this.leftAction,
-    required this.centerAction,
+    required this.rightTopAction,
     required this.rightAction,
     required this.playerService,
     required this.favoritesService,
@@ -72,8 +74,9 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
     final playerScreenMode = widget.playerScreenMode;
     final albumColor = widget.albumColor;
     final albumColorMode = widget.albumColorMode;
+    final leftTopAction = widget.leftTopAction;
     final leftAction = widget.leftAction;
-    final centerAction = widget.centerAction;
+    final rightTopAction = widget.rightTopAction;
     final rightAction = widget.rightAction;
     final immersiveActions = playerScreenMode == PlayerScreenMode.immersive;
     final actionPadding = immersiveActions
@@ -101,11 +104,13 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        _buildActionButton(
+        _buildSideButtons(
+          topAction: leftTopAction,
+          bottomAction: leftAction,
           context: context,
           song: song,
-          action: leftAction,
           actionPadding: actionPadding,
           actionRadius: actionRadius,
           actionIconSize: actionIconSize,
@@ -170,26 +175,11 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
             ],
           ),
         ),
-        _buildActionButton(
+        _buildSideButtons(
+          topAction: rightTopAction,
+          bottomAction: rightAction,
           context: context,
           song: song,
-          action: centerAction,
-          actionPadding: actionPadding,
-          actionRadius: actionRadius,
-          actionIconSize: actionIconSize,
-          inactiveBg: inactiveBg,
-          inactiveBorder: inactiveBorder,
-          albumColor: albumColor,
-          accentBlend: accentBlend,
-          hasAlbumTint: hasAlbumTint,
-          immersiveActions: immersiveActions,
-          lyricsMode: lyricsMode,
-        ),
-        SizedBox(width: context.responsive(5.0, 6.0, 7.0)),
-        _buildActionButton(
-          context: context,
-          song: song,
-          action: rightAction,
           actionPadding: actionPadding,
           actionRadius: actionRadius,
           actionIconSize: actionIconSize,
@@ -226,6 +216,54 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
       ),
     );
   }
+  Widget _buildSideButtons({
+    required PlayerActionButton topAction,
+    required PlayerActionButton bottomAction,
+    required BuildContext context,
+    required Song song,
+    required EdgeInsets actionPadding,
+    required double actionRadius,
+    required double actionIconSize,
+    required Color inactiveBg,
+    required Color inactiveBorder,
+    required Color? albumColor,
+    required double accentBlend,
+    required bool hasAlbumTint,
+    required bool immersiveActions,
+    required bool lyricsMode,
+  }) {
+    final buttons = <Widget>[];
+    for (final action in [topAction, bottomAction]) {
+      if (action == PlayerActionButton.none) continue;
+      if (buttons.isNotEmpty) {
+        buttons.add(SizedBox(height: context.responsive(6.0, 7.0, 8.0)));
+      }
+      buttons.add(
+        _buildActionButton(
+          context: context,
+          song: song,
+          action: action,
+          actionPadding: actionPadding,
+          actionRadius: actionRadius,
+          actionIconSize: actionIconSize,
+          inactiveBg: inactiveBg,
+          inactiveBorder: inactiveBorder,
+          albumColor: albumColor,
+          accentBlend: accentBlend,
+          hasAlbumTint: hasAlbumTint,
+          immersiveActions: immersiveActions,
+          lyricsMode: lyricsMode,
+        ),
+      );
+    }
+    if (buttons.isEmpty) return const SizedBox.shrink();
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: buttons,
+    );
+  }
+
   Widget _buildActionButton({
     required BuildContext context,
     required Song song,
@@ -242,6 +280,9 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
     required bool lyricsMode,
   }) {
     switch (action) {
+      // ponytail: none is filtered out by _buildSideButtons; unreachable here.
+      case PlayerActionButton.none:
+        return const SizedBox.shrink();
       case PlayerActionButton.lyrics:
         return _buildLyricsButton(
           context: context,

--- a/lib/features/player/widgets/player_layout_sheet.dart
+++ b/lib/features/player/widgets/player_layout_sheet.dart
@@ -319,7 +319,19 @@ class _PlayerLayoutSheetState extends ConsumerState<PlayerLayoutSheet> {
                       icon: Icons.swap_horiz_rounded,
                       children: [
                         _PlayerActionButtonSelector(
-                          label: 'Left button',
+                          label: 'Left (top)',
+                          currentValue: PlayerActionButtonX.fromStorageValue(
+                            appPrefs.leftTopActionButton,
+                          ),
+                          onChanged: (action) {
+                            prefsNotifier.setLeftTopActionButton(
+                              action.storageValue,
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 8),
+                        _PlayerActionButtonSelector(
+                          label: 'Left (bottom)',
                           currentValue: PlayerActionButtonX.fromStorageValue(
                             appPrefs.leftActionButton,
                           ),
@@ -331,19 +343,19 @@ class _PlayerLayoutSheetState extends ConsumerState<PlayerLayoutSheet> {
                         ),
                         const SizedBox(height: 8),
                         _PlayerActionButtonSelector(
-                          label: 'Center button',
+                          label: 'Right (top)',
                           currentValue: PlayerActionButtonX.fromStorageValue(
-                            appPrefs.centerActionButton,
+                            appPrefs.rightTopActionButton,
                           ),
                           onChanged: (action) {
-                            prefsNotifier.setCenterActionButton(
+                            prefsNotifier.setRightTopActionButton(
                               action.storageValue,
                             );
                           },
                         ),
                         const SizedBox(height: 8),
                         _PlayerActionButtonSelector(
-                          label: 'Right button',
+                          label: 'Right (bottom)',
                           currentValue: PlayerActionButtonX.fromStorageValue(
                             appPrefs.rightActionButton,
                           ),

--- a/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
+++ b/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
@@ -61,21 +61,23 @@ class _SleepTimerBottomSheetState extends State<SleepTimerBottomSheet> {
                   ),
                 ],
               ),
-              if (widget.playerService.isSleepTimerActive)
-                TextButton(
-                  onPressed: () {
-                    widget.playerService.cancelSleepTimer();
-                    Navigator.pop(context);
+              ValueListenableBuilder<Duration?>(
+                valueListenable:
+                    widget.playerService.sleepTimerRemainingNotifier,
+                builder: (context, remaining, _) => Switch(
+                  value: remaining != null,
+                  activeThumbColor: AppColors.accent,
+                  onChanged: (on) {
+                    if (on) {
+                      widget.playerService.setSleepTimer(
+                        Duration(minutes: _value.round()),
+                      );
+                    } else {
+                      widget.playerService.cancelSleepTimer();
+                    }
                   },
-                  child: const Text(
-                    'Cancel Timer',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      color: Colors.redAccent,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
                 ),
+              ),
             ],
           ),
           const SizedBox(height: 8),

--- a/lib/features/player/widgets/volume_bottom_sheet.dart
+++ b/lib/features/player/widgets/volume_bottom_sheet.dart
@@ -18,15 +18,14 @@ class VolumeBottomSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final initialVolume = playerService.currentVolume;
+    final isAvailable = playerService.isVolumeAvailable;
     double currentVolume = initialVolume;
     return StatefulBuilder(
       builder: (context, setSheetState) {
         return Container(
           decoration: BoxDecoration(
             color: AppColors.surface,
-            borderRadius: const BorderRadius.vertical(
-              top: Radius.circular(24),
-            ),
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
             border: Border.all(color: AppColors.glassBorder),
           ),
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 24),
@@ -80,14 +79,18 @@ class VolumeBottomSheet extends StatelessWidget {
                       max: 1.0,
                       divisions: 100,
                       label: '${(currentVolume * 100).round()}%',
-                      onChanged: (value) {
-                        setSheetState(() {
-                          currentVolume = value;
-                        });
-                      },
-                      onChangeEnd: (value) async {
-                        await playerService.setVolume(value);
-                      },
+                      onChanged: isAvailable
+                          ? (value) {
+                              setSheetState(() {
+                                currentVolume = value;
+                              });
+                            }
+                          : null,
+                      onChangeEnd: isAvailable
+                          ? (value) async {
+                              await playerService.setVolume(value);
+                            }
+                          : null,
                       activeColor: AppColors.accent,
                       inactiveColor: AppColors.textTertiary.withValues(
                         alpha: 0.3,
@@ -101,6 +104,17 @@ class VolumeBottomSheet extends StatelessWidget {
                   ),
                 ],
               ),
+              if (!isAvailable) ...[
+                const SizedBox(height: 8),
+                const Text(
+                  'Volume is fixed while bit-perfect passthrough is active and this DAC has no hardware volume control.',
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 12,
+                    height: 1.4,
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
             ],
           ),

--- a/lib/features/settings/screens/player_layout_settings_screen.dart
+++ b/lib/features/settings/screens/player_layout_settings_screen.dart
@@ -361,8 +361,33 @@ class PlayerLayoutSettingsScreen extends ConsumerWidget {
           SettingsCard(
             children: [
               NavigationSetting(
+                icon: Icons.arrow_upward_rounded,
+                title: 'Left (Top) Button',
+                subtitle: PlayerActionButtonX.fromStorageValue(
+                  appPrefs.leftTopActionButton,
+                ).label,
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => _ActionButtonPickerScreen(
+                        title: 'Left (Top) Button',
+                        currentValue: PlayerActionButtonX.fromStorageValue(
+                          appPrefs.leftTopActionButton,
+                        ),
+                        onSelected: (action) {
+                          ref
+                              .read(appPreferencesProvider.notifier)
+                              .setLeftTopActionButton(action.storageValue);
+                        },
+                      ),
+                    ),
+                  );
+                },
+              ),
+              const SettingsDivider(),
+              NavigationSetting(
                 icon: Icons.arrow_back_rounded,
-                title: 'Left Button',
+                title: 'Left (Bottom) Button',
                 subtitle: PlayerActionButtonX.fromStorageValue(
                   appPrefs.leftActionButton,
                 ).label,
@@ -370,7 +395,7 @@ class PlayerLayoutSettingsScreen extends ConsumerWidget {
                   Navigator.of(context).push(
                     MaterialPageRoute<void>(
                       builder: (_) => _ActionButtonPickerScreen(
-                        title: 'Left Button',
+                        title: 'Left (Bottom) Button',
                         currentValue: PlayerActionButtonX.fromStorageValue(
                           appPrefs.leftActionButton,
                         ),
@@ -386,23 +411,23 @@ class PlayerLayoutSettingsScreen extends ConsumerWidget {
               ),
               const SettingsDivider(),
               NavigationSetting(
-                icon: Icons.vertical_align_center_rounded,
-                title: 'Center Button',
+                icon: Icons.arrow_upward_rounded,
+                title: 'Right (Top) Button',
                 subtitle: PlayerActionButtonX.fromStorageValue(
-                  appPrefs.centerActionButton,
+                  appPrefs.rightTopActionButton,
                 ).label,
                 onTap: () {
                   Navigator.of(context).push(
                     MaterialPageRoute<void>(
                       builder: (_) => _ActionButtonPickerScreen(
-                        title: 'Center Button',
+                        title: 'Right (Top) Button',
                         currentValue: PlayerActionButtonX.fromStorageValue(
-                          appPrefs.centerActionButton,
+                          appPrefs.rightTopActionButton,
                         ),
                         onSelected: (action) {
                           ref
                               .read(appPreferencesProvider.notifier)
-                              .setCenterActionButton(action.storageValue);
+                              .setRightTopActionButton(action.storageValue);
                         },
                       ),
                     ),
@@ -412,7 +437,7 @@ class PlayerLayoutSettingsScreen extends ConsumerWidget {
               const SettingsDivider(),
               NavigationSetting(
                 icon: Icons.arrow_forward_rounded,
-                title: 'Right Button',
+                title: 'Right (Bottom) Button',
                 subtitle: PlayerActionButtonX.fromStorageValue(
                   appPrefs.rightActionButton,
                 ).label,
@@ -420,7 +445,7 @@ class PlayerLayoutSettingsScreen extends ConsumerWidget {
                   Navigator.of(context).push(
                     MaterialPageRoute<void>(
                       builder: (_) => _ActionButtonPickerScreen(
-                        title: 'Right Button',
+                        title: 'Right (Bottom) Button',
                         currentValue: PlayerActionButtonX.fromStorageValue(
                           appPrefs.rightActionButton,
                         ),

--- a/lib/models/player_action_button.dart
+++ b/lib/models/player_action_button.dart
@@ -2,6 +2,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/material.dart';
 
 enum PlayerActionButton {
+  none,
   lyrics,
   favorites,
   visualizer,
@@ -17,6 +18,8 @@ enum PlayerActionButton {
 extension PlayerActionButtonX on PlayerActionButton {
   String get storageValue {
     switch (this) {
+      case PlayerActionButton.none:
+        return 'none';
       case PlayerActionButton.lyrics:
         return 'lyrics';
       case PlayerActionButton.favorites:
@@ -42,6 +45,8 @@ extension PlayerActionButtonX on PlayerActionButton {
 
   String get label {
     switch (this) {
+      case PlayerActionButton.none:
+        return 'None';
       case PlayerActionButton.lyrics:
         return 'Lyrics';
       case PlayerActionButton.favorites:
@@ -67,6 +72,8 @@ extension PlayerActionButtonX on PlayerActionButton {
 
   IconData get icon {
     switch (this) {
+      case PlayerActionButton.none:
+        return Icons.block_rounded;
       case PlayerActionButton.lyrics:
         return LucideIcons.fileText;
       case PlayerActionButton.favorites:
@@ -92,6 +99,8 @@ extension PlayerActionButtonX on PlayerActionButton {
 
   static PlayerActionButton fromStorageValue(String? value) {
     switch (value) {
+      case 'none':
+        return PlayerActionButton.none;
       case 'favorites':
         return PlayerActionButton.favorites;
       case 'visualizer':

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -405,10 +405,20 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setRightActionButton(value);
   }
 
-  Future<void> setCenterActionButton(String value) async {
-    if (state.centerActionButton == value) return;
-    state = state.copyWith(centerActionButton: value);
-    await ref.read(appPreferencesServiceProvider).setCenterActionButton(value);
+  Future<void> setLeftTopActionButton(String value) async {
+    if (state.leftTopActionButton == value) return;
+    state = state.copyWith(leftTopActionButton: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setLeftTopActionButton(value);
+  }
+
+  Future<void> setRightTopActionButton(String value) async {
+    if (state.rightTopActionButton == value) return;
+    state = state.copyWith(rightTopActionButton: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setRightTopActionButton(value);
   }
 
   Future<void> setWelcomeCardDismissed(bool value) async {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -53,8 +53,9 @@ class AppPreferences {
   final double widgetCompactTextScale;
   final bool lyricsMatchAudioFilename;
   final String leftActionButton;
-  final String centerActionButton;
   final String rightActionButton;
+  final String leftTopActionButton;
+  final String rightTopActionButton;
   final bool welcomeCardDismissed;
   final bool glanceCardHidden;
   final bool glanceCardMinimized;
@@ -156,8 +157,9 @@ class AppPreferences {
     this.widgetCompactTextScale = 1.0,
     this.lyricsMatchAudioFilename = false,
     this.leftActionButton = 'lyrics',
-    this.centerActionButton = 'equalizer',
     this.rightActionButton = 'favorites',
+    this.leftTopActionButton = 'none',
+    this.rightTopActionButton = 'none',
     this.welcomeCardDismissed = false,
     this.glanceCardHidden = false,
     this.glanceCardMinimized = false,
@@ -260,8 +262,9 @@ class AppPreferences {
     double? widgetCompactTextScale,
     bool? lyricsMatchAudioFilename,
     String? leftActionButton,
-    String? centerActionButton,
     String? rightActionButton,
+    String? leftTopActionButton,
+    String? rightTopActionButton,
     bool? welcomeCardDismissed,
     bool? glanceCardHidden,
     bool? glanceCardMinimized,
@@ -385,8 +388,9 @@ class AppPreferences {
       lyricsMatchAudioFilename:
           lyricsMatchAudioFilename ?? this.lyricsMatchAudioFilename,
       leftActionButton: leftActionButton ?? this.leftActionButton,
-      centerActionButton: centerActionButton ?? this.centerActionButton,
       rightActionButton: rightActionButton ?? this.rightActionButton,
+      leftTopActionButton: leftTopActionButton ?? this.leftTopActionButton,
+      rightTopActionButton: rightTopActionButton ?? this.rightTopActionButton,
       welcomeCardDismissed: welcomeCardDismissed ?? this.welcomeCardDismissed,
       glanceCardHidden: glanceCardHidden ?? this.glanceCardHidden,
       glanceCardMinimized: glanceCardMinimized ?? this.glanceCardMinimized,
@@ -514,8 +518,9 @@ class AppPreferencesService {
   static const _widgetCompactTextScaleKey = 'widget_compact_text_scale';
   static const _lyricsMatchAudioFilenameKey = 'lyrics_match_audio_filename';
   static const _leftActionButtonKey = 'left_action_button';
-  static const _centerActionButtonKey = 'center_action_button';
   static const _rightActionButtonKey = 'right_action_button';
+  static const _leftTopActionButtonKey = 'left_top_action_button';
+  static const _rightTopActionButtonKey = 'right_top_action_button';
   static const _welcomeCardDismissedKey = 'welcome_card_dismissed';
   static const _glanceCardHiddenKey = 'glance_card_hidden';
   static const _glanceCardMinimizedKey = 'glance_card_minimized';
@@ -650,9 +655,11 @@ class AppPreferencesService {
       lyricsMatchAudioFilename:
           prefs.getBool(_lyricsMatchAudioFilenameKey) ?? false,
       leftActionButton: prefs.getString(_leftActionButtonKey) ?? 'lyrics',
-      centerActionButton:
-          prefs.getString(_centerActionButtonKey) ?? 'equalizer',
       rightActionButton: prefs.getString(_rightActionButtonKey) ?? 'favorites',
+      leftTopActionButton:
+          prefs.getString(_leftTopActionButtonKey) ?? 'none',
+      rightTopActionButton:
+          prefs.getString(_rightTopActionButtonKey) ?? 'none',
       welcomeCardDismissed: prefs.getBool(_welcomeCardDismissedKey) ?? false,
       glanceCardHidden: prefs.getBool(_glanceCardHiddenKey) ?? false,
       glanceCardMinimized: prefs.getBool(_glanceCardMinimizedKey) ?? false,
@@ -1188,14 +1195,24 @@ class AppPreferencesService {
     await prefs.setString(_rightActionButtonKey, value);
   }
 
-  Future<String> getCenterActionButton() async {
+  Future<String> getLeftTopActionButton() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_centerActionButtonKey) ?? 'equalizer';
+    return prefs.getString(_leftTopActionButtonKey) ?? 'none';
   }
 
-  Future<void> setCenterActionButton(String value) async {
+  Future<void> setLeftTopActionButton(String value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_centerActionButtonKey, value);
+    await prefs.setString(_leftTopActionButtonKey, value);
+  }
+
+  Future<String> getRightTopActionButton() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_rightTopActionButtonKey) ?? 'none';
+  }
+
+  Future<void> setRightTopActionButton(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_rightTopActionButtonKey, value);
   }
 
   Future<bool> getWelcomeCardDismissed() async {

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -40,26 +40,48 @@ import 'package:flick/services/alac_converter_service.dart';
 import 'package:flick/services/remote_source_service.dart';
 import 'package:flick/core/utils/dev_log.dart';
 
-enum HwVolumeCapability { unknown, supported, unsupported }
-
 /// Volume Control State Machine:
 ///
-/// ┌──────────┐  SET_CUR OK   ┌───────────┐
-/// │ UNKNOWN  │──────────────►│ HARDWARE  │
-/// │          │               │ engine=1.0│
-/// └──────────┘               └─────┬─────┘
-///      │                           │
-///      │ SET_CUR fail              │ GET_CUR mismatch
-///      │                           │ (health check fail)
-///      ▼                           ▼
-/// ┌──────────┐               ┌───────────┐
-/// │ SOFTWARE │◄──────────────│           │
-/// │ engine=V │  fallback     │           │
-/// └──────────┘               └───────────┘
+/// Tier evaluation: [determineVolumeTier] — for the direct USB / DAP
+/// bit-perfect paths it trusts `Uac2DeviceStatus.volumeMode` (computed
+/// natively from `nativeHasRustDirectUsbHardwareVolume()`), the single
+/// authoritative source. [PlayerService] feeds it a lie-detector flag
+/// (`hwVolumeFailed`) when a DAC that claimed hardware volume rejects
+/// writes / fails the GET_CUR health check.
 ///
-/// Reconciliation: [_reconcileVolumeForTier]
-/// Tier evaluation: [_determineCurrentTier]
-enum VolumeTier { hardware, software, system }
+/// Reconciliation: [PlayerService._reconcileVolumeForTier]
+enum VolumeTier { hardware, software, system, unavailable }
+
+/// Pure tier decision for [PlayerService._determineCurrentTier].
+///
+/// - Outside the bit-perfect volume path: Rust → software, else system.
+/// - DoP: only DAC hardware volume (or the opt-in PCM-decimation switch)
+///   can change level — software gain corrupts DoP markers.
+/// - Hardware mode trusted → hardware tier.
+/// - Otherwise engine gain only works on the DSP path; bit-perfect
+///   passthrough must never be scaled → unavailable.
+VolumeTier determineVolumeTier({
+  required bool isBitPerfectVolumePath,
+  required Uac2VolumeMode? volumeMode,
+  required bool hwVolumeFailed,
+  required bool isDoP,
+  required bool autoSwitchDsdForVolume,
+  required bool isPassthrough,
+  required bool usingRustBackend,
+}) {
+  if (!isBitPerfectVolumePath) {
+    return usingRustBackend ? VolumeTier.software : VolumeTier.system;
+  }
+  final hwTrusted = volumeMode == Uac2VolumeMode.hardware && !hwVolumeFailed;
+  if (isDoP) {
+    if (hwTrusted) return VolumeTier.hardware;
+    return autoSwitchDsdForVolume
+        ? VolumeTier.software
+        : VolumeTier.unavailable;
+  }
+  if (hwTrusted) return VolumeTier.hardware;
+  return isPassthrough ? VolumeTier.unavailable : VolumeTier.software;
+}
 
 /// Loop mode for playback
 enum LoopMode {
@@ -381,7 +403,9 @@ class PlayerService {
 
   double get currentVolume => _currentVolume;
 
-  HwVolumeCapability _hwVolumeCap = HwVolumeCapability.unknown;
+  /// Lie-detector: set when a DAC that claimed hardware volume rejects
+  /// writes or fails the GET_CUR health check.
+  bool _hwVolumeFailed = false;
   VolumeTier _activeTier = VolumeTier.system;
 
   // Timer to periodically save position
@@ -577,7 +601,9 @@ class PlayerService {
   }
 
   void _initUsbDacDisconnectHandling() {
-    _usbDacDetachSubscription = _uac2Service.deviceDetachedEvents.listen((_) async {
+    _usbDacDetachSubscription = _uac2Service.deviceDetachedEvents.listen((
+      _,
+    ) async {
       if (!isPlayingNotifier.value) return;
       final enabled = await _appPreferencesService.getPauseOnUsbDacDisconnect();
       if (enabled) pause();
@@ -585,7 +611,9 @@ class PlayerService {
   }
 
   void _initUsbDacAttachHandling() {
-    _usbDacAttachSubscription = _uac2Service.deviceAttachedEvents.listen((_) async {
+    _usbDacAttachSubscription = _uac2Service.deviceAttachedEvents.listen((
+      _,
+    ) async {
       if (!isPlayingNotifier.value) return;
       final enabled = await _appPreferencesService.getPauseOnUsbDacConnect();
       if (enabled) pause();
@@ -597,20 +625,20 @@ class PlayerService {
   /// signed with the platform key, so the post-set verify loop in
   /// [BluetoothService.setCodecConfig] logs the real outcome.
   Future<void> _applyBluetoothCodecPrefs() async {
-    final enabled =
-        await _appPreferencesService.getBtEnableCodecControl();
+    final enabled = await _appPreferencesService.getBtEnableCodecControl();
     if (!enabled) return;
     final codecType = await _appPreferencesService.getBtPreferredCodec();
     if (codecType < 0) return; // automatic; nothing to force
     final devices = await BluetoothService.instance.getConnectedDevices();
-    final preferred = await _appPreferencesService.getPreferredBluetoothDevice();
+    final preferred = await _appPreferencesService
+        .getPreferredBluetoothDevice();
     final target = devices.isEmpty
         ? null
         : (preferred.isNotEmpty
-              ? devices.where((d) => d.address == preferred).firstOrNull
-              : null) ??
-            devices.where((d) => d.isA2dp).firstOrNull ??
-            devices.first;
+                  ? devices.where((d) => d.address == preferred).firstOrNull
+                  : null) ??
+              devices.where((d) => d.isA2dp).firstOrNull ??
+              devices.first;
     if (target == null) return;
     final sampleRate = await _appPreferencesService.getBtSampleRate();
     final bits = codecType == BluetoothCodecType.ldac
@@ -638,11 +666,10 @@ class PlayerService {
     final disconnectTime = _bluetoothDisconnectedAt;
     if (disconnectTime == null) return;
     _bluetoothDisconnectedAt = null;
-    final resumeEnabled =
-        await _appPreferencesService.getResumeOnBluetoothReconnect();
+    final resumeEnabled = await _appPreferencesService
+        .getResumeOnBluetoothReconnect();
     if (!resumeEnabled) return;
-    if (DateTime.now().difference(disconnectTime) >
-        _bluetoothReconnectWindow) {
+    if (DateTime.now().difference(disconnectTime) > _bluetoothReconnectWindow) {
       return;
     }
     if (currentSongNotifier.value == null || isPlayingNotifier.value) return;
@@ -656,8 +683,8 @@ class PlayerService {
   // On Bluetooth connect: pause if opted in (overrides resume-on-reconnect);
   // otherwise fall back to the resume-on-reconnect behaviour.
   Future<void> _maybePauseOnBluetoothConnect() async {
-    final pauseOnConnect =
-        await _appPreferencesService.getPauseOnBluetoothConnect();
+    final pauseOnConnect = await _appPreferencesService
+        .getPauseOnBluetoothConnect();
     if (pauseOnConnect && isPlayingNotifier.value) {
       _bluetoothDisconnectedAt = null;
       _debugLog('[Bluetooth] Connected; pausing due to pause-on-connect pref');
@@ -670,7 +697,8 @@ class PlayerService {
   Future<void> _loadCrossfadePreferences() async {
     final enabled = await _appPreferencesService.getCrossfadeEnabled();
     final duration = await _appPreferencesService.getCrossfadeDurationSecs();
-    _crossfadeCurveIndex = await _appPreferencesService.getCrossfadeCurveIndex();
+    _crossfadeCurveIndex = await _appPreferencesService
+        .getCrossfadeCurveIndex();
     _rustAudioService.crossfadeEnabledNotifier.value = enabled;
     _rustAudioService.crossfadeDurationNotifier.value = duration;
   }
@@ -687,7 +715,7 @@ class PlayerService {
   ///   to keep it in sync after status refreshes.
   void _mirrorUsbVolumeFromUac2Status(Uac2DeviceStatus? status) {
     if (status == null) {
-      _hwVolumeCap = HwVolumeCapability.unknown;
+      _hwVolumeFailed = false;
       unawaited(_reconcileVolumeForTier(_determineCurrentTier()));
       return;
     }
@@ -706,6 +734,7 @@ class PlayerService {
       if (_usingRustBackend && _rustAudioService.isInitialized) {
         unawaited(_rustAudioService.setVolume(_currentVolume));
       }
+      unawaited(_reconcileVolumeForTier(_determineCurrentTier()));
     }
   }
 
@@ -770,7 +799,8 @@ class PlayerService {
     final wasEnabled = _rustAudioService.crossfadeEnabledNotifier.value;
     _rustAudioService.crossfadeEnabledNotifier.value = enabled;
     _rustAudioService.crossfadeDurationNotifier.value = durationSecs;
-    _crossfadeCurveIndex = await _appPreferencesService.getCrossfadeCurveIndex();
+    _crossfadeCurveIndex = await _appPreferencesService
+        .getCrossfadeCurveIndex();
 
     if (_usingRustBackend) {
       await _applyRustPlaybackProcessingPolicy(currentEngineType);
@@ -1205,7 +1235,9 @@ class PlayerService {
     );
   }
 
-  Future<void> setAudioEnginePreference(AudioEnginePreference preference) async {
+  Future<void> setAudioEnginePreference(
+    AudioEnginePreference preference,
+  ) async {
     await _preferencesService.setAudioEnginePreference(preference);
     await initAudio();
     await _sessionManager.syncRouteSelection(
@@ -1430,10 +1462,10 @@ class PlayerService {
           loopModeNotifier.value != LoopMode.all,
       crossfadeConfigProvider: () {
         final curves = AndroidCrossfadeCurve.values;
-        final curve =
-            curves[_crossfadeCurveIndex.clamp(0, curves.length - 1)];
+        final curve = curves[_crossfadeCurveIndex.clamp(0, curves.length - 1)];
         return AndroidCrossfadeConfig(
-          enabled: _rustAudioService.crossfadeEnabledNotifier.value &&
+          enabled:
+              _rustAudioService.crossfadeEnabledNotifier.value &&
               !isBitPerfectProcessingLocked,
           durationSecs: _rustAudioService.crossfadeDurationNotifier.value,
           curve: curve,
@@ -1603,16 +1635,6 @@ class PlayerService {
         a.isNativeDsd == b.isNativeDsd;
   }
 
-  bool _shouldAttemptHardwareVolume() {
-    switch (_hwVolumeCap) {
-      case HwVolumeCapability.unsupported:
-        return false;
-      case HwVolumeCapability.supported:
-      case HwVolumeCapability.unknown:
-        return true;
-    }
-  }
-
   bool get _isDirectUsbPath =>
       Platform.isAndroid &&
       currentEngineType == AudioEngineType.usbDacExperimental;
@@ -1629,32 +1651,44 @@ class PlayerService {
   }
 
   void _onHwVolumeResult(bool success) {
-    _hwVolumeCap = success
-        ? HwVolumeCapability.supported
-        : HwVolumeCapability.unsupported;
+    _hwVolumeFailed = !success;
     unawaited(_reconcileVolumeForTier(_determineCurrentTier()));
   }
 
-  VolumeTier _determineCurrentTier() {
-    // DoP requires hardware volume; software gain corrupts DoP markers
-    // and produces silence at any level other than 100 %.
-    if (isCurrentTrackDoP && _isDirectUsbPath) {
-      return _hwVolumeCap == HwVolumeCapability.unsupported
-          ? VolumeTier.software
-          : VolumeTier.hardware;
-    }
-    if (!isBitPerfectModeEnabled || !_isDirectUsbPath) {
-      return _usingRustBackend ? VolumeTier.software : VolumeTier.system;
-    }
-    switch (_hwVolumeCap) {
-      case HwVolumeCapability.supported:
-        return VolumeTier.hardware;
-      case HwVolumeCapability.unsupported:
-        return VolumeTier.software;
-      case HwVolumeCapability.unknown:
-        return VolumeTier.software;
-    }
+  /// True when the Rust pipeline runs its pure passthrough callback, which
+  /// ignores engine volume entirely (bit-perfect guarantee). EQ/tuning,
+  /// crossfade and pitch force the DSP path, where engine gain works.
+  bool get _isPassthroughActive {
+    final passthrough =
+        audioOutputDiagnosticsNotifier.value?.passthroughAllowed ?? false;
+    if (!passthrough) return false;
+    if (Uac2PreferencesService.is432HzTuningEnabledSync) return false;
+    if (gaplessPlaybackEnabledNotifier.value) return false;
+    if ((playbackSpeedNotifier.value - 1.0).abs() > 0.001) return false;
+    return true;
   }
+
+  /// Bit-perfect volume path: direct USB DAC or DAP internal hi-res engine.
+  bool get _isBitPerfectVolumePath =>
+      isBitPerfectModeEnabled &&
+      (currentEngineType == AudioEngineType.usbDacExperimental ||
+          currentEngineType == AudioEngineType.dapInternalHighRes);
+
+  /// Whether the user can change volume right now. False in bit-perfect
+  /// passthrough when the DAC has no hardware (UAC2 Feature Unit) volume —
+  /// engine gain would corrupt the stream, so the slider must disable.
+  bool get isVolumeAvailable =>
+      _determineCurrentTier() != VolumeTier.unavailable;
+
+  VolumeTier _determineCurrentTier() => determineVolumeTier(
+    isBitPerfectVolumePath: _isBitPerfectVolumePath,
+    volumeMode: _uac2Service.currentDeviceStatus?.volumeMode,
+    hwVolumeFailed: _hwVolumeFailed,
+    isDoP: isCurrentTrackDoP && _isDirectUsbPath,
+    autoSwitchDsdForVolume: Uac2PreferencesService.autoSwitchDsdForVolumeSync,
+    isPassthrough: _isPassthroughActive,
+    usingRustBackend: _usingRustBackend,
+  );
 
   Future<void> _reconcileVolumeForTier(VolumeTier tier) async {
     _activeTier = tier;
@@ -1666,16 +1700,16 @@ class PlayerService {
     if (!_rustAudioService.isInitialized) return;
     switch (tier) {
       case VolumeTier.hardware:
-        // DoP callback ignores engine volume — keep at 1.0.
-        await _rustAudioService.setVolume(
-          isCurrentTrackDoP ? 1.0 : _bitPerfectDefaultVolume,
-        );
+        // DAC Feature Unit is the only volume authority — engine at unity.
+        await _rustAudioService.setVolume(1.0);
         break;
       case VolumeTier.software:
         await _rustAudioService.setVolume(_currentVolume);
         break;
       case VolumeTier.system:
-        await _rustAudioService.setVolume(_bitPerfectDefaultVolume);
+        await _rustAudioService.setVolume(_currentVolume);
+        break;
+      case VolumeTier.unavailable:
         break;
     }
   }
@@ -1854,8 +1888,8 @@ class PlayerService {
     // bitPerfect on USB paths comes from direct USB verification; on internal
     // DAP paths it means passthrough (no DSP) with no resampling — the DSD
     // bitstream or PCM stream reaches the DAC intact.
-    final effectiveBitPerfect = (outputStrategy == 'usb_direct' ||
-            outputStrategy == 'usb_dsd_native')
+    final effectiveBitPerfect =
+        (outputStrategy == 'usb_direct' || outputStrategy == 'usb_dsd_native')
         ? directUsbBitPerfectVerified
         : (usesRustDiagnostics && passthroughAllowed && !resamplerActive);
     final verificationReason =
@@ -2195,7 +2229,10 @@ class PlayerService {
     // Defer the streak popup when a milestone unlocks so the celebration
     // dialog owns the moment; it will fire on the next launch.
     final snoozed = await _milestoneService.isStreakPopupSnoozed();
-    if (milestone == null && !snoozed && streak >= 1 && streakPopupNotifier.value == null) {
+    if (milestone == null &&
+        !snoozed &&
+        streak >= 1 &&
+        streakPopupNotifier.value == null) {
       streakPopupNotifier.value = streak;
     }
   }
@@ -2297,7 +2334,9 @@ class PlayerService {
               autoResumeAfterFallback: !pauseOnDisconnect,
             );
             if (!fellBack) {
-              await _refreshAudioOutputDiagnostics(reason: 'Rust backend error');
+              await _refreshAudioOutputDiagnostics(
+                reason: 'Rust backend error',
+              );
             }
           } finally {
             _midStreamUsbFallbackActive = false;
@@ -2332,7 +2371,8 @@ class PlayerService {
       if (isPlayingNotifier.value != state.isPlaying) {
         isPlayingNotifier.value = state.isPlaying;
       }
-      if (!_suppressPositionUpdatesFromEngine && positionNotifier.value != state.position) {
+      if (!_suppressPositionUpdatesFromEngine &&
+          positionNotifier.value != state.position) {
         positionNotifier.value = state.position;
         if (isAbRepeatActive) {
           checkAbRepeatBoundary(state.position);
@@ -2734,7 +2774,9 @@ class PlayerService {
         sourceKey: sourceKey,
         sourcePath: resolvedPath,
       );
-      _debugLog('[WAV-conv] converted: ${convertedPath ?? "null (fallback to native)"}');
+      _debugLog(
+        '[WAV-conv] converted: ${convertedPath ?? "null (fallback to native)"}',
+      );
       if (convertedPath != null) {
         resolvedPath = convertedPath;
       }
@@ -3167,7 +3209,17 @@ class PlayerService {
       return;
     }
 
+    // The engine can remain in passthrough after bit-perfect is disabled.
+    // Select DSP before sending software volume so the callback applies it.
+    if (!isBitPerfectModeEnabled) {
+      await _rustAudioService.setPipelineModePassthrough(false);
+    }
+
     if (isBitPerfectModeEnabled) {
+      if (playbackMode == AudioEngineType.usbDacExperimental ||
+          playbackMode == AudioEngineType.dapInternalHighRes) {
+        await _rustAudioService.setPipelineModePassthrough(true);
+      }
       await _reconcileVolumeForTier(_determineCurrentTier());
       await _rustAudioService.setPlaybackSpeed(1.0);
       await _rustAudioService.setPitchShiftSemitones(0.0);
@@ -3207,7 +3259,9 @@ class PlayerService {
     }
 
     await reapplyEqualizer();
-    await _rustAudioService.setPitchShiftSemitones(pitchSemitonesNotifier.value);
+    await _rustAudioService.setPitchShiftSemitones(
+      pitchSemitonesNotifier.value,
+    );
     _updatePriorityAnchor();
   }
 
@@ -3329,9 +3383,7 @@ class PlayerService {
     // This prevents USB "Resource busy" from overlapping sessions.
     if (from != to || from == null) {
       if (_rustEngine != null) {
-        _debugLog(
-          '[Engine] Full dispose of Rust engine before ${to.logLabel}',
-        );
+        _debugLog('[Engine] Full dispose of Rust engine before ${to.logLabel}');
         await _disposeUsbEngine();
       }
       if (_justAudioPlayer != null) {
@@ -3841,8 +3893,8 @@ class PlayerService {
     if (advanceIdx >= 0 && advanceIdx < AdvanceListOrder.values.length) {
       _advanceListOrder = AdvanceListOrder.values[advanceIdx];
     }
-    wrapAroundQueueNotifier.value =
-        await _appPreferencesService.getWrapAroundQueue();
+    wrapAroundQueueNotifier.value = await _appPreferencesService
+        .getWrapAroundQueue();
   }
 
   Future<void> restoreLastPlayed() async {
@@ -4418,26 +4470,25 @@ class PlayerService {
     // DoP: software gain corrupts DoP markers (0x05/0xFA).
     // Volume must go through DAC hardware exclusively.
     if (isCurrentTrackDoP && _isDirectUsbPath) {
-      if (_shouldAttemptHardwareVolume()) {
+      final mode = _uac2Service.currentDeviceStatus?.volumeMode;
+      if (mode == Uac2VolumeMode.hardware && !_hwVolumeFailed) {
         _debugLog('[VolFlow] DoP HW path: uac2 setVolume($clampedVolume)');
         final hwOk = await _uac2Service.setVolume(clampedVolume);
         _onHwVolumeResult(hwOk);
+      } else if (Uac2PreferencesService.autoSwitchDsdForVolumeSync &&
+          clampedVolume < 1.0 &&
+          _usingRustBackend &&
+          _rustAudioService.isInitialized) {
+        // Auto-switch to PCM for software volume control.
+        // Pure DoP cannot apply software gain: it corrupts DoP markers
+        // and produces silence/hiss at any level other than 100 %.
+        // The only correct path is to restart the decoder in PCM decimation
+        // mode, where volume works via the normal audio-callback gain loop.
+        await _switchDoPForVolumeTrack(clampedVolume);
       } else {
         _debugLog(
           '[VolFlow] DoP: no hardware volume available — volume unchanged',
         );
-      }
-
-      // Auto-switch to PCM for software volume control.
-      // Pure DoP cannot apply software gain: it corrupts DoP markers
-      // and produces silence/hiss at any level other than 100 %.
-      // The only correct path is to restart the decoder in PCM decimation
-      // mode, where volume works via the normal audio-callback gain loop.
-      if (Uac2PreferencesService.autoSwitchDsdForVolumeSync &&
-          clampedVolume < 1.0 &&
-          _usingRustBackend &&
-          _rustAudioService.isInitialized) {
-        await _switchDoPForVolumeTrack(clampedVolume);
       }
       return;
     }
@@ -4446,10 +4497,14 @@ class PlayerService {
     _activeTier = tier;
     switch (tier) {
       case VolumeTier.hardware:
-        if (_shouldAttemptHardwareVolume()) {
-          _debugLog('[VolFlow] HW path: uac2 setVolume($clampedVolume)');
-          final hwOk = await _uac2Service.setVolume(clampedVolume);
-          _onHwVolumeResult(hwOk);
+        _debugLog('[VolFlow] HW path: uac2 setVolume($clampedVolume)');
+        final hwOk = await _uac2Service.setVolume(clampedVolume);
+        _onHwVolumeResult(hwOk);
+        if (!hwOk && !_isPassthroughActive && _usingRustBackend) {
+          // Lie-detector fallback: DAC claimed hardware volume but rejected
+          // the write — engine gain still works on the DSP path.
+          _debugLog('[VolFlow] HW write failed — falling back to engine gain');
+          await _rustAudioService.setVolume(clampedVolume);
         }
         break;
       case VolumeTier.software:
@@ -4463,6 +4518,11 @@ class PlayerService {
         if (player != null) {
           await player.setVolume(clampedVolume);
         }
+        break;
+      case VolumeTier.unavailable:
+        _debugLog(
+          '[VolFlow] Volume unavailable (bit-perfect passthrough) — ignored',
+        );
         break;
     }
   }
@@ -4840,13 +4900,10 @@ class PlayerService {
 
   void _ensurePositionSaveTimer() {
     _positionSaveTimer?.cancel();
-    _positionSaveTimer = Timer.periodic(
-      const Duration(seconds: 5),
-      (_) {
-        _savePosition();
-        _maybePrefetchNextNetworkSong();
-      },
-    );
+    _positionSaveTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      _savePosition();
+      _maybePrefetchNextNetworkSong();
+    });
   }
 
   /// Last song id handed to [RemoteSourceService.prefetch]. Reset whenever the
@@ -4872,7 +4929,9 @@ class PlayerService {
         loopModeNotifier.value != LoopMode.all) {
       return;
     }
-    final nextIndex = _currentIndex >= _playlist.length - 1 ? 0 : _currentIndex + 1;
+    final nextIndex = _currentIndex >= _playlist.length - 1
+        ? 0
+        : _currentIndex + 1;
     final next = _playlist[nextIndex];
     if (!next.isNetworkSource) return;
     if (next.id == _prefetchedNextSongId) return;

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -329,6 +329,16 @@ class RustAudioService {
     await rust_audio.audioSetVolume(volume: clampedVolume);
   }
 
+  /// Select the callback's base pipeline mode.
+  Future<void> setPipelineModePassthrough(bool enabled) async {
+    if (!_initialized) return;
+    try {
+      rust_audio.audioSetPipelineModePassthrough(enabled: enabled);
+    } catch (e) {
+      devLog('[RustAudio] Failed to set pipeline mode: $e');
+    }
+  }
+
   /// Enable or disable crossfade.
   Future<void> setCrossfade({
     required bool enabled,

--- a/lib/src/rust/api/audio_api.dart
+++ b/lib/src/rust/api/audio_api.dart
@@ -86,6 +86,15 @@ void audioSetDapBitPerfectEnabled({required bool enabled}) => RustLib
     .api
     .crateApiAudioApiAudioSetDapBitPerfectEnabled(enabled: enabled);
 
+/// Set the running Rust callback's base pipeline mode.
+///
+/// This is separate from the DAP preference because direct USB playback can
+/// leave the engine in passthrough after bit-perfect is disabled.
+void audioSetPipelineModePassthrough({required bool enabled}) => RustLib
+    .instance
+    .api
+    .crateApiAudioApiAudioSetPipelineModePassthrough(enabled: enabled);
+
 /// Sync the preferred Android audio API (AAudio / OpenSL ES / Auto) from Dart.
 /// The change is staged on the engine manager and applied on the next engine
 /// (re)initialization — the live stream is reopened when the preference no

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -77,7 +77,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -725233641;
+  int get rustContentHash => 2126244572;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -249,6 +249,8 @@ abstract class RustLibApi extends BaseApi {
     required double ceilingDb,
     required double releaseMs,
   });
+
+  void crateApiAudioApiAudioSetPipelineModePassthrough({required bool enabled});
 
   Future<void> crateApiAudioApiAudioSetPitchShiftSemitones({
     required double semitones,
@@ -1851,6 +1853,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiAudioApiAudioSetPipelineModePassthrough({
+    required bool enabled,
+  }) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_bool(enabled, serializer);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiAudioApiAudioSetPipelineModePassthroughConstMeta,
+        argValues: [enabled],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiAudioSetPipelineModePassthroughConstMeta =>
+      const TaskConstMeta(
+        debugName: "audio_set_pipeline_mode_passthrough",
+        argNames: ["enabled"],
+      );
+
+  @override
   Future<void> crateApiAudioApiAudioSetPitchShiftSemitones({
     required double semitones,
   }) {
@@ -1862,7 +1892,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -1893,7 +1923,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -1924,7 +1954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -1951,7 +1981,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -1978,7 +2008,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2005,7 +2035,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2039,7 +2069,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2069,7 +2099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2096,7 +2126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2123,7 +2153,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2155,7 +2185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2188,7 +2218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2223,7 +2253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2256,7 +2286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2284,7 +2314,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2309,7 +2339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2337,7 +2367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2367,7 +2397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 68,
+              funcId: 69,
               port: port_,
             );
           },
@@ -2406,7 +2436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 69,
+              funcId: 70,
               port: port_,
             );
           },
@@ -2445,7 +2475,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -2475,7 +2505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2507,7 +2537,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2540,7 +2570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -2571,7 +2601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -2602,7 +2632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -2630,7 +2660,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -2657,7 +2687,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -2684,7 +2714,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -2711,7 +2741,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -2738,7 +2768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -2762,7 +2792,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 81)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2787,7 +2817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_uac_2_connection_state,
@@ -2815,7 +2845,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -2842,7 +2872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_uac_2_fallback_info,
@@ -2864,7 +2894,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2886,7 +2916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -2911,7 +2941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_64,
@@ -2936,7 +2966,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -2960,7 +2990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2982,7 +3012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3007,7 +3037,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_uac_2_device_info,
@@ -3035,7 +3065,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -3066,7 +3096,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -3097,7 +3127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3127,7 +3157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3158,7 +3188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3188,7 +3218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -3218,7 +3248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -3250,7 +3280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3287,7 +3317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },

--- a/lib/widgets/uac2/iso_volume_popup.dart
+++ b/lib/widgets/uac2/iso_volume_popup.dart
@@ -62,8 +62,7 @@ class _IsoVolumePopupOverlay extends ConsumerStatefulWidget {
       _IsoVolumePopupOverlayState();
 }
 
-class _IsoVolumePopupOverlayState
-    extends ConsumerState<_IsoVolumePopupOverlay>
+class _IsoVolumePopupOverlayState extends ConsumerState<_IsoVolumePopupOverlay>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animController;
   late final Animation<double> _fadeAnimation;
@@ -90,23 +89,21 @@ class _IsoVolumePopupOverlayState
       reverseCurve: Curves.easeInCubic,
     );
 
-    _scaleAnimation = Tween<double>(
-      begin: 0.85,
-      end: 1.0,
-    ).animate(CurvedAnimation(
-      parent: _animController,
-      curve: Curves.easeOutBack,
-      reverseCurve: Curves.easeInBack,
-    ));
+    _scaleAnimation = Tween<double>(begin: 0.85, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _animController,
+        curve: Curves.easeOutBack,
+        reverseCurve: Curves.easeInBack,
+      ),
+    );
 
-    _slideAnimation = Tween<double>(
-      begin: 12.0,
-      end: 0.0,
-    ).animate(CurvedAnimation(
-      parent: _animController,
-      curve: Curves.easeOutCubic,
-      reverseCurve: Curves.easeInCubic,
-    ));
+    _slideAnimation = Tween<double>(begin: 12.0, end: 0.0).animate(
+      CurvedAnimation(
+        parent: _animController,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      ),
+    );
 
     _animController.forward();
   }
@@ -135,53 +132,36 @@ class _IsoVolumePopupOverlayState
   Future<void> _onSliderChangeEnd(double volume) async {
     setState(() => _draggingVolume = null);
 
-    final notifier = ref.read(uac2DeviceStatusProvider.notifier);
-    final status = ref.read(uac2DeviceStatusProvider);
-    final wasMuted = status?.muted ?? false;
-    final isSoftwareVolume = status?.volumeMode == Uac2VolumeMode.software;
+    final playerService = ref.read(playerServiceProvider);
+    final wasMuted = ref.read(uac2DeviceStatusProvider)?.muted ?? false;
 
     if (wasMuted && volume > 0.0) {
-      await notifier.setMute(false);
+      await ref.read(uac2DeviceStatusProvider.notifier).setMute(false);
     }
     if (!wasMuted && volume == 0.0) {
-      final currentVol = isSoftwareVolume
-          ? ref.read(playerServiceProvider).currentVolume
-          : (status?.volume ?? 1.0);
-      _preMuteVolume = currentVol > 0.0 ? currentVol : 1.0;
-      await notifier.setMute(true);
+      _preMuteVolume = playerService.currentVolume > 0.0
+          ? playerService.currentVolume
+          : 1.0;
+      await ref.read(uac2DeviceStatusProvider.notifier).setMute(true);
     }
-    await notifier.setVolume(volume);
-
-    if (isSoftwareVolume) {
-      await ref.read(playerServiceProvider).setVolume(volume);
-    }
+    await playerService.setVolume(volume);
   }
 
   Future<void> _toggleMute() async {
     final notifier = ref.read(uac2DeviceStatusProvider.notifier);
-    final status = ref.read(uac2DeviceStatusProvider);
-    final currentMuted = status?.muted ?? false;
+    final playerService = ref.read(playerServiceProvider);
+    final currentMuted = ref.read(uac2DeviceStatusProvider)?.muted ?? false;
     final newMuted = !currentMuted;
-    final isSoftwareVolume = status?.volumeMode == Uac2VolumeMode.software;
 
     setState(() => _muteUpdateInFlight = true);
 
     if (newMuted) {
-      _preMuteVolume = (isSoftwareVolume
-              ? ref.read(playerServiceProvider).currentVolume
-              : (status?.volume ?? 1.0))
-          .clamp(0.01, 1.0);
-      final success = await notifier.setMute(true);
-      if (success) await notifier.setVolume(0.0);
-      if (isSoftwareVolume) {
-        await ref.read(playerServiceProvider).setVolume(0.0);
-      }
+      _preMuteVolume = playerService.currentVolume.clamp(0.01, 1.0);
+      await notifier.setMute(true);
+      await playerService.setVolume(0.0);
     } else {
-      await notifier.setVolume(_preMuteVolume);
+      await playerService.setVolume(_preMuteVolume);
       await notifier.setMute(false);
-      if (isSoftwareVolume) {
-        await ref.read(playerServiceProvider).setVolume(_preMuteVolume);
-      }
     }
 
     if (mounted) setState(() => _muteUpdateInFlight = false);
@@ -201,22 +181,29 @@ class _IsoVolumePopupOverlayState
     }
 
     final isSoftwareVolume = deviceStatus.volumeMode == Uac2VolumeMode.software;
-    final playerVolume = ref.read(playerServiceProvider).currentVolume;
-    final effectiveVolume = _draggingVolume ??
-        (isSoftwareVolume ? playerVolume : (deviceStatus.volume ?? 1.0));
+    final playerService = ref.read(playerServiceProvider);
+    final isAvailable = playerService.isVolumeAvailable;
+    final playerVolume = playerService.currentVolume;
+    final effectiveVolume =
+        _draggingVolume ??
+        ((isSoftwareVolume || !isAvailable)
+            ? playerVolume
+            : (deviceStatus.volume ?? playerVolume));
     final effectiveMuted = deviceStatus.muted ?? false;
     final volumeControlWritable =
-        deviceStatus.volumeControlWritable && !_muteUpdateInFlight;
-    final showDb = isSoftwareVolume ||
-        deviceStatus.volumeMode == Uac2VolumeMode.hardware;
+        deviceStatus.volumeControlWritable &&
+        isAvailable &&
+        !_muteUpdateInFlight;
+    final showDb =
+        isSoftwareVolume || deviceStatus.volumeMode == Uac2VolumeMode.hardware;
 
     final isLeft = widget.buttonPosition.dx < widget.screenSize.width / 2;
     final popupLeft = isLeft ? widget.buttonPosition.dx : null;
     final popupRight = isLeft
         ? null
         : (widget.screenSize.width -
-            widget.buttonPosition.dx -
-            widget.buttonSize.width);
+              widget.buttonPosition.dx -
+              widget.buttonSize.width);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -244,7 +231,9 @@ class _IsoVolumePopupOverlayState
                       height: 260,
                       decoration: BoxDecoration(
                         color: AppColors.surface.withValues(alpha: 0.92),
-                        borderRadius: BorderRadius.circular(AppConstants.radiusLg),
+                        borderRadius: BorderRadius.circular(
+                          AppConstants.radiusLg,
+                        ),
                         border: Border.all(color: AppColors.glassBorder),
                       ),
                       child: Column(
@@ -255,10 +244,14 @@ class _IsoVolumePopupOverlayState
                             height: 44,
                             child: IconButton(
                               icon: Icon(
-                                effectiveMuted ? LucideIcons.volumeX : LucideIcons.volume2,
+                                effectiveMuted
+                                    ? LucideIcons.volumeX
+                                    : LucideIcons.volume2,
                                 size: 18,
                               ),
-                              onPressed: volumeControlWritable ? _toggleMute : null,
+                              onPressed: volumeControlWritable
+                                  ? _toggleMute
+                                  : null,
                               color: effectiveMuted
                                   ? Colors.red.shade400
                                   : context.adaptiveTextPrimary,
@@ -280,12 +273,15 @@ class _IsoVolumePopupOverlayState
                                 label: showDb
                                     ? '${(effectiveVolume * 100).round()}%  ${_volumeToDb(effectiveVolume)} dB'
                                     : '${(effectiveVolume * 100).round()}%',
-                                onChanged: volumeControlWritable ? _onSliderChanged : null,
-                                onChangeEnd:
-                                    volumeControlWritable ? _onSliderChangeEnd : null,
+                                onChanged: volumeControlWritable
+                                    ? _onSliderChanged
+                                    : null,
+                                onChangeEnd: volumeControlWritable
+                                    ? _onSliderChangeEnd
+                                    : null,
                                 activeColor: AppColors.accent,
-                                inactiveColor:
-                                    AppColors.textTertiary.withValues(alpha: 0.3),
+                                inactiveColor: AppColors.textTertiary
+                                    .withValues(alpha: 0.3),
                               ),
                             ),
                           ),
@@ -295,14 +291,15 @@ class _IsoVolumePopupOverlayState
                                 ? '${(effectiveVolume * 100).round()}%\n${_volumeToDb(effectiveVolume)} dB'
                                 : '${(effectiveVolume * 100).round()}%',
                             textAlign: TextAlign.center,
-                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
                                   color: context.adaptiveTextSecondary,
                                   fontWeight: FontWeight.w500,
                                   fontSize: 10,
                                   height: 1.2,
                                 ),
                           ),
-                          if (!deviceStatus.volumeControlWritable) ...[
+                          if (!volumeControlWritable) ...[
                             const SizedBox(height: 2),
                             Icon(
                               LucideIcons.lock,

--- a/lib/widgets/uac2/uac2_volume_control.dart
+++ b/lib/widgets/uac2/uac2_volume_control.dart
@@ -44,59 +44,43 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
     setState(() => _draggingVolume = volume);
   }
 
-  /// Called when the user lifts the finger — commits the value to the platform.
-  /// For software volume mode, also syncs to PlayerService so that
-  /// [_currentVolume] stays in sync with the slider.
+  /// Called when the user lifts the finger — commits the value to the
+  /// platform. PlayerService.setVolume is the single entry point; it routes
+  /// to the DAC Feature Unit (hardware), the engine (software/DSP) or drops
+  /// the write when volume is unavailable (bit-perfect passthrough).
   Future<void> _onSliderChangeEnd(double volume) async {
     setState(() => _draggingVolume = null);
 
-    final notifier = ref.read(uac2DeviceStatusProvider.notifier);
-    final status = ref.read(uac2DeviceStatusProvider);
-    final wasMuted = status?.muted ?? false;
-    final isSoftwareVolume = status?.volumeMode == Uac2VolumeMode.software;
+    final playerService = ref.read(playerServiceProvider);
+    final wasMuted = ref.read(uac2DeviceStatusProvider)?.muted ?? false;
 
     if (wasMuted && volume > 0.0) {
-      await notifier.setMute(false);
+      await ref.read(uac2DeviceStatusProvider.notifier).setMute(false);
     }
     if (!wasMuted && volume == 0.0) {
-      final currentVol = isSoftwareVolume
-          ? ref.read(playerServiceProvider).currentVolume
-          : (status?.volume ?? 1.0);
-      _preMuteVolume = currentVol > 0.0 ? currentVol : 1.0;
-      await notifier.setMute(true);
+      _preMuteVolume = playerService.currentVolume > 0.0
+          ? playerService.currentVolume
+          : 1.0;
+      await ref.read(uac2DeviceStatusProvider.notifier).setMute(true);
     }
-    await notifier.setVolume(volume);
-
-    if (isSoftwareVolume) {
-      await ref.read(playerServiceProvider).setVolume(volume);
-    }
+    await playerService.setVolume(volume);
   }
 
   Future<void> _toggleMute() async {
     final notifier = ref.read(uac2DeviceStatusProvider.notifier);
-    final status = ref.read(uac2DeviceStatusProvider);
-    final currentMuted = status?.muted ?? false;
+    final playerService = ref.read(playerServiceProvider);
+    final currentMuted = ref.read(uac2DeviceStatusProvider)?.muted ?? false;
     final newMuted = !currentMuted;
-    final isSoftwareVolume = status?.volumeMode == Uac2VolumeMode.software;
 
     setState(() => _muteUpdateInFlight = true);
 
     if (newMuted) {
-      _preMuteVolume = (isSoftwareVolume
-              ? ref.read(playerServiceProvider).currentVolume
-              : (status?.volume ?? 1.0))
-          .clamp(0.01, 1.0);
-      final success = await notifier.setMute(true);
-      if (success) await notifier.setVolume(0.0);
-      if (isSoftwareVolume) {
-        await ref.read(playerServiceProvider).setVolume(0.0);
-      }
+      _preMuteVolume = playerService.currentVolume.clamp(0.01, 1.0);
+      await notifier.setMute(true);
+      await playerService.setVolume(0.0);
     } else {
-      await notifier.setVolume(_preMuteVolume);
+      await playerService.setVolume(_preMuteVolume);
       await notifier.setMute(false);
-      if (isSoftwareVolume) {
-        await ref.read(playerServiceProvider).setVolume(_preMuteVolume);
-      }
     }
 
     if (mounted) setState(() => _muteUpdateInFlight = false);
@@ -113,24 +97,27 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
     }
 
     final isSoftwareVolume = deviceStatus.volumeMode == Uac2VolumeMode.software;
-    final playerVolume = ref.read(playerServiceProvider).currentVolume;
-    final effectiveVolume = _draggingVolume ??
-        (isSoftwareVolume ? playerVolume : (deviceStatus.volume ?? 1.0));
+    final playerService = ref.read(playerServiceProvider);
+    final isAvailable = playerService.isVolumeAvailable;
+    final playerVolume = playerService.currentVolume;
+    final effectiveVolume =
+        _draggingVolume ??
+        ((isSoftwareVolume || !isAvailable)
+            ? playerVolume
+            : (deviceStatus.volume ?? playerVolume));
     final effectiveMuted = deviceStatus.muted ?? false;
     final volumeControlWritable =
-        deviceStatus.volumeControlWritable && !_muteUpdateInFlight;
-    final showDb = isSoftwareVolume ||
-        deviceStatus.volumeMode == Uac2VolumeMode.hardware;
+        deviceStatus.volumeControlWritable &&
+        isAvailable &&
+        !_muteUpdateInFlight;
+    final showDb =
+        isSoftwareVolume || deviceStatus.volumeMode == Uac2VolumeMode.hardware;
 
     final useGradient = widget.useGradientBackground;
-    final gradientColors = widget.gradientColors ??
-        const [
-          Color(0xFF194B68),
-          Color(0xFF0C1624),
-          Color(0xFF1D2A19),
-        ];
-    final labelColor =
-        useGradient ? Colors.white : context.adaptiveTextPrimary;
+    final gradientColors =
+        widget.gradientColors ??
+        const [Color(0xFF194B68), Color(0xFF0C1624), Color(0xFF1D2A19)];
+    final labelColor = useGradient ? Colors.white : context.adaptiveTextPrimary;
     final subLabelColor = useGradient
         ? Colors.white.withValues(alpha: 0.7)
         : context.adaptiveTextSecondary;
@@ -149,9 +136,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                 stops: const [0.0, 0.56, 1.0],
               )
             : null,
-        color: useGradient
-            ? null
-            : AppColors.surface.withValues(alpha: 0.6),
+        color: useGradient ? null : AppColors.surface.withValues(alpha: 0.6),
         borderRadius: BorderRadius.circular(AppConstants.radiusLg),
         border: Border.all(
           color: useGradient
@@ -164,11 +149,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
         children: [
           Row(
             children: [
-              Icon(
-                LucideIcons.volume2,
-                color: subLabelColor,
-                size: 20,
-              ),
+              Icon(LucideIcons.volume2, color: subLabelColor, size: 20),
               const SizedBox(width: AppConstants.spacingSm),
               Expanded(
                 child: Column(
@@ -188,9 +169,9 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                       Text(
                         deviceStatus.routeLabel!,
                         overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: tertiaryColor,
-                        ),
+                        style: Theme.of(
+                          context,
+                        ).textTheme.bodySmall?.copyWith(color: tertiaryColor),
                       ),
                   ],
                 ),
@@ -201,9 +182,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                   size: 20,
                 ),
                 onPressed: volumeControlWritable ? _toggleMute : null,
-                color: effectiveMuted
-                    ? Colors.red.shade400
-                    : subLabelColor,
+                color: effectiveMuted ? Colors.red.shade400 : subLabelColor,
                 tooltip: effectiveMuted ? 'Unmute' : 'Mute',
               ),
             ],
@@ -211,11 +190,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
           const SizedBox(height: AppConstants.spacingSm),
           Row(
             children: [
-              Icon(
-                LucideIcons.volume1,
-                color: tertiaryColor,
-                size: 16,
-              ),
+              Icon(LucideIcons.volume1, color: tertiaryColor, size: 16),
               Expanded(
                 child: Slider(
                   value: effectiveVolume,
@@ -235,11 +210,7 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                       : AppColors.textTertiary.withValues(alpha: 0.3),
                 ),
               ),
-              Icon(
-                LucideIcons.volume2,
-                color: tertiaryColor,
-                size: 16,
-              ),
+              Icon(LucideIcons.volume2, color: tertiaryColor, size: 16),
               const SizedBox(width: AppConstants.spacingSm),
               SizedBox(
                 width: showDb ? 82 : 40,
@@ -256,13 +227,23 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
               ),
             ],
           ),
-          if (!deviceStatus.volumeControlWritable) ...[
+          if (!isAvailable) ...[
+            const SizedBox(height: AppConstants.spacingXs),
+            Text(
+              'Volume is fixed while bit-perfect passthrough is active: '
+              'the stream is sent untouched and this DAC has no hardware '
+              'volume control.',
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: tertiaryColor),
+            ),
+          ] else if (!deviceStatus.volumeControlWritable) ...[
             const SizedBox(height: AppConstants.spacingXs),
             Text(
               'Hardware volume is detected, but writes stay blocked while live direct USB playback is active.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: tertiaryColor,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: tertiaryColor),
             ),
           ],
         ],

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -706,6 +706,15 @@ pub fn audio_set_dap_bit_perfect_enabled(enabled: bool) {
     let _ = enabled;
 }
 
+/// Set the running Rust callback's base pipeline mode.
+///
+/// This is separate from the DAP preference because direct USB playback can
+/// leave the engine in passthrough after bit-perfect is disabled.
+#[flutter_rust_bridge::frb(sync)]
+pub fn audio_set_pipeline_mode_passthrough(enabled: bool) -> Result<(), String> {
+    with_audio_engine(|handle| handle.set_pipeline_mode_passthrough(enabled))
+}
+
 /// Sync the preferred Android audio API (AAudio / OpenSL ES / Auto) from Dart.
 /// The change is staged on the engine manager and applied on the next engine
 /// (re)initialization — the live stream is reopened when the preference no

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -2441,10 +2441,11 @@ pub(crate) fn audio_callback(
         return;
     }
 
-    // No EQ, no dynamics, no speed, no crossfade. Gain is applied for
-    // volume control (a no-op when DAC hardware volume is available).
+    // Passthrough: raw samples from decoder straight to output. Volume is
+    // intentionally never applied here — bit-perfect means the DAC (UAC2
+    // hardware volume) is the only volume authority. Software gain would
+    // corrupt the stream.
     if data.is_passthrough() {
-        let gain = data.get_gain();
         let mut sources = match data.sources.try_lock() {
             Some(s) => s,
             None => {
@@ -2459,9 +2460,6 @@ pub(crate) fn audio_callback(
         }
         if read < output.len() {
             output[read..].fill(0.0);
-        }
-        for sample in output[..read].iter_mut() {
-            *sample *= gain;
         }
         return;
     }
@@ -2869,10 +2867,16 @@ fn command_processing_loop(
                         } else {
                             PipelineMode::Dsp
                         };
-                        callback_data.set_pipeline_mode(mode);
                         callback_data
                             .base_pipeline_mode
                             .store(mode as u8, Ordering::Relaxed);
+                        // Keep an active DoP stream in DoP mode. The new base
+                        // mode is restored when the raw override ends.
+                        if callback_data.pipeline_mode.load(Ordering::Relaxed)
+                            != PipelineMode::Dop as u8
+                        {
+                            callback_data.set_pipeline_mode(mode);
+                        }
                     }
                     AudioCommand::SetDopOverride { is_dop } => {
                         if is_dop {
@@ -3361,11 +3365,27 @@ mod tests {
     }
 
     #[test]
-    fn callback_passthrough_applies_volume() {
+    fn callback_passthrough_ignores_volume() {
         let data = build_passthrough_callback_data(48_000, 2);
         let input = vec![0.0, 0.25, -0.5, 0.5, -0.25, 0.0, 1.0, -1.0];
 
         data.set_volume(0.25);
+        data.sources
+            .lock()
+            .set_current(build_source(&input, 48_000, 2));
+
+        let output = run_callback(&data, input.len());
+
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn callback_applies_volume_after_switching_to_dsp() {
+        let data = build_passthrough_callback_data(48_000, 2);
+        let input = vec![0.5, -0.5, 0.25, -0.25];
+
+        data.set_volume(0.25);
+        data.set_pipeline_mode(PipelineMode::Dsp);
         data.sources
             .lock()
             .set_current(build_source(&input, 48_000, 2));
@@ -3398,21 +3418,6 @@ mod tests {
         let output = run_callback(&data, 8);
 
         assert_eq!(output, vec![0.0; 8]);
-    }
-
-    #[test]
-    fn callback_passthrough_passthrough_at_volume_1() {
-        let data = build_passthrough_callback_data(48_000, 2);
-        let input = vec![0.0, 0.25, -0.5, 0.5, -0.25, 0.0, 1.0, -1.0];
-
-        data.set_volume(1.0);
-        data.sources
-            .lock()
-            .set_current(build_source(&input, 48_000, 2));
-
-        let output = run_callback(&data, input.len());
-
-        assert_eq!(output, input);
     }
 
     #[test]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -725233641;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2126244572;
 
 // Section: executor
 
@@ -1700,6 +1700,37 @@ fn wire__crate__api__audio_api__audio_set_limiter_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__audio_api__audio_set_pipeline_mode_passthrough_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "audio_set_pipeline_mode_passthrough",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_enabled = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok =
+                    crate::api::audio_api::audio_set_pipeline_mode_passthrough(api_enabled)?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -4438,157 +4469,159 @@ fn pde_ffi_dispatcher_primary_impl(
         50 => {
             wire__crate__api__audio_api__audio_set_limiter_impl(port, ptr, rust_vec_len, data_len)
         }
-        51 => wire__crate__api__audio_api__audio_set_pitch_shift_semitones_impl(
+        52 => wire__crate__api__audio_api__audio_set_pitch_shift_semitones_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__audio_api__audio_set_playback_speed_impl(
+        53 => wire__crate__api__audio_api__audio_set_playback_speed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
-        55 => {
+        54 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
+        56 => {
             wire__crate__api__audio_api__audio_skip_to_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
-        57 => {
+        57 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
+        58 => {
             wire__crate__api__scanner__check_deleted_paths_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
+        59 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        59 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
+        60 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
+        61 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__scanner__discover_playlist_files_impl(
+        62 => wire__crate__api__scanner__discover_playlist_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
+        63 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
+        64 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__scanner__extract_embedded_artwork_impl(
+        65 => wire__crate__api__scanner__extract_embedded_artwork_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
-        71 => {
+        67 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
+        72 => {
             wire__crate__api__audio_api__set_dsd_track_rate_impl(port, ptr, rust_vec_len, data_len)
         }
-        72 => wire__crate__api__audio_api__set_pending_crossfade_impl(
+        73 => wire__crate__api__audio_api__set_pending_crossfade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
+        74 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        74 => {
+        75 => {
             wire__crate__api__audio_api__set_pending_volume_impl(port, ptr, rust_vec_len, data_len)
         }
-        75 => wire__crate__api__audio_api__take_pending_crossfade_impl(
+        76 => wire__crate__api__audio_api__take_pending_crossfade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        76 => {
+        77 => {
             wire__crate__api__audio_api__take_pending_volume_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
+        78 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        78 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
+        79 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        79 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
+        80 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        80 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
+        81 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        88 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
+        89 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        92 => {
+        93 => {
             wire__crate__api__uac2_api__uac2_select_device_impl(port, ptr, rust_vec_len, data_len)
         }
-        93 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
+        94 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        94 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
+        95 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        96 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        97 => {
+        97 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        98 => {
             wire__crate__api__uac2_api__uac2_start_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        98 => {
+        99 => {
             wire__crate__api__uac2_api__uac2_stop_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        99 => wire__crate__api__metadata_editor__write_tags_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
+        100 => {
+            wire__crate__api__metadata_editor__write_tags_impl(port, ptr, rust_vec_len, data_len)
+        }
+        101 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
             port,
             ptr,
             rust_vec_len,
@@ -4695,28 +4728,33 @@ fn pde_ffi_dispatcher_sync_impl(
         49 => {
             wire__crate__api__audio_api__audio_set_high_res_mode_impl(ptr, rust_vec_len, data_len)
         }
-        65 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
+        51 => wire__crate__api__audio_api__audio_set_pipeline_mode_passthrough_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        82 => {
+        66 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        83 => {
             wire__crate__api__uac2_api__uac2_get_connection_state_impl(ptr, rust_vec_len, data_len)
         }
-        84 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
+        85 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        87 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
-        90 => {
+        88 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
+        91 => {
             wire__crate__api__uac2_api__uac2_is_usb_session_active_impl(ptr, rust_vec_len, data_len)
         }
-        91 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -4533,7 +4533,27 @@ fn run_usb_render_loop(
             continue;
         }
 
-        if playback_format.is_dop || playback_format.dsd_transport == DsdTransportMode::Native {
+        let is_raw_bitstream =
+            playback_format.is_dop || playback_format.dsd_transport == DsdTransportMode::Native;
+
+        // ponytail: direct-USB runs the engine in Passthrough, so audio_callback
+        // returns raw decoder samples WITHOUT applying engine gain. Apply it here
+        // for the PCM path so DACs without UAC2 HW volume get audible software
+        // gain. When HW volume is active, _reconcileVolumeForTier pins engine
+        // gain to 1.0, so this is a no-op (bit-perfect preserved). DSP-mode
+        // (tuning/crossfade/pitch) makes is_passthrough() false and audio_callback
+        // already applied gain, so we skip to avoid double-apply. Raw DSD/DoP
+        // bitstreams are skipped to avoid corrupting framing markers.
+        if !is_raw_bitstream && callback_data.is_passthrough() {
+            let gain = callback_data.get_gain();
+            if gain != 1.0 {
+                for sample in render_buffer.iter_mut() {
+                    *sample *= gain;
+                }
+            }
+        }
+
+        if is_raw_bitstream {
             for (dst, src) in pcm_samples.iter_mut().zip(render_buffer.iter()) {
                 *dst = src.to_bits() as i32;
             }

--- a/test/services/player_service_volume_tier_test.dart
+++ b/test/services/player_service_volume_tier_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/services/player_service.dart';
+import 'package:flick/services/uac2_service.dart';
+
+VolumeTier tier({
+  bool bitPerfectPath = true,
+  Uac2VolumeMode? mode,
+  bool hwFailed = false,
+  bool dop = false,
+  bool autoSwitch = false,
+  bool passthrough = true,
+  bool rust = true,
+}) => determineVolumeTier(
+  isBitPerfectVolumePath: bitPerfectPath,
+  volumeMode: mode,
+  hwVolumeFailed: hwFailed,
+  isDoP: dop,
+  autoSwitchDsdForVolume: autoSwitch,
+  isPassthrough: passthrough,
+  usingRustBackend: rust,
+);
+
+void main() {
+  group('determineVolumeTier', () {
+    test('non-bit-perfect path maps Rust to software, else system', () {
+      expect(tier(bitPerfectPath: false, rust: true), VolumeTier.software);
+      expect(tier(bitPerfectPath: false, rust: false), VolumeTier.system);
+    });
+
+    test('hardware mode is trusted unless the lie-detector fired', () {
+      expect(tier(mode: Uac2VolumeMode.hardware), VolumeTier.hardware);
+      expect(
+        tier(mode: Uac2VolumeMode.hardware, hwFailed: true),
+        VolumeTier.unavailable,
+      );
+    });
+
+    test('no DAC hardware volume: DSP path keeps software gain', () {
+      expect(
+        tier(mode: Uac2VolumeMode.software, passthrough: false),
+        VolumeTier.software,
+      );
+      expect(
+        tier(mode: Uac2VolumeMode.unavailable, passthrough: false),
+        VolumeTier.software,
+      );
+    });
+
+    test('bit-perfect passthrough with no hardware volume is unavailable', () {
+      expect(tier(mode: Uac2VolumeMode.software), VolumeTier.unavailable);
+      expect(tier(mode: Uac2VolumeMode.unavailable), VolumeTier.unavailable);
+      expect(tier(mode: null), VolumeTier.unavailable);
+    });
+
+    test('DoP requires hardware volume or the PCM auto-switch', () {
+      expect(
+        tier(dop: true, mode: Uac2VolumeMode.hardware),
+        VolumeTier.hardware,
+      );
+      expect(
+        tier(dop: true, mode: Uac2VolumeMode.software),
+        VolumeTier.unavailable,
+      );
+      expect(
+        tier(dop: true, mode: Uac2VolumeMode.software, autoSwitch: true),
+        VolumeTier.software,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Refactor player action buttons from center action to left-top and right-top button pairs with none option and sleep timer toggle
- Add `audio_set_pipeline_mode_passthrough` API for bit-perfect direct-USB passthrough PCM playback
- Refactor volume tier system: replace `HwVolumeCapability` enum with `determineVolumeTier()` pure function and unavailable tier with lie-detector flag
- Add tests for volume tier determination logic
- Route volume control through `PlayerService` and consolidate iso volume popup logic

# Changes

## Player Action Buttons

- Add `none` option to `PlayerActionButton` enum
- Add left-top and right-top action buttons with player layout settings reorganization
- Refactor player action buttons to top/bottom pairs
- Add `leftTopAction` and `rightTopAction` to player provider
- Add sleep timer toggle to action button pairs
- Replace center action button with left and right top action buttons in full player screen
- Update player layout settings screen (45 lines) and layout sheet (22 lines)

## Bit-Perfect Passthrough

- Add `audio_set_pipeline_mode_passthrough` API function in Rust audio engine
- Apply software gain in direct-USB passthrough PCM path, then make passthrough bit-perfect by removing software gain
- Add `setPipelineModePassthrough` method to `RustAudioService`
- Add `audioSetPipelineModePassthrough` to Dart audio API with funcIds and FFI bindings
- Update FRB generated code

## Volume Tier System

- Replace `HwVolumeCapability` enum with `determineVolumeTier()` pure function
- Add unavailable tier and `_hwVolumeFailed` lie-detector flag
- Add tests for `determineVolumeTier` logic (70 lines)
- Refactor volume control to route through `PlayerService` (287 lines changed)
- Refactor iso volume popup to consolidate volume/mute logic through `playerService` (135 lines)

## Files Changed

- `lib/providers/app_preferences_provider.dart`
- `lib/providers/player_provider.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/player_service.dart`
- `lib/services/rust_audio_service.dart`
- `lib/models/player_action_button.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/player/widgets/player_action_button_row.dart`
- `lib/features/player/widgets/player_layout_sheet.dart`
- `lib/features/player/widgets/sleep_timer_bottom_sheet.dart`
- `lib/features/settings/screens/player_layout_settings_screen.dart`
- `lib/widgets/uac2/uac2_volume_control.dart`
- `lib/widgets/uac2/iso_volume_popup.dart`
- `lib/src/rust/api/audio_api.dart`
- `lib/src/rust/frb_generated.dart`
- `rust/src/api/audio_api.rs`
- `rust/src/audio/engine.rs`
- `rust/src/uac2/android_direct.rs`
- `rust/src/frb_generated.rs`
- `test/services/player_service_volume_tier_test.dart`