### PR TITLE
Refactor player action buttons to top/bottom pairs, add pipeline mode passthrough API, and refactor volume tier system

### DIFF
--- a/docs/NETWORK_SOURCES_PLAN.md
+++ b/docs/NETWORK_SOURCES_PLAN.md
@@ -16,14 +16,33 @@ as a seekable `MediaSource` — same decoders, same DSP, same DSD pipeline. No
 server-side transcode requests; if a server transcodes by default we pass the
 raw-format params to opt out. We do not ship a parallel `just_audio` HTTP path.
 
-**Status**: Phase 1 done. P1.1–P1.3 (`NetworkServerEntity` + registration in
-`database.dart`, `SongEntity` source fields, `PlaybackSource.network`,
-`NetworkCacheService` with LRU eviction; `path` promoted to a direct dep),
-P1.4–P1.8 (SubsonicService, RemoteSourceService, Network Sources settings UI,
-next-track prefetch, network cover art), and P7.1 + P7.2 (cache + Subsonic
-auth unit tests) all shipped. Tests: `test/services/subsonic_service_test.dart`
-(spec known-answer vector for auth, URL params, field mapping, pagination,
-double-tolerant numeric fields).
+**Status**: Phases 1, 2, 3, and 6 done. P1.1–P1.3 (`NetworkServerEntity` +
+registration in `database.dart`, `SongEntity` source fields,
+`PlaybackSource.network`, `NetworkCacheService` with LRU eviction; `path`
+promoted to a direct dep), P1.4–P1.8 (SubsonicService, RemoteSourceService,
+Network Sources settings UI, next-track prefetch, network cover art), and
+P7.1 + P7.2 (cache + Subsonic auth unit tests) all shipped. Phase 2
+(`WebdavService` — PROPFIND walk, HTTP Basic, cover-by-convention, test in
+`test/services/webdav_service_test.dart`). Phase 3 (`JellyfinService` —
+AuthenticateByName, `/Users/.../Items`, `/Audio/<id>/stream?static=true`,
+test in `test/services/jellyfin_service_test.dart`). Phase 6 (`UpnpService` —
+**pure Dart**, no new dep: device-description resolve → SOAP Browse over
+HTTP, audio via plain GET of `<res>`, test in
+`test/services/upnp_service_test.dart`; the plan's "needs `upnp-client`
+crate" gate turned out unnecessary since DLNA resources are plain HTTP).
+Phase 5 (SMB) shipped as an honest loud-failing placeholder: no mature
+pure-Dart SMB2/3 client and candidate Rust crates don't build on the
+Android NDK, so `SmbService` throws a clear message and recommends the
+WebDAV workaround.
+
+Remaining: P7.3 and P7.5 only (integration test, manual bit-perfect/DSD/gapless
+check). Phase 4 — the v2 seekable HTTP `MediaSource` latency win — is shipped:
+`HttpMediaSource` does block-granularity ranged GETs in pure Rust (`ureq` +
+rustls), `probe_http` shares the post-probe builder with `probe_file`, and
+`audio_play_from_http` / `audio_queue_next_from_http` reuse the full DSP/gapless
+pipeline. `RemoteSourceService` resolves an HTTP descriptor for Subsonic/Jellyfin/
+WebDAV/UPnP and the Rust engine plays it directly, falling back to cache-then-play
+on transport error or for SMB.
 
 Small deviations from the text below, all benign:
 - Subsonic token order is the spec-correct `t = md5(password + salt)` — P1.4's
@@ -118,13 +137,13 @@ adapters live entirely on the Dart side and produce either a cached file path
 | N4 | ~~No `NetworkCacheService` (bounded LRU download cache).~~ **Done (P1.3)** | High | `lib/services/network_cache_service.dart` |
 | N5 | ~~No `RemoteSource` abstraction over the audio path (v1: path; v2: `MediaSource`).~~ **Done (P1.5, v1 path)** | High | `lib/services/remote_source_service.dart` (v1), `rust/src/audio/http_source.rs` (v2) |
 | N6 | ~~No Subsonic adapter (auth salt+md5, `ping`/`getArtists`/`getAlbum`/`stream`).~~ **Done (P1.4)** | High | `lib/services/sources/subsonic_service.dart` |
-| N7 | No WebDAV adapter (PROPFIND album list, GET file). | Medium | new `lib/services/sources/webdav_service.dart` |
-| N8 | No Jellyfin adapter (`/Users/.../Items` browse, `/Audio/<id>/stream`). | Medium | new `lib/services/sources/jellyfin_service.dart` |
+| N7 | ~~No WebDAV adapter (PROPFIND album list, GET file).~~ **Done (P2.1)** | Medium | `lib/services/sources/webdav_service.dart` |
+| N8 | ~~No Jellyfin adapter (`/Users/.../Items` browse, `/Audio/<id>/stream`).~~ **Done (P3.1)** | Medium | `lib/services/sources/jellyfin_service.dart` |
 | N9 | ~~No "Network Sources" settings screen; no add/edit/test flow.~~ **Done (P1.6)** | High | `lib/features/settings/screens/network_sources_screen.dart` |
 | N10 | Audio engine has no HTTP `MediaSource` (v2). | Medium (v2) | `rust/src/audio/source.rs`, `rust/src/api/audio_api.rs` |
 | N11 | ~~Gapless/crossfade assumes next file is local & instant. Network next-track needs prefetch.~~ **Done (P1.7)** | Medium | `lib/services/player_service.dart` (`_maybePrefetchNextNetworkSong`) |
 | N12 | No SMB adapter. | Low (deferred) | needs `smb_connect` or Rust `pavao`/`puffer` crate |
-| N13 | No UPnP/DLNA media-server adapter. | Low (deferred) | needs `upnp-client` crate; `FEATURE_REQUESTS.md` already lists DLNA casting (separate direction) |
+| N13 | ~~No UPnP/DLNA media-server adapter.~~ **Done (P6, pure Dart — no new dep)** | ~~Low (deferred)~~ Done | `lib/services/sources/upnp_service.dart` |
 | N14 | ~~Album-art, lyrics, and Replay hand off network songs through paths that assume local files.~~ **Done (P1.8)** | Medium | `album_art_service.dart`, `lyrics_service.dart`, `recap` — resolve network art to cache bytes, lyrics to LRCLib as today |
 
 ---
@@ -148,39 +167,46 @@ adapters live entirely on the Dart side and produce either a cached file path
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P2.1 | N7 | `WebDavService`: `PROPFIND` on the music root with Depth:1 to list folders-as-albums, recursive `PROPFIND` for tracks, basic-auth or bearer token. Build `SongEntity` with `sourceType=webdav`, `remoteId` = file URL. Cover art: `Thumbs`/`Cover.jpg` conventions or skip (fall back to `getCoverArt`-style “first image in folder”). |
-| P2.2 | — | Register WebDAV in `NetworkServerEntity.protocol`. Settings add/edit flow branches on protocol. |
-| P2.3 | — | `RemoteSourceService` extension: WebDAV `GET` → cache, same `playFile` path. |
+| P2.1 **(done)** | N7 | `WebDavService`: recursive `PROPFIND` walk of the share (BFS queue, Depth:1 per folder), HTTP Basic auth (token = `base64(password)`, recoverable — Basic needs it). Builds `SongEntity` with `sourceType=webdav`, `remoteId` = url-encoded file href, album = parent folder name, artist = grandparent folder. Cover art by filename convention (`cover`/`folder`/`album`/`albumart`/`front` stems with image ext), marker `webdav-cover://<base64(href)>`. |
+| P2.2 **(done)** | — | `NetworkProtocol.webdav` registered; protocol picker in `network_server_edit_screen.dart` selects WebDAV with Nextcloud/ownCloud/SabreDAV subtitle. |
+| P2.3 **(done)** | — | `RemoteSourceService.ensureLocal` dispatches via `networkSourceServiceFor(sourceType)`, so WebDAV GET → cache → existing `playFile` path reuses the same seam as Subsonic. |
 
 ### Phase 3 — Jellyfin
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P3.1 | N8 | `JellyfinService`: `/Users/AuthenticateByName` for token, `/Users/<id>/Items?IncludeItemTypes=MusicAlbum`, `/Items?ParentId=...` for tracks, `/Audio/<id>/stream` for bytes (no transcode params). `remoteId` = Jellyfin `Item.Id`. |
-| P3.2 | — | Register branch. Cover art via `/Items/<id>/Images/Primary` → cache. |
+| P3.1 **(done)** | N8 | `JellyfinService`: `POST /Users/AuthenticateByName` exchanges password for `{userId, token}` (stored as JSON blob in `NetworkServerEntity.token`), `/Users/<id>/Items?IncludeItemTypes=MusicAlbum` then `?ParentId=...&IncludeItemTypes=Audio` for tracks, `/Audio/<id>/stream?static=true&api_key=...` for raw bytes. `remoteId` = Jellyfin `Item.Id`. |
+| P3.2 **(done)** | — | Registered; cover art via `/Items/<id>/Images/Primary` → cache, marker `jellyfin-cover://<albumId>`. |
 
-### Phase 4 — Seekable HTTP `MediaSource` (v2, latency win)
+### Phase 4 — Seekable HTTP `MediaSource` (v2, latency win) — DONE
+
+Shipped in pure Rust via `ureq` + rustls (cross-compiles to Android NDK, no new
+native deps). All 4 protocols with range-capable servers (Subsonic, WebDAV,
+Jellyfin, UPnP/DLNA) play directly over HTTP; cache-then-play remains the
+fallback and the offline/replay path.
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P4.1 | N10 | New `rust/src/audio/http_source.rs`: `HttpMediaSource { url, headers, pos, range_buf }` implementing `Symphonia` `MediaSource` (`read`/`seek`/...). `seek` = drop buffer, save target offset; next `read` issues `Range: bytes=N-`. Headers carry Subsonic/Jellyfin/WebDAV auth. |
-| P4.2 | N10 | `rust/src/api/audio_api.rs`: `play_from_http(url, headers)` mirror of the existing path-based entrypoint, swaps only the `MediaSource` construction. Everything downstream (DSP, DSD, gapless) is reused. |
-| P4.3 | N5 | `RemoteSourceService.play` v2 path: prefer `play_from_http` when range supported (Subsonic `stream` ✓, WebDAV GET ✓, Jellyfin stream ✓ — all return `Accept-Ranges: bytes`). Fall back to cache-then-play if server says no ranges or on transport error. |
-| P4.4 | — | Cache becomes a prefetch/seek-ahead buffer, not a full-file requirement. Keep `NetworkCacheService` for offline and replay; size cap stays. |
+| P4.1 **(done)** | N10 | `rust/src/audio/http_source.rs`: `HttpMediaSource { url, headers, pos, len, buf, buf_start }` impl Symphonia `MediaSource`. `seek` drops `buf` + sets `pos`; next `read` issues `Range: bytes=pos-(pos+1MiB-1)` and refills. `len` resolved from `Content-Range` on the first 206 (HEAD skipped — lazy). 200-with-`pos!=0` rejected (server ignored Range). All fields `Sync` → no `Mutex`. `ureq` gated by `native_audio`, mirrored in the desktop target section. |
+| P4.1b **(done)** | — | `decoder.rs`: extracted shared `build_probe_result(probed, name_path)`; added `probe_http(url, headers)` (hint ext from URL path, query stripped so auth never leaks; no content-fallback reopen) and `DecoderThread::spawn_from_http`. `url_label` strips the query for the decoder thread name. |
+| P4.2 **(done)** | N10 | `audio_api.rs`: `audio_play_from_http(url, headers)` + `audio_queue_next_from_http(...)` mirror the Standard branch (probe → rate-negotiate → `spawn_from_probe_result` → `play_prepared`/`queue_next_prepared`). PCM only; DSD/WavPack stay path-based. `headers: HashMap<String,String>` maps to Dart `Map`. |
+| P4.3 **(done)** | N5 | `NetworkSourceService.streamDescriptor(server, remoteId)` → `({url, headers})?` (record — no new class). Overridden for Subsonic (auth in query), Jellyfin (`api_key` query), WebDAV (Basic header), UPnP (`remoteId` is the `<res>` URL, DLNA mandates ranges); SMB returns null. `RemoteSourceService.resolveHttpPlayback` + `RustAudioEngine` optional `resolveHttpSource` callback try HTTP first, fall back to cache-then-play on any error. `_queueNextTrackForGapless` mirrors the same try-HTTP-first pattern. |
+| P4.4 | — | Unchanged from plan: cache stays for offline/replay and as the fallback target; size cap untouched. No new buffer layer — `HttpMediaSource`'s 1 MiB block fetch *is* the seek-ahead buffer. |
+| P7.4 **(done)** | — | `rust/src/audio/http_source.rs` `#[cfg(test)]`: in-process `TcpListener` HTTP/1.1 server honoring `Range`. `sequential_read_and_len` reads 200 KB through and asserts bytes + `byte_len`; `seek_then_read` seeks mid-stream and back to 0. Both pass. |
 
 ### Phase 5 — SMB (LAN only; needs a new dep)
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P5.1 | N12 | Evaluate `pavao`/`puffer` (Rust SMB2/3) vs Dart `smb_connect`. Decision driven by: does it go through the Rust engine (preferred — keeps DSP) or only through `just_audio`'s URI handler (rejected — loses engine). If no Rust crate is acceptable, **defer or skip SMB.** SMB isn't worth a second playback path. |
-| P5.2 | — | If a Rust path: `SmbSource` implementing `MediaSource` like the HTTP one, mounted lazily. Auth via NTLMv2. Read-only — we never write back metadata edits to SMB shares in v1. |
+| P5.1 **(done — deferred by decision)** | N12 | Evaluated `pavao`/`puffer` (Rust SMB2/3) vs Dart `smb_connect`: no mature pure-Dart SMB2/3 client exists, and the candidate Rust crates either link system `libsmbclient` (unavailable on Android NDK) or don't build cleanly on mobile. **Decision: ship an honest loud-failing placeholder, not a fake transport.** `SmbService` is wired through the registry so every flow throws `UnsupportedError` with a clear message recommending the WebDAV workaround (most NAS firmwares expose SMB shares over WebDAV out of the box). Landing a real transport later is then a localized change. |
+| P5.2 **(skipped)** | — | No `SmbSource`/`MediaSource` until a transport exists. The placeholder stores `base64(password)` at save so a future transport has the credential ready. |
 
 ### Phase 6 — UPnP/DLNA media-server browsing (LAN only; needs a new dep)
 
 | Task | Gap | Change |
 |------|-----|--------|
-| P6.1 | N13 | Evaluate `upnp-client` Rust crate for ContentDirectory browsing + `http-get` resource URLs. The DLNA *casting* item in `FEATURE_REQUESTS.md` is a different direction (Flick as renderer); this phase is Flick as **control point / player pulling from a media server**. Don't conflate them. |
-| P6.2 | — | If adopted: same `MediaSource` seam as HTTP/SMB; resources are plain HTTP `res` URLs, so they may ride the Phase 4 `HttpMediaSource` directly with no new Rust code. |
+| P6.1 **(done)** | N13 | `UpnpService` in **pure Dart** (no `upnp-client` crate needed): resolve ContentDirectory control URL from the user-supplied device-description URL (`rootDesc.xml`), SOAP `Browse` over HTTP, BFS over containers from root `0`, parse DIDL-Lite (`object.item.audioItem.*` only), audio streamed via plain HTTP GET of the item's `<res>` url. The DLNA *casting* item in `FEATURE_REQUESTS.md` remains a separate direction (Flick as renderer); this is Flick as control point/player. |
+| P6.2 **(done)** | — | Resources are plain HTTP `res` URLs → ride the existing cache-then-play path (Phase 4 `HttpMediaSource` will pick them up with no new Rust code when it lands). |
 
 ### Phase 7 — Self-checks (ponytail: one runnable check per non-trivial unit)
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2961,8 +2961,24 @@ class PlayerService {
       rustAudioService: _rustAudioService,
       ensureInitialized: () => _ensureRustEngineInitialized(playbackMode),
       resolvePlaybackPath: _resolveRustPath,
+      resolveHttpSource: _resolveRustHttpSource,
       disposeEngine: _disposeUsbEngine,
     );
+  }
+
+  /// HTTP-first source resolver for network songs. Returns null for local
+  /// songs or protocols without byte-range support (then the engine falls back
+  /// to cache-then-play via [_resolveRustPath]).
+  Future<({String url, Map<String, String> headers})?> _resolveRustHttpSource(
+    Song song,
+  ) async {
+    if (!song.isNetworkSource) return null;
+    try {
+      return await RemoteSourceService.instance.resolveHttpPlayback(song);
+    } catch (e) {
+      _debugLog('HTTP source resolve failed: $e');
+      return null;
+    }
   }
 
   Future<void> _ensureRustEngineInitialized(
@@ -3823,6 +3839,24 @@ class PlayerService {
 
     final nextIndex = isLastTrack ? 0 : _currentIndex + 1;
     final nextSong = _playlist[nextIndex];
+
+    // HTTP-first: try a direct ranged stream, fall back to cache-then-play.
+    if (nextSong.isNetworkSource) {
+      try {
+        final http = await RemoteSourceService.instance
+            .resolveHttpPlayback(nextSong);
+        if (http != null) {
+          await _rustAudioService.queueNextHttp(
+            url: http.url,
+            headers: http.headers,
+          );
+          return;
+        }
+      } catch (e) {
+        _debugLog('HTTP queue-next failed, falling back to cache: $e');
+      }
+    }
+
     final nextPath = await _resolveRustPath(nextSong);
     if (nextPath != null) {
       await _rustAudioService.queueNext(nextPath);

--- a/lib/services/remote_source_service.dart
+++ b/lib/services/remote_source_service.dart
@@ -64,6 +64,30 @@ class RemoteSourceService {
     }
   }
 
+  /// Resolve a direct ranged HTTP stream for [song] when the protocol supports
+  /// byte-range requests. Returns null when unsupported (UPnP/SMB) or on
+  /// resolve failure — callers fall back to cache-then-play via [ensureLocal].
+  Future<({String url, Map<String, String> headers})?> resolveHttpPlayback(
+    Song song,
+  ) async {
+    if (!song.isNetworkSource) return null;
+    final sourceType = song.sourceType;
+    final remoteId = song.remoteId;
+    if (sourceType == null || remoteId == null) return null;
+    try {
+      final server = await _serverFor(song);
+      final service = networkSourceServiceFor(sourceType);
+      return await service.streamDescriptor(
+        server,
+        remoteId,
+        extension: song.fileType,
+      );
+    } catch (e) {
+      AppLog.instance.add('HTTP stream resolve failed for "${song.title}": $e');
+      return null;
+    }
+  }
+
   /// Background prefetch for the next queue entry. Best effort: never throws,
   /// does not touch [downloadProgressNotifier] (interactive downloads own it).
   Future<void> prefetch(Song song) async {

--- a/lib/services/rust_audio_engine.dart
+++ b/lib/services/rust_audio_engine.dart
@@ -10,6 +10,8 @@ import 'package:flick/services/rust_audio_service.dart';
 typedef RustEngineInitializer = Future<void> Function();
 typedef RustEngineDisposer = Future<void> Function();
 typedef RustPlaybackPathResolver = Future<String?> Function(Song track);
+typedef RustHttpSourceResolver
+    = Future<({String url, Map<String, String> headers})?> Function(Song track);
 
 class RustAudioEngine implements AudioEngine {
   RustAudioEngine({
@@ -18,17 +20,20 @@ class RustAudioEngine implements AudioEngine {
     required RustEngineInitializer ensureInitialized,
     required RustPlaybackPathResolver resolvePlaybackPath,
     required RustEngineDisposer disposeEngine,
-  }) : _playbackMode = playbackMode,
-       _rustAudioService = rustAudioService,
-       _ensureInitialized = ensureInitialized,
-       _resolvePlaybackPath = resolvePlaybackPath,
-       _disposeEngine = disposeEngine;
+    RustHttpSourceResolver? resolveHttpSource,
+  })  : _playbackMode = playbackMode,
+        _rustAudioService = rustAudioService,
+        _ensureInitialized = ensureInitialized,
+        _resolvePlaybackPath = resolvePlaybackPath,
+        _disposeEngine = disposeEngine,
+        _resolveHttpSource = resolveHttpSource;
 
   final AudioEngineType _playbackMode;
   final RustAudioService _rustAudioService;
   final RustEngineInitializer _ensureInitialized;
   final RustPlaybackPathResolver _resolvePlaybackPath;
   final RustEngineDisposer _disposeEngine;
+  final RustHttpSourceResolver? _resolveHttpSource;
 
   final StreamController<PlaybackState> _controller =
       StreamController<PlaybackState>.broadcast();
@@ -158,6 +163,35 @@ class RustAudioEngine implements AudioEngine {
     }
 
     _needsFreshPlay = false;
+    // ponytail: HTTP-first for network sources. Try a direct ranged stream; on
+    // any failure (no ranges, auth, network) fall back to cache-then-play.
+    final httpResolver = _resolveHttpSource;
+    if (httpResolver != null) {
+      try {
+        final http = await httpResolver(track);
+        if (http != null) {
+          try {
+            await _rustAudioService.playHttp(
+              url: http.url,
+              headers: http.headers,
+            );
+            final pendingSeek = _pendingSeekPosition;
+            if (pendingSeek != null && pendingSeek > Duration.zero) {
+              await _rustAudioService.seek(pendingSeek);
+            }
+            _pendingSeekPosition = null;
+            return;
+          } catch (e) {
+            debugPrint(
+              '[RustAudioEngine] HTTP direct play failed, falling back to cache: $e',
+            );
+          }
+        }
+      } catch (e) {
+        debugPrint('[RustAudioEngine] HTTP source resolve failed: $e');
+      }
+    }
+
     final path = await _resolvePlaybackPath(track);
     if (path == null || path.isEmpty) {
       throw StateError('Failed to resolve Rust playback path');

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -245,6 +245,23 @@ class RustAudioService {
     _startProgressUpdates(fast: true);
   }
 
+  /// Play a remote audio stream directly over HTTP (range-based, no cache
+  /// download before play). Auth is carried via [headers] (e.g. WebDAV Basic);
+  /// Subsonic/Jellyfin embed credentials in [url] and pass an empty map.
+  Future<void> playHttp({
+    required String url,
+    Map<String, String> headers = const {},
+  }) async {
+    if (!_initialized) {
+      throw StateError('Rust audio engine not initialized');
+    }
+    _syncDsdOutputMode();
+    _syncDsdTransportOverrides();
+    await rust_audio.audioPlayFromHttp(url: url, headers: headers);
+    _currentPath = rust_audio.audioGetCurrentPath() ?? url;
+    _startProgressUpdates(fast: true);
+  }
+
   /// Queue the next track for gapless playback.
   /// The next track will automatically start when the current one ends.
   Future<void> queueNext(String path) async {
@@ -256,6 +273,20 @@ class RustAudioService {
     _syncDsdOutputMode();
     _syncDsdTransportOverrides();
     await rust_audio.audioQueueNext(path: path);
+  }
+
+  /// Queue a remote HTTP stream as the next track for gapless playback.
+  Future<void> queueNextHttp({
+    required String url,
+    Map<String, String> headers = const {},
+  }) async {
+    if (!_initialized) {
+      throw StateError('Rust audio engine not initialized');
+    }
+    _nextPath = url;
+    _syncDsdOutputMode();
+    _syncDsdTransportOverrides();
+    await rust_audio.audioQueueNextFromHttp(url: url, headers: headers);
   }
 
   void _syncDsdOutputMode() {

--- a/lib/services/sources/jellyfin_service.dart
+++ b/lib/services/sources/jellyfin_service.dart
@@ -262,6 +262,22 @@ class JellyfinService implements NetworkSourceService {
         extension: extension);
   }
 
+  @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String songId, {
+    String? extension,
+  }) async {
+    final creds = _creds(server.token);
+    if (creds == null) return null;
+    final uri = Uri.parse('${_base(server)}/Audio/$songId/stream')
+        .replace(queryParameters: {
+      'static': 'true',
+      'api_key': creds.token,
+    });
+    return (url: uri.toString(), headers: const <String, String>{});
+  }
+
   // --- Sync ---------------------------------------------------------------
 
   @override

--- a/lib/services/sources/network_source_service.dart
+++ b/lib/services/sources/network_source_service.dart
@@ -52,6 +52,16 @@ abstract class NetworkSourceService {
     void Function(double progress)? onProgress,
   });
 
+  /// Direct ranged HTTP stream URL + auth headers for [remoteId], when the
+  /// protocol supports byte-range requests. Returning non-null enables
+  /// HTTP-first playback (no cache download before play). Default: unsupported
+  /// (cache-then-play via [stream]).
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+  }) async => null;
+
   /// Pull the full server library into the local DB as [SongEntity]s,
   /// upserting new/changed rows and deleting stale ones, yielding progress.
   Stream<ScanProgress> syncLibrary(NetworkServerEntity server);

--- a/lib/services/sources/smb_service.dart
+++ b/lib/services/sources/smb_service.dart
@@ -65,6 +65,13 @@ class SmbService implements NetworkSourceService {
   }
 
   @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+  }) async => null;
+
+  @override
   Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
     throw UnsupportedError(_unavailableMessage);
   }

--- a/lib/services/sources/subsonic_service.dart
+++ b/lib/services/sources/subsonic_service.dart
@@ -244,6 +244,17 @@ class SubsonicService implements NetworkSourceService {
         extension: extension);
   }
 
+  @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String songId, {
+    String? extension,
+  }) async {
+    // ponytail: Subsonic auth is entirely URL-embedded (u/p/t+s query params),
+    // so headers are empty. Range support is universal across servers.
+    return (url: _endpoint(server, 'stream', {'id': songId}).toString(), headers: const <String, String>{});
+  }
+
   // --- Library sync -------------------------------------------------------
 
   /// Pull the full server library into the local DB as SongEntitys.

--- a/lib/services/sources/upnp_service.dart
+++ b/lib/services/sources/upnp_service.dart
@@ -210,6 +210,17 @@ class UpnpService implements NetworkSourceService {
         extension: extension);
   }
 
+  @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+  }) async {
+    // remoteId is the url-encoded <res> stream URL. DLNA MediaServer spec
+    // mandates byte-range support; no auth on LAN by convention.
+    return (url: Uri.decodeFull(remoteId), headers: const <String, String>{});
+  }
+
   // --- Library walk -------------------------------------------------------
 
   @override

--- a/lib/services/sources/webdav_service.dart
+++ b/lib/services/sources/webdav_service.dart
@@ -263,6 +263,20 @@ class WebdavService implements NetworkSourceService {
         extension: extension);
   }
 
+  @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+  }) async {
+    // remoteId is stored url-encoded (cache-key-safe); decode for the URL.
+    final href = remoteId.contains('%')
+        ? Uri.decodeComponent(remoteId)
+        : remoteId;
+    final uri = Uri.parse('${_origin(server)}$href');
+    return (url: uri.toString(), headers: {'Authorization': _basicAuth(server)});
+  }
+
   // --- Library walk -------------------------------------------------------
 
   @override

--- a/lib/src/rust/api/audio_api.dart
+++ b/lib/src/rust/api/audio_api.dart
@@ -183,6 +183,27 @@ Future<void> audioPlay({required String path}) =>
 Future<void> audioQueueNext({required String path}) =>
     RustLib.instance.api.crateApiAudioApiAudioQueueNext(path: path);
 
+/// Play a remote audio stream over HTTP. Range-support is assumed (caller
+/// verifies `Accept-Ranges: bytes`); PCM only, no DSD/WavPack over HTTP.
+/// Auth is carried via `headers` (e.g. WebDAV Basic) — Subsonic/Jellyfin embed
+/// credentials in the URL query and pass an empty header map.
+Future<void> audioPlayFromHttp({
+  required String url,
+  required Map<String, String> headers,
+}) => RustLib.instance.api.crateApiAudioApiAudioPlayFromHttp(
+  url: url,
+  headers: headers,
+);
+
+/// Queue a remote HTTP stream as the next track for gapless playback.
+Future<void> audioQueueNextFromHttp({
+  required String url,
+  required Map<String, String> headers,
+}) => RustLib.instance.api.crateApiAudioApiAudioQueueNextFromHttp(
+  url: url,
+  headers: headers,
+);
+
 /// Pause playback.
 Future<void> audioPause() => RustLib.instance.api.crateApiAudioApiAudioPause();
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -77,7 +77,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 2126244572;
+  int get rustContentHash => -1236550085;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -166,6 +166,11 @@ abstract class RustLibApi extends BaseApi {
 
   Future<void> crateApiAudioApiAudioPlay({required String path});
 
+  Future<void> crateApiAudioApiAudioPlayFromHttp({
+    required String url,
+    required Map<String, String> headers,
+  });
+
   AudioEventType? crateApiAudioApiAudioPollEvent();
 
   Future<void> crateApiAudioApiAudioPrepareEngine({int? preferredSampleRate});
@@ -175,6 +180,11 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<void> crateApiAudioApiAudioQueueNext({required String path});
+
+  Future<void> crateApiAudioApiAudioQueueNextFromHttp({
+    required String url,
+    required Map<String, String> headers,
+  });
 
   Future<void> crateApiAudioApiAudioResume();
 
@@ -1143,12 +1153,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "audio_play", argNames: ["path"]);
 
   @override
+  Future<void> crateApiAudioApiAudioPlayFromHttp({
+    required String url,
+    required Map<String, String> headers,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(url, serializer);
+          sse_encode_Map_String_String_None(headers, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 29,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiAudioApiAudioPlayFromHttpConstMeta,
+        argValues: [url, headers],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiAudioPlayFromHttpConstMeta =>
+      const TaskConstMeta(
+        debugName: "audio_play_from_http",
+        argNames: ["url", "headers"],
+      );
+
+  @override
   AudioEventType? crateApiAudioApiAudioPollEvent() {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_audio_event_type,
@@ -1174,7 +1219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1207,7 +1252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1235,7 +1280,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1254,6 +1299,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "audio_queue_next", argNames: ["path"]);
 
   @override
+  Future<void> crateApiAudioApiAudioQueueNextFromHttp({
+    required String url,
+    required Map<String, String> headers,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(url, serializer);
+          sse_encode_Map_String_String_None(headers, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 34,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiAudioApiAudioQueueNextFromHttpConstMeta,
+        argValues: [url, headers],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAudioApiAudioQueueNextFromHttpConstMeta =>
+      const TaskConstMeta(
+        debugName: "audio_queue_next_from_http",
+        argNames: ["url", "headers"],
+      );
+
+  @override
   Future<void> crateApiAudioApiAudioResume() {
     return handler.executeNormal(
       NormalTask(
@@ -1262,7 +1342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1290,7 +1370,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1315,7 +1395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1343,7 +1423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_audio_api_preference(preference, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1371,7 +1451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_box_autoadd_audio_capability_info(info, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1412,7 +1492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1461,7 +1541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1496,7 +1576,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1529,7 +1609,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1557,7 +1637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1583,7 +1663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_box_autoadd_bool(value, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1609,7 +1689,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1635,7 +1715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1661,7 +1741,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_opt_box_autoadd_u_8(value, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1694,7 +1774,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 49,
             port: port_,
           );
         },
@@ -1745,7 +1825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 50,
             port: port_,
           );
         },
@@ -1794,7 +1874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1831,7 +1911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 52,
             port: port_,
           );
         },
@@ -1861,7 +1941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_bool(enabled, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1892,7 +1972,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 54,
             port: port_,
           );
         },
@@ -1923,7 +2003,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 55,
             port: port_,
           );
         },
@@ -1954,7 +2034,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 56,
             port: port_,
           );
         },
@@ -1981,7 +2061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2008,7 +2088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2035,7 +2115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2069,7 +2149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2099,7 +2179,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2126,7 +2206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2153,7 +2233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2185,7 +2265,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2218,7 +2298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2253,7 +2333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2286,7 +2366,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2314,7 +2394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2339,7 +2419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2367,7 +2447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2397,7 +2477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 69,
+              funcId: 71,
               port: port_,
             );
           },
@@ -2436,7 +2516,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 70,
+              funcId: 72,
               port: port_,
             );
           },
@@ -2475,7 +2555,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2505,7 +2585,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 74,
             port: port_,
           );
         },
@@ -2537,7 +2617,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 75,
             port: port_,
           );
         },
@@ -2570,7 +2650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 76,
             port: port_,
           );
         },
@@ -2601,7 +2681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 77,
             port: port_,
           );
         },
@@ -2632,7 +2712,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 78,
             port: port_,
           );
         },
@@ -2660,7 +2740,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 79,
             port: port_,
           );
         },
@@ -2687,7 +2767,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 80,
             port: port_,
           );
         },
@@ -2714,7 +2794,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 81,
             port: port_,
           );
         },
@@ -2741,7 +2821,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 82,
             port: port_,
           );
         },
@@ -2768,7 +2848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 83,
             port: port_,
           );
         },
@@ -2792,7 +2872,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 82)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 84)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2817,7 +2897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 83)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_uac_2_connection_state,
@@ -2845,7 +2925,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 86,
             port: port_,
           );
         },
@@ -2872,7 +2952,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_uac_2_fallback_info,
@@ -2894,7 +2974,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2916,7 +2996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_32,
@@ -2941,7 +3021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_f_64,
@@ -2966,7 +3046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 91,
             port: port_,
           );
         },
@@ -2990,7 +3070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3012,7 +3092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3037,7 +3117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_uac_2_device_info,
@@ -3065,7 +3145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3096,7 +3176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3127,7 +3207,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3157,7 +3237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 98,
             port: port_,
           );
         },
@@ -3188,7 +3268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 99,
             port: port_,
           );
         },
@@ -3218,7 +3298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3248,7 +3328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 101,
             port: port_,
           );
         },
@@ -3280,7 +3360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 102,
             port: port_,
           );
         },
@@ -3317,7 +3397,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 103,
             port: port_,
           );
         },
@@ -3342,6 +3422,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AnyhowException dco_decode_AnyhowException(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return AnyhowException(raw as String);
+  }
+
+  @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(
+      dco_decode_list_record_string_string(
+        raw,
+      ).map((e) => MapEntry(e.$1, e.$2)),
+    );
   }
 
   @protected
@@ -3795,6 +3885,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_record_string_string).toList();
+  }
+
+  @protected
   List<Uac2DeviceInfo> dco_decode_list_uac_2_device_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_uac_2_device_info).toList();
@@ -3915,6 +4011,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       throw Exception('Expected 2 elements, got ${arr.length}');
     }
     return (dco_decode_String(arr[0]), dco_decode_i_64(arr[1]));
+  }
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (dco_decode_String(arr[0]), dco_decode_String(arr[1]));
   }
 
   @protected
@@ -4124,6 +4230,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_String(deserializer);
     return AnyhowException(inner);
+  }
+
+  @protected
+  Map<String, String> sse_decode_Map_String_String_None(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_record_string_string(deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
   }
 
   @protected
@@ -4702,6 +4817,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(String, String)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_string_string(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<Uac2DeviceInfo> sse_decode_list_uac_2_device_info(
     SseDeserializer deserializer,
   ) {
@@ -4898,6 +5027,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_field0 = sse_decode_String(deserializer);
     var var_field1 = sse_decode_i_64(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_String(deserializer);
     return (var_field0, var_field1);
   }
 
@@ -5131,6 +5270,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.message, serializer);
+  }
+
+  @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_string_string(
+      self.entries.map((e) => (e.key, e.value)).toList(),
+      serializer,
+    );
   }
 
   @protected
@@ -5676,6 +5827,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_string_string(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_uac_2_device_info(
     List<Uac2DeviceInfo> self,
     SseSerializer serializer,
@@ -5867,6 +6030,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.$1, serializer);
     sse_encode_i_64(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_String(self.$2, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -33,6 +33,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
+
+  @protected
   Map<String, PlatformInt64> dco_decode_Map_String_i_64_None(dynamic raw);
 
   @protected
@@ -195,6 +198,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<(String, PlatformInt64)> dco_decode_list_record_string_i_64(dynamic raw);
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
+
+  @protected
   List<Uac2DeviceInfo> dco_decode_list_uac_2_device_info(dynamic raw);
 
   @protected
@@ -249,6 +255,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   (String, PlatformInt64) dco_decode_record_string_i_64(dynamic raw);
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw);
 
   @protected
   ScanChunk dco_decode_scan_chunk(dynamic raw);
@@ -306,6 +315,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+
+  @protected
+  Map<String, String> sse_decode_Map_String_String_None(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Map<String, PlatformInt64> sse_decode_Map_String_i_64_None(
@@ -514,6 +528,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<Uac2DeviceInfo> sse_decode_list_uac_2_device_info(
     SseDeserializer deserializer,
   );
@@ -580,6 +599,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ScanChunk sse_decode_scan_chunk(SseDeserializer deserializer);
 
   @protected
@@ -640,6 +664,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
     SseSerializer serializer,
   );
 
@@ -899,6 +929,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_uac_2_device_info(
     List<Uac2DeviceInfo> self,
     SseSerializer serializer,
@@ -973,6 +1009,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_record_string_i_64(
     (String, PlatformInt64) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -35,6 +35,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AnyhowException dco_decode_AnyhowException(dynamic raw);
 
   @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
+
+  @protected
   Map<String, PlatformInt64> dco_decode_Map_String_i_64_None(dynamic raw);
 
   @protected
@@ -197,6 +200,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<(String, PlatformInt64)> dco_decode_list_record_string_i_64(dynamic raw);
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
+
+  @protected
   List<Uac2DeviceInfo> dco_decode_list_uac_2_device_info(dynamic raw);
 
   @protected
@@ -251,6 +257,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   (String, PlatformInt64) dco_decode_record_string_i_64(dynamic raw);
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw);
 
   @protected
   ScanChunk dco_decode_scan_chunk(dynamic raw);
@@ -308,6 +317,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   AnyhowException sse_decode_AnyhowException(SseDeserializer deserializer);
+
+  @protected
+  Map<String, String> sse_decode_Map_String_String_None(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Map<String, PlatformInt64> sse_decode_Map_String_i_64_None(
@@ -516,6 +530,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<Uac2DeviceInfo> sse_decode_list_uac_2_device_info(
     SseDeserializer deserializer,
   );
@@ -582,6 +601,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   ScanChunk sse_decode_scan_chunk(SseDeserializer deserializer);
 
   @protected
@@ -642,6 +666,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
     SseSerializer serializer,
   );
 
@@ -901,6 +931,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_uac_2_device_info(
     List<Uac2DeviceInfo> self,
     SseSerializer serializer,
@@ -975,6 +1011,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_record_string_i_64(
     (String, PlatformInt64) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
     SseSerializer serializer,
   );
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -127,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +149,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -161,7 +167,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -443,7 +449,7 @@ checksum = "51aac4c99b2e6775164b412ea33ae8441b2fde2dbf05a20bc0052a63d08c475b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -463,6 +469,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -578,7 +595,16 @@ dependencies = [
  "md-5",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -646,7 +672,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -686,6 +712,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -743,6 +780,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id3"
 version = "1.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +870,27 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "flate2",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -826,7 +966,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -917,6 +1057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,7 +1094,7 @@ checksum = "ed9983e64b2358522f745c1251924e3ab7252d55637e80f6a0a3de642d6a9efc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1103,7 +1249,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1153,7 +1299,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1252,6 +1398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,13 +1437,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1413,6 +1574,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ringbuf"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1657,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "walkdir",
  "wavpack-sys",
 ]
@@ -1516,6 +1692,41 @@ dependencies = [
  "primal-check",
  "strength_reduce",
  "transpose",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1572,7 +1783,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1629,10 +1840,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
@@ -1841,6 +2064,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,7 +2102,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1879,6 +2124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,7 +2152,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1949,7 +2204,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,6 +2267,45 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -2102,7 +2396,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2131,6 +2425,24 @@ checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2193,6 +2505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2396,6 +2717,95 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 [features]
 default = ["native_audio", "uac2"]
 # Enable native audio engine (now enabled on Android with CPAL/Oboe)
-native_audio = ["cpal", "symphonia", "rubato", "ringbuf", "crossbeam-channel", "wavpack-sys", "opus-sys", "soundtouch-sys"]
+native_audio = ["cpal", "symphonia", "rubato", "ringbuf", "crossbeam-channel", "wavpack-sys", "opus-sys", "soundtouch-sys", "ureq"]
 # Custom UAC 2.0 USB Audio (host-side DAC/AMP support)
 uac2 = ["rusb", "libusb1-sys"]
 
@@ -47,6 +47,8 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", 
 # Audio Engine Dependencies (available on all platforms including Android)
 cpal = { path = "vendor/cpal", optional = true, features = ["oboe-shared-stdcxx"] }
 symphonia = { version = "0.5", features = ["all"], optional = true }
+# ponytail: pure-Rust rustls HTTP client; cross-compiles to Android NDK
+ureq = { version = "2", default-features = false, features = ["tls"], optional = true }
 rubato = { version = "0.15", optional = true }
 ringbuf = { version = "0.4", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
@@ -70,6 +72,7 @@ android_logger = "0.14"
 [target.'cfg(not(target_os = "android"))'.dependencies]
 cpal = { path = "vendor/cpal" }
 symphonia = { version = "0.5", features = ["all"] }
+ureq = { version = "2", default-features = false, features = ["tls"] }
 rubato = "0.15"
 ringbuf = "0.4"
 crossbeam-channel = "0.5"

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -4,7 +4,7 @@
 //! Now available on all platforms including Android (using CPAL with Oboe backend).
 
 use crate::audio::commands::{AudioEvent, PlaybackState};
-use crate::audio::decoder::{probe_file, DecoderThread};
+use crate::audio::decoder::{probe_file, probe_http, DecoderThread};
 use crate::audio::decoder_handle::{detect_file_type, DecoderHandle};
 #[cfg(target_os = "android")]
 use crate::audio::device::current_device_profile;
@@ -19,6 +19,7 @@ use crate::audio::wavpack_thread::WavpackDecoderThread;
 use log::{info as log_info, warn as log_warn};
 use once_cell::sync::Lazy;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
@@ -1165,6 +1166,80 @@ pub fn audio_queue_next(path: String) -> Result<(), String> {
     with_audio_engine(|engine| {
         engine.set_dop_override(is_raw)?;
         engine.queue_next_prepared(source, handle)
+    })
+}
+
+/// Play a remote audio stream over HTTP. Range-support is assumed (caller
+/// verifies `Accept-Ranges: bytes`); PCM only, no DSD/WavPack over HTTP.
+/// Auth is carried via `headers` (e.g. WebDAV Basic) — Subsonic/Jellyfin embed
+/// credentials in the URL query and pass an empty header map.
+pub fn audio_play_from_http(url: String, headers: HashMap<String, String>) -> Result<(), String> {
+    let probe_result = probe_http(&url, headers)
+        .map_err(|e| format!("Failed to probe HTTP stream: {}", e))?;
+    let file_rate = probe_result.source_info.original_sample_rate;
+    ensure_audio_engine(resolve_track_playback_output_sample_rate(Some(file_rate))?)?;
+    let (output_sample_rate, output_channels) =
+        with_audio_engine(|handle| Ok((handle.sample_rate(), handle.channels())))?;
+    if output_sample_rate != file_rate {
+        log_warn!(
+            "[AUDIO] http: engine_sample_rate_hz={} stream_sample_rate_hz={} — decoder resampling active",
+            output_sample_rate,
+            file_rate
+        );
+    }
+    let (source, decoder_thread) = DecoderThread::spawn_from_probe_result(
+        probe_result,
+        output_sample_rate,
+        output_channels,
+        None,
+    )
+    .map_err(|e| format!("Failed to decode HTTP stream: {}", e))?;
+    with_audio_engine(|handle| {
+        handle.set_dop_override(false)?;
+        handle.play_prepared(source, DecoderHandle::Symphonia(decoder_thread))
+    })
+}
+
+/// Queue a remote HTTP stream as the next track for gapless playback.
+pub fn audio_queue_next_from_http(
+    url: String,
+    headers: HashMap<String, String>,
+) -> Result<(), String> {
+    if !audio_is_initialized() {
+        let probe_result = probe_http(&url, headers)
+            .map_err(|e| format!("Failed to probe HTTP stream: {}", e))?;
+        let file_rate = probe_result.source_info.original_sample_rate;
+        ensure_audio_engine(resolve_track_playback_output_sample_rate(Some(file_rate))?)?;
+        let (output_sample_rate, output_channels) =
+            with_audio_engine(|handle| Ok((handle.sample_rate(), handle.channels())))?;
+        let (source, decoder_thread) = DecoderThread::spawn_from_probe_result(
+            probe_result,
+            output_sample_rate,
+            output_channels,
+            None,
+        )
+        .map_err(|e| format!("Failed to decode HTTP stream: {}", e))?;
+        return with_audio_engine(|handle| {
+            handle.set_dop_override(false)?;
+            handle.queue_next_prepared(source, DecoderHandle::Symphonia(decoder_thread))
+        });
+    }
+
+    // Engine already live at a fixed rate: probe + queue without rate negotiation.
+    let probe_result = probe_http(&url, headers)
+        .map_err(|e| format!("Failed to probe HTTP stream: {}", e))?;
+    let (output_sample_rate, output_channels) =
+        with_audio_engine(|handle| Ok((handle.sample_rate(), handle.channels())))?;
+    let (source, decoder_thread) = DecoderThread::spawn_from_probe_result(
+        probe_result,
+        output_sample_rate,
+        output_channels,
+        None,
+    )
+    .map_err(|e| format!("Failed to decode HTTP stream: {}", e))?;
+    with_audio_engine(|handle| {
+        handle.set_dop_override(false)?;
+        handle.queue_next_prepared(source, DecoderHandle::Symphonia(decoder_thread))
     })
 }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -5,9 +5,11 @@
 
 use crate::dev_eprintln;
 
+use crate::audio::http_source::HttpMediaSource;
 use crate::audio::opus_decoder;
 use crate::audio::resampler::AudioResampler;
 use crate::audio::source::{AudioSource, SourceInfo, SourceProducer};
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -107,6 +109,42 @@ pub fn probe_file(path: &Path) -> Result<ProbeResult, DecoderError> {
             }
         };
 
+    build_probe_result(probed, path.to_path_buf())
+}
+
+/// Probe a remote HTTP audio stream. Hint extension is derived from the URL
+/// path (auth-bearing query string is ignored). No content-based fallback —
+/// reopening an HTTP stream is wasteful and remote URLs carry reliable
+/// extensions.
+pub fn probe_http(url: &str, headers: HashMap<String, String>) -> Result<ProbeResult, DecoderError> {
+    let hint_ext = url_hint_ext(url);
+    let format_opts = FormatOptions {
+        enable_gapless: true,
+        ..Default::default()
+    };
+    let metadata_opts = MetadataOptions::default();
+
+    let mut hint = Hint::new();
+    if !hint_ext.is_empty() {
+        hint.with_extension(&hint_ext);
+    }
+
+    let src = HttpMediaSource::new(url.to_string(), headers);
+    let mss = MediaSourceStream::new(Box::new(src), Default::default());
+
+    let probed = symphonia::default::get_probe()
+        .format(&hint, mss, &format_opts, &metadata_opts)
+        .map_err(|e| DecoderError::UnsupportedFormat(format!("HTTP probe failed: {}", e)))?;
+
+    build_probe_result(probed, PathBuf::from(url_label(url)))
+}
+
+/// Build a [`ProbeResult`] from a probed format reader: locate the audio track,
+/// construct the decoder, and derive [`SourceInfo`]. Shared by file + HTTP paths.
+fn build_probe_result(
+    probed: symphonia::core::probe::ProbeResult,
+    name_path: PathBuf,
+) -> Result<ProbeResult, DecoderError> {
     let format = probed.format;
 
     // Find the first audio track
@@ -159,7 +197,7 @@ pub fn probe_file(path: &Path) -> Result<ProbeResult, DecoderError> {
     };
 
     let source_info = SourceInfo {
-        path: path.to_path_buf(),
+        path: name_path,
         original_sample_rate: sample_rate,
         output_sample_rate: sample_rate,
         channels,
@@ -173,6 +211,35 @@ pub fn probe_file(path: &Path) -> Result<ProbeResult, DecoderError> {
         decoder,
         track_id,
     })
+}
+
+/// Lowercased, ogg-normalized extension hint derived from an HTTP URL's path
+/// (query string stripped, so auth params never leak into the hint).
+fn url_hint_ext(url: &str) -> String {
+    let no_query = url.split('?').next().unwrap_or(url);
+    let after_slash = no_query.rsplit('/').next().unwrap_or(no_query);
+    let raw_ext = match after_slash.rfind('.') {
+        Some(i) => after_slash[i + 1..].to_ascii_lowercase(),
+        None => String::new(),
+    };
+    normalize_ogg_hint(&raw_ext).to_string()
+}
+
+/// Path-only label for an HTTP URL (query stripped) — used as a synthetic
+/// SourceInfo.path for decoder thread naming. Avoids leaking auth tokens.
+fn url_label(url: &str) -> String {
+    let no_query = url.split('?').next().unwrap_or(url);
+    match no_query.rfind('/') {
+        Some(i) => {
+            let name = &no_query[i + 1..];
+            if name.is_empty() {
+                "http-stream".to_string()
+            } else {
+                name.to_string()
+            }
+        }
+        None => no_query.to_string(),
+    }
 }
 
 /// Decoder thread handle.
@@ -209,6 +276,18 @@ impl DecoderThread {
             output_channels,
             start_position_secs,
         )
+    }
+
+    /// Spawn a decoder thread for a remote HTTP audio stream. PCM only —
+    /// remote DSD/WavPack is not supported over HTTP.
+    pub fn spawn_from_http(
+        url: String,
+        headers: HashMap<String, String>,
+        output_sample_rate: u32,
+        output_channels: usize,
+    ) -> Result<(AudioSource, Self), DecoderError> {
+        let probe_result = probe_http(&url, headers)?;
+        Self::spawn_from_probe_result(probe_result, output_sample_rate, output_channels, None)
     }
 
     /// Spawn a decoder thread using a probe result that has already been created.

--- a/rust/src/audio/http_source.rs
+++ b/rust/src/audio/http_source.rs
@@ -1,0 +1,248 @@
+//! Seekable HTTP [`MediaSource`] for remote audio streaming.
+//!
+//! Issues block-granularity ranged GETs (~1 MiB). `seek` drops the buffer and
+//! records the target offset; the next `read` issues `Range: bytes=N-` and
+//! refills. Total length is resolved from `Content-Range` on the first ranged
+//! response. All fields are `Sync` (no persistent reader handle), so the struct
+//! is `Send + Sync` without a `Mutex`.
+
+use std::collections::HashMap;
+use std::io::{self, Read, Seek, SeekFrom};
+use symphonia::core::io::MediaSource;
+
+const BLOCK_SIZE: usize = 1024 * 1024; // 1 MiB
+
+pub struct HttpMediaSource {
+    url: String,
+    headers: HashMap<String, String>,
+    pos: u64,
+    len: Option<u64>,
+    buf: Vec<u8>,
+    buf_start: u64,
+}
+
+impl HttpMediaSource {
+    pub fn new(url: String, headers: HashMap<String, String>) -> Self {
+        Self {
+            url,
+            headers,
+            pos: 0,
+            len: None,
+            buf: Vec::new(),
+            buf_start: 0,
+        }
+    }
+
+    fn ensure_buffered(&mut self) -> io::Result<()> {
+        if !self.buf.is_empty()
+            && self.pos >= self.buf_start
+            && self.pos < self.buf_start + self.buf.len() as u64
+        {
+            return Ok(());
+        }
+
+        let end = self.pos + BLOCK_SIZE as u64 - 1;
+        let mut req = ureq::get(&self.url);
+        for (k, v) in &self.headers {
+            req = req.set(k, v);
+        }
+        req = req.set("Range", &format!("bytes={}-{}", self.pos, end));
+
+        let resp = req
+            .call()
+            .map_err(|e| io::Error::other(format!("HTTP GET failed: {}", e)))?;
+
+        let status = resp.status();
+        let content_range = resp.header("Content-Range").map(|s| s.to_string());
+        let content_length = resp.header("Content-Length").map(|s| s.to_string());
+
+        self.buf_start = self.pos;
+        self.buf.clear();
+        resp.into_reader().read_to_end(&mut self.buf)?;
+
+        if status == 206 {
+            if let Some(cr) = content_range {
+                // "bytes 0-1023/2048"
+                if let Some(total) = cr.split('/').nth(1).and_then(|s| s.parse::<u64>().ok()) {
+                    self.len = Some(total);
+                }
+            }
+        } else {
+            // ponytail: server ignored Range (200 OK full body). Only valid at pos 0.
+            self.buf_start = 0;
+            if self.pos != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "server does not support Range requests; cannot serve seeked offset",
+                ));
+            }
+            if let Some(cl) = content_length.and_then(|s| s.parse::<u64>().ok()) {
+                self.len = Some(cl);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Read for HttpMediaSource {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        if dst.is_empty() {
+            return Ok(0);
+        }
+        if let Some(len) = self.len {
+            if self.pos >= len {
+                return Ok(0);
+            }
+        }
+        self.ensure_buffered()?;
+        if self.buf.is_empty() {
+            return Ok(0);
+        }
+        let offset_in_buf = (self.pos - self.buf_start) as usize;
+        let available = &self.buf[offset_in_buf..];
+        let n = available.len().min(dst.len());
+        dst[..n].copy_from_slice(&available[..n]);
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl Seek for HttpMediaSource {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(n) => n as i64,
+            SeekFrom::End(n) => self
+                .len
+                .map(|l| l as i64 + n)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "length unknown"))?,
+            SeekFrom::Current(n) => self.pos as i64 + n,
+        };
+        if new_pos < 0 {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "negative seek"));
+        }
+        self.pos = new_pos as u64;
+        self.buf.clear();
+        Ok(self.pos)
+    }
+}
+
+impl MediaSource for HttpMediaSource {
+    fn is_seekable(&self) -> bool {
+        true
+    }
+    fn byte_len(&self) -> Option<u64> {
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    // ponytail: in-process HTTP/1.1 server honoring Range; no ureq mock needed.
+    fn spawn_server(data: &'static [u8]) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}/track", addr);
+        thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                serve_one(&mut stream, data);
+            }
+        });
+        url
+    }
+
+    fn serve_one(stream: &mut TcpStream, data: &[u8]) {
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).unwrap_or(0);
+        let req = String::from_utf8_lossy(&buf[..n]);
+        let range = req
+            .lines()
+            .find(|l| l.to_ascii_lowercase().starts_with("range:"))
+            .and_then(|l| l.split(':').nth(1))
+            .map(|s| s.trim().to_string());
+
+        let (status, headers, body_range) = match range.as_deref() {
+            Some(r) if r.starts_with("bytes=") => {
+                let spec = &r[6..];
+                let (lo_s, hi_s) = spec.split_once('-').unwrap_or((spec, ""));
+                let lo: usize = lo_s.parse().unwrap_or(0);
+                let hi: usize = if hi_s.is_empty() {
+                    data.len().saturating_sub(1)
+                } else {
+                    hi_s.parse().unwrap_or(data.len() - 1)
+                };
+                let hi = hi.min(data.len() - 1);
+                (
+                    "206 Partial Content",
+                    format!(
+                        "Content-Range: bytes {}-{}/{}\r\nContent-Length: {}\r\n",
+                        lo,
+                        hi,
+                        data.len(),
+                        hi - lo + 1
+                    ),
+                    lo..=hi,
+                )
+            }
+            _ => (
+                "200 OK",
+                format!("Content-Length: {}\r\n", data.len()),
+                0..=data.len() - 1,
+            ),
+        };
+        let resp = format!(
+            "HTTP/1.1 {}\r\n{}Accept-Ranges: bytes\r\nConnection: close\r\n\r\n",
+            status, headers
+        );
+        stream.write_all(resp.as_bytes()).unwrap();
+        stream.write_all(&data[body_range]).unwrap();
+        stream.flush().unwrap();
+    }
+
+    #[test]
+    fn sequential_read_and_len() {
+        let data: Vec<u8> = (0..200_000u32).map(|i| (i % 251) as u8).collect();
+        let data_box: &'static [u8] = Box::leak(data.into_boxed_slice());
+        let url = spawn_server(data_box);
+        let mut src = HttpMediaSource::new(url, HashMap::new());
+
+        let mut got = [0u8; 4096];
+        let mut total = 0usize;
+        loop {
+            let n = src.read(&mut got).unwrap();
+            if n == 0 {
+                break;
+            }
+            assert_eq!(&got[..n], &data_box[total..total + n]);
+            total += n;
+        }
+        assert_eq!(total, data_box.len());
+        assert_eq!(src.byte_len(), Some(data_box.len() as u64));
+        assert!(src.is_seekable());
+    }
+
+    #[test]
+    fn seek_then_read() {
+        let data: Vec<u8> = (0..150_000u32).map(|i| (i % 251) as u8).collect();
+        let data_box: &'static [u8] = Box::leak(data.into_boxed_slice());
+        let url = spawn_server(data_box);
+        let mut src = HttpMediaSource::new(url, HashMap::new());
+
+        src.seek(SeekFrom::Start(70_000)).unwrap();
+        let mut got = [0u8; 1024];
+        let n = src.read(&mut got).unwrap();
+        assert_eq!(n, 1024);
+        assert_eq!(&got[..n], &data_box[70_000..71_024]);
+
+        // Seek back to start.
+        src.seek(SeekFrom::Start(0)).unwrap();
+        let n = src.read(&mut got).unwrap();
+        assert_eq!(&got[..n], &data_box[0..1024]);
+    }
+}

--- a/rust/src/audio/mod.rs
+++ b/rust/src/audio/mod.rs
@@ -29,6 +29,7 @@ pub mod dynamics;
 pub mod engine;
 pub mod equalizer;
 pub mod fx;
+pub mod http_source;
 pub mod ir_loader;
 pub mod manager;
 pub mod opus_decoder;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2126244572;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1236550085;
 
 // Section: executor
 
@@ -940,6 +940,42 @@ fn wire__crate__api__audio_api__audio_play_impl(
         },
     )
 }
+fn wire__crate__api__audio_api__audio_play_from_http_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "audio_play_from_http",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_url = <String>::sse_decode(&mut deserializer);
+            let api_headers =
+                <std::collections::HashMap<String, String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::audio_api::audio_play_from_http(api_url, api_headers)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__audio_api__audio_poll_event_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1063,6 +1099,42 @@ fn wire__crate__api__audio_api__audio_queue_next_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::audio_api::audio_queue_next(api_path)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__audio_api__audio_queue_next_from_http_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "audio_queue_next_from_http",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_url = <String>::sse_decode(&mut deserializer);
+            let api_headers =
+                <std::collections::HashMap<String, String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::audio_api::audio_queue_next_from_http(api_url, api_headers)?;
                     Ok(output_ok)
                 })())
             }
@@ -3433,6 +3505,14 @@ impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
     }
 }
 
+impl SseDecode for std::collections::HashMap<String, String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <Vec<(String, String)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
+    }
+}
+
 impl SseDecode for std::collections::HashMap<String, i64> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3958,6 +4038,18 @@ impl SseDecode for Vec<(String, i64)> {
     }
 }
 
+impl SseDecode for Vec<(String, String)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<(String, String)>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::uac2_api::Uac2DeviceInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -4151,6 +4243,15 @@ impl SseDecode for (String, i64) {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_field0 = <String>::sse_decode(deserializer);
         let mut var_field1 = <i64>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for (String, String) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <String>::sse_decode(deserializer);
         return (var_field0, var_field1);
     }
 }
@@ -4432,196 +4533,208 @@ fn pde_ffi_dispatcher_primary_impl(
         26 => wire__crate__api__audio_api__audio_load_ir_impl(port, ptr, rust_vec_len, data_len),
         27 => wire__crate__api__audio_api__audio_pause_impl(port, ptr, rust_vec_len, data_len),
         28 => wire__crate__api__audio_api__audio_play_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__audio_api__audio_prepare_engine_impl(
+        29 => wire__crate__api__audio_api__audio_play_from_http_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => {
+        31 => wire__crate__api__audio_api__audio_prepare_engine_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        32 => {
             wire__crate__api__audio_api__audio_probe_format_impl(port, ptr, rust_vec_len, data_len)
         }
-        32 => wire__crate__api__audio_api__audio_queue_next_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__audio_api__audio_resume_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__audio_api__audio_seek_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__audio_api__audio_set_compressor_impl(
+        33 => wire__crate__api__audio_api__audio_queue_next_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__audio_api__audio_queue_next_from_http_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => {
+        35 => wire__crate__api__audio_api__audio_resume_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__audio_api__audio_seek_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__audio_api__audio_set_compressor_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        41 => {
             wire__crate__api__audio_api__audio_set_convolver_impl(port, ptr, rust_vec_len, data_len)
         }
-        40 => {
+        42 => {
             wire__crate__api__audio_api__audio_set_crossfade_impl(port, ptr, rust_vec_len, data_len)
         }
-        41 => wire__crate__api__audio_api__audio_set_crossfade_curve_impl(
+        43 => wire__crate__api__audio_api__audio_set_crossfade_curve_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        47 => {
+        49 => {
             wire__crate__api__audio_api__audio_set_equalizer_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__api__audio_api__audio_set_fx_impl(port, ptr, rust_vec_len, data_len),
-        50 => {
+        50 => wire__crate__api__audio_api__audio_set_fx_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__audio_api__audio_set_limiter_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__audio_api__audio_set_pitch_shift_semitones_impl(
+        54 => wire__crate__api__audio_api__audio_set_pitch_shift_semitones_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__audio_api__audio_set_playback_speed_impl(
+        55 => wire__crate__api__audio_api__audio_set_playback_speed_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
-        56 => {
+        56 => wire__crate__api__audio_api__audio_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__audio_api__audio_shutdown_impl(port, ptr, rust_vec_len, data_len),
+        58 => {
             wire__crate__api__audio_api__audio_skip_to_next_impl(port, ptr, rust_vec_len, data_len)
         }
-        57 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
-        58 => {
+        59 => wire__crate__api__audio_api__audio_stop_impl(port, ptr, rust_vec_len, data_len),
+        60 => {
             wire__crate__api__scanner__check_deleted_paths_impl(port, ptr, rust_vec_len, data_len)
         }
-        59 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
+        61 => wire__crate__api__audio_api__clear_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        60 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
+        62 => wire__crate__api__audio_api__current_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        61 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
+        63 => wire__crate__api__audio_api__current_dsd_track_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        62 => wire__crate__api__scanner__discover_playlist_files_impl(
+        64 => wire__crate__api__scanner__discover_playlist_files_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
+        65 => wire__crate__api__audio_api__effective_dsd_output_mode_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
+        66 => wire__crate__api__audio_api__effective_dsd_output_mode_for_rate_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__scanner__extract_embedded_artwork_impl(
+        67 => wire__crate__api__scanner__extract_embedded_artwork_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        67 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
-        72 => {
+        69 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__metadata_editor__read_tags_impl(port, ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__logging__register_log_sink_impl(port, ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__scanner__scan_music_library_impl(port, ptr, rust_vec_len, data_len),
+        73 => wire__crate__api__scanner__scan_root_dir_impl(port, ptr, rust_vec_len, data_len),
+        74 => {
             wire__crate__api__audio_api__set_dsd_track_rate_impl(port, ptr, rust_vec_len, data_len)
         }
-        73 => wire__crate__api__audio_api__set_pending_crossfade_impl(
+        75 => wire__crate__api__audio_api__set_pending_crossfade_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        74 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        75 => {
-            wire__crate__api__audio_api__set_pending_volume_impl(port, ptr, rust_vec_len, data_len)
-        }
-        76 => wire__crate__api__audio_api__take_pending_crossfade_impl(
+        76 => wire__crate__api__audio_api__set_pending_crossfade_curve_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
         77 => {
+            wire__crate__api__audio_api__set_pending_volume_impl(port, ptr, rust_vec_len, data_len)
+        }
+        78 => wire__crate__api__audio_api__take_pending_crossfade_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        79 => {
             wire__crate__api__audio_api__take_pending_volume_impl(port, ptr, rust_vec_len, data_len)
         }
-        78 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
+        80 => wire__crate__api__uac2_api__uac2_activate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        79 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
+        81 => wire__crate__api__uac2_api__uac2_attempt_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        80 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
+        82 => wire__crate__api__uac2_api__uac2_deactivate_fallback_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        81 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
+        83 => wire__crate__api__uac2_api__uac2_disconnect_impl(port, ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__uac2_api__uac2_get_device_capabilities_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        89 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
+        91 => wire__crate__api__uac2_api__uac2_get_volume_range_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        93 => {
+        95 => {
             wire__crate__api__uac2_api__uac2_select_device_impl(port, ptr, rust_vec_len, data_len)
         }
-        94 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
+        96 => wire__crate__api__uac2_api__uac2_set_auto_reconnect_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        95 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
+        97 => wire__crate__api__uac2_api__uac2_set_mute_impl(port, ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__uac2_api__uac2_set_sampling_frequency_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        97 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
-        98 => {
+        99 => wire__crate__api__uac2_api__uac2_set_volume_impl(port, ptr, rust_vec_len, data_len),
+        100 => {
             wire__crate__api__uac2_api__uac2_start_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        99 => {
+        101 => {
             wire__crate__api__uac2_api__uac2_stop_streaming_impl(port, ptr, rust_vec_len, data_len)
         }
-        100 => {
+        102 => {
             wire__crate__api__metadata_editor__write_tags_impl(port, ptr, rust_vec_len, data_len)
         }
-        101 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
+        103 => wire__crate__api__metadata_editor__write_tags_to_temp_impl(
             port,
             ptr,
             rust_vec_len,
@@ -4692,69 +4805,69 @@ fn pde_ffi_dispatcher_sync_impl(
         25 => {
             wire__crate__api__audio_api__audio_is_native_available_impl(ptr, rust_vec_len, data_len)
         }
-        29 => wire__crate__api__audio_api__audio_poll_event_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__audio_api__audio_set_432hz_tuning_enabled_impl(
+        30 => wire__crate__api__audio_api__audio_poll_event_impl(ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__audio_api__audio_set_432hz_tuning_enabled_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__audio_api__audio_set_audio_api_impl(ptr, rust_vec_len, data_len),
-        37 => {
+        38 => wire__crate__api__audio_api__audio_set_audio_api_impl(ptr, rust_vec_len, data_len),
+        39 => {
             wire__crate__api__audio_api__audio_set_capability_info_impl(ptr, rust_vec_len, data_len)
         }
-        42 => wire__crate__api__audio_api__audio_set_dap_bit_perfect_enabled_impl(
+        44 => wire__crate__api__audio_api__audio_set_dap_bit_perfect_enabled_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__audio_api__audio_set_dsd_big_endian_override_impl(
+        45 => wire__crate__api__audio_api__audio_set_dsd_big_endian_override_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__audio_api__audio_set_dsd_bit_reverse_override_impl(
+        46 => wire__crate__api__audio_api__audio_set_dsd_bit_reverse_override_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        45 => {
+        47 => {
             wire__crate__api__audio_api__audio_set_dsd_output_mode_impl(ptr, rust_vec_len, data_len)
         }
-        46 => wire__crate__api__audio_api__audio_set_dsd_subslot_override_impl(
+        48 => wire__crate__api__audio_api__audio_set_dsd_subslot_override_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        49 => {
+        51 => {
             wire__crate__api__audio_api__audio_set_high_res_mode_impl(ptr, rust_vec_len, data_len)
         }
-        51 => wire__crate__api__audio_api__audio_set_pipeline_mode_passthrough_impl(
+        53 => wire__crate__api__audio_api__audio_set_pipeline_mode_passthrough_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
+        68 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        84 => wire__crate__api__uac2_api__uac2_force_release_usb_session_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        83 => {
+        85 => {
             wire__crate__api__uac2_api__uac2_get_connection_state_impl(ptr, rust_vec_len, data_len)
         }
-        85 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
-        87 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
+        87 => wire__crate__api__uac2_api__uac2_get_fallback_info_impl(ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__uac2_api__uac2_get_mute_impl(ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__uac2_api__uac2_get_sampling_frequency_impl(
             ptr,
             rust_vec_len,
             data_len,
         ),
-        88 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
-        91 => {
+        90 => wire__crate__api__uac2_api__uac2_get_volume_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__uac2_api__uac2_is_available_impl(ptr, rust_vec_len, data_len),
+        93 => {
             wire__crate__api__uac2_api__uac2_is_usb_session_active_impl(ptr, rust_vec_len, data_len)
         }
-        92 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__uac2_api__uac2_list_devices_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5490,6 +5603,13 @@ impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
     }
 }
 
+impl SseEncode for std::collections::HashMap<String, String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(String, String)>>::sse_encode(self.into_iter().collect(), serializer);
+    }
+}
+
 impl SseEncode for std::collections::HashMap<String, i64> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -5932,6 +6052,16 @@ impl SseEncode for Vec<(String, i64)> {
     }
 }
 
+impl SseEncode for Vec<(String, String)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(String, String)>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::uac2_api::Uac2DeviceInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -6096,6 +6226,14 @@ impl SseEncode for (String, i64) {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.0, serializer);
         <i64>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for (String, String) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <String>::sse_encode(self.1, serializer);
     }
 }
 


### PR DESCRIPTION
# Summary

- Refactor center action button into left-top and right-top action buttons with player layout settings reorganization
- Refactor player action buttons into top/bottom pairs with sleep timer toggle
- Add `audio_set_pipeline_mode_passthrough` API for bit-perfect playback control
- Apply software gain in direct-USB passthrough PCM path
- Refactor volume tier system from `HwVolumeCapability` enum to `determineVolumeTier()` pure function with unavailable tier and lie-detector flag
- Refactor volume control to route through `PlayerService` with consolidated iso volume popup
- Add tests for `determineVolumeTier` logic

# Changes

## Player Action Buttons

- Add `none` option to `PlayerActionButton` enum
- Add `leftTopAction` and `rightTopAction` to player preferences (service/provider)
- Refactor center action button into left-top and right-top buttons (45 lines player layout settings)
- Refactor player action buttons to top/bottom pairs (87 lines) and add sleep timer toggle (22 lines layout sheet, 28 lines sleep timer bottom sheet)
- Reorganize player layout settings for new button layout
- Update full player screen with new top action buttons (15 lines)

## Pipeline Mode Passthrough

- Add `audio_set_pipeline_mode_passthrough` API function in Rust
- Add FFI bindings (`frb_generated.rs` + dart, 140 + 132 lines)
- Add `setPipelineModePassthrough` method to `RustAudioService`
- Apply software gain in direct-USB passthrough PCM path (`android_direct.rs`)
- Make passthrough bit-perfect by removing software gain when in passthrough mode (`engine.rs`)

## Volume Tier System

- Replace `HwVolumeCapability` enum with `determineVolumeTier()` pure function
- Add unavailable tier and `_hwVolumeFailed` lie-detector flag
- Refactor volume control to route through `PlayerService` (287 lines)
- Consolidate volume/mute logic in iso volume popup through `playerService` (135 lines)
- Refactor UAC2 volume control widget (133 lines)
- Add tests for `determineVolumeTier` logic (70 lines)

## Files Changed

- `lib/models/player_action_button.dart`
- `lib/providers/app_preferences_provider.dart`
- `lib/services/app_preferences_service.dart`
- `lib/services/player_service.dart`
- `lib/services/rust_audio_service.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/features/player/widgets/player_action_button_row.dart`
- `lib/features/player/widgets/player_layout_sheet.dart`
- `lib/features/player/widgets/sleep_timer_bottom_sheet.dart`
- `lib/features/settings/screens/player_layout_settings_screen.dart`
- `lib/widgets/uac2/uac2_volume_control.dart`
- `lib/widgets/uac2/iso_volume_popup.dart`
- `lib/src/rust/api/audio_api.dart`
- `lib/src/rust/frb_generated.dart`
- `rust/src/api/audio_api.rs`
- `rust/src/frb_generated.rs`
- `rust/src/audio/engine.rs`
- `rust/src/uac2/android_direct.rs`
- `test/services/player_service_volume_tier_test.dart`