### PR TITLE
Add Tidal streaming service, custom artwork cache, and WAV conversion caching

### DIFF
--- a/FEATURE_REQUESTS.md
+++ b/FEATURE_REQUESTS.md
@@ -74,7 +74,7 @@ name, track count, artist, and (newly added) **Year**.
   - ~~HRTF preset library~~
   - ~~Optional HRTF scan upload~~
 - ~~**MQA (Master Quality Authenticated)**~~ — too far. Licensed, instant bankrupt for me.
-- [ ] **Pitch shifter** — adjust audio pitch independently of tempo
+- [X] **Pitch shifter** — adjust audio pitch independently of tempo
 
 ---
 
@@ -95,7 +95,7 @@ name, track count, artist, and (newly added) **Year**.
 
 ## Integrations
 
-- [ ] **Tidal integration** — Tidal streaming service support
+- [x] **Tidal integration** — Tidal streaming service support (reverse-engineered web/OAuth2 path: user signs in with their own account; HiFi lossless FLAC/ALAC through the bit-perfect engine; HiRes/MQA/Atmos gated by Tidal and surfaced as an error).
 - [X] **Local Media Server** — stream music from NAS / network shares. Shipped as Network Sources (`docs/NETWORK_SOURCES_PLAN.md`): Subsonic (Navidrome/Airsonic/gonic/etc.), WebDAV (Nextcloud/ownCloud/Synology/generic), Jellyfin, and UPnP/DLNA media-server browse/play, all through the existing Rust engine (bit-perfect/DSD/gapless preserved). SMB is a loud-failing placeholder recommending the WebDAV workaround.
 
 ---

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -132,5 +132,17 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- url_launcher: Android 11+ (API 30+) package-visibility requires
+             declaring the browser VIEW intent or launchUrl throws
+             ACTIVITY_NOT_FOUND. Needed for Tidal/Last.fm OAuth device flow. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
     </queries>
 </manifest>

--- a/lib/core/utils/dev_log.dart
+++ b/lib/core/utils/dev_log.dart
@@ -3,7 +3,11 @@ import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/core/utils/app_log.dart';
 
 void devLog(String message) {
+  // Terminal output is a developer surface (visible via `flutter run`,
+  // `flutter run --release`, or logcat) — always print so logs can be
+  // copy-pasted without first enabling developer mode.
+  debugPrint(message);
+  // The in-app log viewer is a user-facing surface: keep it gated.
   if (!Uac2PreferencesService.isDeveloperModeEnabledSync) return;
   AppLog.instance.add(message, source: LogSource.dart);
-  debugPrint(message);
 }

--- a/lib/data/entities/network_server_entity.dart
+++ b/lib/data/entities/network_server_entity.dart
@@ -10,7 +10,7 @@ class NetworkServerEntity {
   /// Display name shown in the Network Sources settings screen.
   late String label;
 
-  /// Protocol: 'subsonic' | 'webdav' | 'jellyfin' (SMB/UPnP deferred).
+  /// Protocol: 'subsonic' | 'webdav' | 'jellyfin' | 'tidal' (SMB/UPnP too).
   late String protocol;
 
   /// Base URL of the server, e.g. https://music.example.com/subsonic.

--- a/lib/data/entities/song_entity.dart
+++ b/lib/data/entities/song_entity.dart
@@ -109,7 +109,7 @@ class SongEntity {
   bool hasLocalEdits = false;
 
   /// Where this song came from: null = local file, otherwise one of
-  /// 'subsonic' | 'webdav' | 'jellyfin'.
+  /// 'subsonic' | 'webdav' | 'jellyfin' | 'tidal' | 'upnp'.
   @Index()
   String? sourceType;
 

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -1,6 +1,8 @@
 // Main sources
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 // App constants and other app UI libraries
 import '../../../core/constants/app_constants.dart';
@@ -13,6 +15,7 @@ import '../../../core/utils/responsive.dart';
 import '../../../data/database.dart';
 import '../../../data/repositories/song_repository.dart';
 import '../../../services/sources/network_source_service.dart';
+import '../../../services/sources/tidal_service.dart';
 import '../widgets/settings_widgets.dart';
 
 /// Add or edit a network server. All registered protocols are selectable;
@@ -85,6 +88,14 @@ const List<_ProtocolMeta> _protocols = [
     urlHint: 'smb://nas/music',
     passwordHelper: 'Stored encoded; playback unavailable in this build',
   ),
+  _ProtocolMeta(
+    id: NetworkProtocol.tidal,
+    label: 'Tidal',
+    subtitle: 'Sign in with your account · HiFi lossless',
+    icon: LucideIcons.waves,
+    urlHint: TidalService.tidalBaseUrl,
+    passwordHelper: 'OAuth sign-in; no password stored here',
+  ),
 ];
 
 class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
@@ -96,10 +107,18 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   bool _testing = false;
   bool? _testPassed;
   String? _testError;
+  /// Set when Tidal sign-in can't auto-open the browser; the live banner shows
+  /// it for manual copy/open while polling continues.
+  String? _testVerificationUri;
   bool _saving = false;
   bool _isValid = false;
 
   bool get _isNew => widget.server == null;
+
+  bool get _isTidal => _selectedProtocol == NetworkProtocol.tidal;
+
+  /// Tidal OAuth token resolved during this session (device-code login).
+  String? _resolvedToken;
 
   _ProtocolMeta get _meta =>
       _protocols.firstWhere((p) => p.id == _selectedProtocol);
@@ -132,16 +151,22 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
   }
 
   void _updateValidity() {
-    final valid =
-        _labelController.text.trim().isNotEmpty &&
-        _urlController.text.trim().isNotEmpty;
+    final valid = _labelController.text.trim().isNotEmpty &&
+        (_isTidal || _urlController.text.trim().isNotEmpty);
     if (_isValid != valid) setState(() => _isValid = valid);
   }
 
   /// Resolve the token to persist. When a password is typed it's resolved
   /// through the protocol service (local transform for Subsonic/WebDAV, a
   /// sign-in round-trip for Jellyfin). Otherwise the existing token is kept.
+  /// Tidal has no password field — its device-code token is captured in
+  /// [_resolvedToken] during [_testConnection], or the previously-stored
+  /// sign-in is reused.
   Future<String?> _resolvePersistedToken() async {
+    if (_isTidal) {
+      if (_resolvedToken != null) return _resolvedToken;
+      return widget.server?.token;
+    }
     final password = _passwordController.text;
     if (password.isNotEmpty) {
       final draft = _draftEntity(token: null);
@@ -160,7 +185,9 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     server
       ..label = _labelController.text.trim()
       ..protocol = _selectedProtocol
-      ..baseUrl = _urlController.text.trim().replaceAll(RegExp(r'/+$'), '')
+      ..baseUrl = _isTidal
+          ? TidalService.tidalBaseUrl
+          : _urlController.text.trim().replaceAll(RegExp(r'/+$'), '')
       ..username = _usernameController.text.trim().isEmpty
           ? null
           : _usernameController.text.trim()
@@ -173,9 +200,33 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       _testing = true;
       _testPassed = null;
       _testError = null;
+      _testVerificationUri = null;
     });
     AppHaptics.tap();
-    final token = await _resolvePersistedToken();
+    var token = await _resolvePersistedToken();
+    // Tidal with no session token yet: drive the device-code login (opens the
+    // browser, polls until authorized), then validate.
+    if (_isTidal && (token == null || token.isEmpty)) {
+      try {
+        token = await TidalService.instance.signIn(
+          onVerificationLink: (uri) {
+            if (!mounted) return;
+            setState(() => _testVerificationUri = uri);
+          },
+        );
+        _resolvedToken = token;
+        if (!mounted) return;
+        setState(() => _testVerificationUri = null);
+      } catch (e) {
+        if (!mounted) return;
+        setState(() {
+          _testing = false;
+          _testPassed = false;
+          _testError = _humanError(e);
+        });
+        return;
+      }
+    }
     final entity = _draftEntity(token: token);
     try {
       final ok = await networkSourceServiceFor(_selectedProtocol).ping(entity);
@@ -251,11 +302,18 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       ? LucideIcons.checkCircle
       : LucideIcons.xCircle;
 
-  String get _testLabel => _testPassed == null
-      ? 'Test Connection'
-      : _testPassed!
-      ? 'Connection OK'
-      : 'Connection Failed — Retry';
+  String get _testLabel {
+    if (_testPassed == true) return _isTidal ? 'Signed in' : 'Connection OK';
+    if (_testPassed == false) {
+      return _isTidal ? 'Sign-in Failed — Retry' : 'Connection Failed — Retry';
+    }
+    if (_isTidal) {
+      final hasToken = _resolvedToken != null ||
+          (widget.server?.token?.isNotEmpty ?? false);
+      return hasToken ? 'Test Connection' : 'Sign in with Tidal';
+    }
+    return 'Test Connection';
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -281,6 +339,8 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
                             _selectedProtocol = _protocols[i].id;
                             _testPassed = null;
                             _testError = null;
+                            _testVerificationUri = null;
+                            _resolvedToken = null;
                           });
                         }
                       : null,
@@ -302,6 +362,21 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
                     ),
               ),
             ),
+          if (_isTidal)
+            Padding(
+              padding: const EdgeInsets.only(
+                left: AppConstants.spacingXs,
+                top: AppConstants.spacingSm,
+              ),
+              child: Text(
+                'Sign in with your own Tidal account. HiFi lossless (FLAC/ALAC) '
+                'plays through the bit-perfect engine; HiRes/MQA and Atmos are '
+                'gated by Tidal and will show an error instead of playing.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: context.adaptiveTextTertiary,
+                    ),
+              ),
+            ),
           const SizedBox(height: AppConstants.spacingLg),
           SettingsSectionHeader('Connection'),
           SettingsCard(
@@ -310,32 +385,34 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
                 controller: _labelController,
                 icon: LucideIcons.tag,
                 label: 'Label',
-                hint: 'My Navidrome',
+                hint: 'My ${_meta.label}',
               ),
-              const SettingsDivider(),
-              _TextFieldSetting(
-                controller: _urlController,
-                icon: LucideIcons.link,
-                label: 'Server URL',
-                hint: _meta.urlHint,
-                keyboardType: TextInputType.url,
-              ),
-              const SettingsDivider(),
-              _TextFieldSetting(
-                controller: _usernameController,
-                icon: LucideIcons.user,
-                label: 'Username',
-              ),
-              const SettingsDivider(),
-              _TextFieldSetting(
-                controller: _passwordController,
-                icon: LucideIcons.lock,
-                label: 'Password',
-                obscureText: true,
-                helperText: _isNew
-                    ? _meta.passwordHelper
-                    : 'Leave empty to keep the current credentials',
-              ),
+              if (!_isTidal) ...[
+                const SettingsDivider(),
+                _TextFieldSetting(
+                  controller: _urlController,
+                  icon: LucideIcons.link,
+                  label: 'Server URL',
+                  hint: _meta.urlHint,
+                  keyboardType: TextInputType.url,
+                ),
+                const SettingsDivider(),
+                _TextFieldSetting(
+                  controller: _usernameController,
+                  icon: LucideIcons.user,
+                  label: 'Username',
+                ),
+                const SettingsDivider(),
+                _TextFieldSetting(
+                  controller: _passwordController,
+                  icon: LucideIcons.lock,
+                  label: 'Password',
+                  obscureText: true,
+                  helperText: _isNew
+                      ? _meta.passwordHelper
+                      : 'Leave empty to keep the current credentials',
+                ),
+              ],
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
@@ -359,6 +436,10 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
               ),
             ),
           ),
+          if (_testing && _testVerificationUri != null) ...[
+            const SizedBox(height: AppConstants.spacingSm),
+            _buildSignInLinkBanner(context),
+          ],
           if (_testPassed == false) ...[
             const SizedBox(height: AppConstants.spacingSm),
             _buildFailureBanner(context),
@@ -431,6 +512,130 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
         ],
       ),
     );
+  }
+
+  /// Shown live while Tidal device-code polling runs after the browser failed
+  /// to auto-open. Offers manual copy/open of the verification link.
+  Widget _buildSignInLinkBanner(BuildContext context) {
+    final uri = _testVerificationUri!;
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingSm),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackground,
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                LucideIcons.link,
+                size: 16,
+                color: context.adaptiveTextSecondary,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  "Couldn't open the browser automatically. Authorize on any "
+                  "device with this link — we'll finish signing in once you do:",
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.adaptiveTextSecondary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            decoration: BoxDecoration(
+              color: AppColors.glassBackgroundStrong,
+              borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+              border: Border.all(color: AppColors.glassBorder),
+            ),
+            child: SelectableText(
+              uri,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextSecondary,
+                fontFamily: 'monospace',
+                letterSpacing: 0.2,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppConstants.spacingSm),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _linkAction(
+                icon: LucideIcons.externalLink,
+                label: 'Open in browser',
+                onTap: () => _openLink(uri),
+              ),
+              _linkAction(
+                icon: LucideIcons.copy,
+                label: 'Copy link',
+                onTap: () {
+                  Clipboard.setData(ClipboardData(text: uri));
+                  AppHaptics.tap();
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Glass-styled action button matching the app design language (used for the
+  /// Tidal sign-in link actions).
+  Widget _linkAction({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: AppColors.glassBackgroundStrong,
+            borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+            border: Border.all(color: AppColors.glassBorderStrong),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 15, color: context.adaptiveTextSecondary),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: context.adaptiveTextPrimary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Open [uri] for the Tidal device flow in the default browser. If no
+  /// default browser is set, the system shows its own chooser.
+  Future<void> _openLink(String uri) async {
+    AppHaptics.tap();
+    try {
+      await launchUrl(Uri.parse(uri), mode: LaunchMode.externalApplication);
+    } catch (_) {/* nothing to do — the banner still shows the link */}
   }
 }
 

--- a/lib/features/settings/screens/network_sources_screen.dart
+++ b/lib/features/settings/screens/network_sources_screen.dart
@@ -14,7 +14,7 @@ import '../widgets/settings_widgets.dart';
 import 'network_server_edit_screen.dart';
 
 /// Manage configured network music servers (Subsonic, Jellyfin, WebDAV,
-/// UPnP/DLNA, SMB).
+/// UPnP/DLNA, SMB, Tidal).
 class NetworkSourcesScreen extends StatefulWidget {
   const NetworkSourcesScreen({super.key});
 
@@ -157,8 +157,8 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
             ),
             const SizedBox(height: AppConstants.spacingXs),
             Text(
-              'Connect a Subsonic, Jellyfin, WebDAV, or UPnP server to stream '
-              'your remote library.',
+              'Connect a Subsonic, Jellyfin, WebDAV, UPnP, or Tidal server to '
+              'stream your remote library.',
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 color: context.adaptiveTextTertiary,

--- a/lib/services/alac_converter_service.dart
+++ b/lib/services/alac_converter_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
@@ -12,35 +13,119 @@ import 'package:flick/core/utils/dev_log.dart';
 class AlacConverterService {
   static final Map<String, bool> _wavConversionSupportCache = {};
 
-  /// Convert a supported source file to WAV and save to a temporary file.
+  // --- persistent WAV cache (survives app restarts) ---
+  static const _cacheDirName = 'wav_cache';
+  static const _manifestName = 'manifest.json';
+  static Map<String, _WavCacheEntry>? _manifest;
+  static bool _manifestLoaded = false;
+
+  static Future<Directory> _wavCacheDir() async {
+    final support = await getApplicationSupportDirectory();
+    final dir = Directory('${support.path}/$_cacheDirName');
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  static Future<void> _ensureManifest() async {
+    if (_manifestLoaded) return;
+    _manifestLoaded = true;
+    try {
+      final dir = await _wavCacheDir();
+      final file = File('${dir.path}/$_manifestName');
+      if (await file.exists()) {
+        final raw = jsonDecode(await file.readAsString());
+        if (raw is Map<String, dynamic>) {
+          _manifest = raw.map(
+            (k, v) => MapEntry(k, _WavCacheEntry.fromJson(v as Map<String, dynamic>)),
+          );
+          return;
+        }
+      }
+      _manifest = {};
+    } catch (_) {
+      _manifest = {};
+    }
+  }
+
+  static Future<void> _persistManifest() async {
+    final manifest = _manifest;
+    if (manifest == null) return;
+    try {
+      final dir = await _wavCacheDir();
+      final file = File('${dir.path}/$_manifestName');
+      await file.writeAsString(
+        jsonEncode(manifest.map((k, v) => MapEntry(k, v.toJson()))),
+      );
+    } catch (_) {
+      // best-effort; in-session cache still works
+    }
+  }
+
+  /// Returns the persisted WAV path for [sourcePath] if a valid converted copy
+  /// already exists on disk, otherwise null.
+  // ponytail: validity keyed on source byte size only. A replaced source with
+  // identical size would reuse a stale WAV; add content hashing if that bites.
+  // Uncompressed WAVs are ~10x the source; no eviction yet, add LRU if the dir
+  // grows too large.
+  static Future<String?> tryGetCachedWav(String sourcePath) async {
+    await _ensureManifest();
+    final entry = _manifest?[sourcePath];
+    if (entry == null) return null;
+    try {
+      final srcFile = File(sourcePath);
+      if (!await srcFile.exists()) return null;
+      if (await srcFile.length() != entry.sourceSize) return null;
+      final wavFile = File(entry.wavPath);
+      if (!await wavFile.exists()) return null;
+      return entry.wavPath;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Convert a supported source file to WAV and save to the persistent cache.
   ///
-  /// Returns the path to the converted WAV file
+  /// Returns the path to the converted WAV file. Reuses an existing cached
+  /// copy when valid, so repeated launches skip re-conversion.
   static Future<String> convertToWavFile(String sourcePath) async {
-    final tempDir = await getTemporaryDirectory();
-    return _convertToWavFile(sourcePath: sourcePath, tempDirPath: tempDir.path);
+    final cached = await tryGetCachedWav(sourcePath);
+    if (cached != null) return cached;
+
+    final dir = await _wavCacheDir();
+    final wavPath = await _convertToWavFile(
+      sourcePath: sourcePath,
+      cacheDirPath: dir.path,
+    );
+
+    _manifest ??= {};
+    _manifest![sourcePath] = _WavCacheEntry(
+      wavPath: wavPath,
+      sourceSize: await File(sourcePath).length(),
+    );
+    await _persistManifest();
+    return wavPath;
   }
 
   static Future<String> _convertToWavFile({
     required String sourcePath,
-    required String tempDirPath,
+    required String cacheDirPath,
   }) async {
-    // Read source file
     final sourceFile = File(sourcePath);
     final fileBytes = await sourceFile.readAsBytes();
 
-    // Convert to WAV
     final wavBytes = alac_api.alacConvertToWav(fileBytes: fileBytes);
     if (wavBytes.isEmpty) {
       throw StateError('Rust converter returned empty WAV data');
     }
 
-    // Save to temporary file
     final sourceName = sourcePath.split('/').last;
     final baseName = sourceName.replaceAll(
       RegExp(r'\.(alac|m4a|aiff|aif)$', caseSensitive: false),
       '',
     );
-    final wavPath = '$tempDirPath/${baseName}_${sourcePath.hashCode.abs()}.wav';
+    final wavPath = '$cacheDirPath/${baseName}_${sourcePath.hashCode.abs()}.wav';
     final wavFile = File(wavPath);
     await wavFile.writeAsBytes(wavBytes);
 
@@ -93,6 +178,20 @@ class AlacConverterService {
   static bool requiresWavConversion(String filePath) {
     return isAlacOrM4a(filePath) || isAiff(filePath);
   }
+}
+
+class _WavCacheEntry {
+  final String wavPath;
+  final int sourceSize;
+
+  _WavCacheEntry({required this.wavPath, required this.sourceSize});
+
+  Map<String, dynamic> toJson() => {'wavPath': wavPath, 'sourceSize': sourceSize};
+
+  factory _WavCacheEntry.fromJson(Map<String, dynamic> json) => _WavCacheEntry(
+        wavPath: json['wavPath'] as String,
+        sourceSize: json['sourceSize'] as int,
+      );
 }
 
 /// Streaming ALAC converter for large files

--- a/lib/services/album_art_service.dart
+++ b/lib/services/album_art_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:image/image.dart' as img;
 import 'package:path_provider/path_provider.dart';
 
@@ -18,20 +17,19 @@ class AlbumArtService {
   AlbumArtService._();
 
   static final AlbumArtService instance = AlbumArtService._();
-  static const String _storeKey = 'flickArtworkCache';
-  // ponytail: 30-day staleness + 500-entry LRU cap bounds on-disk storage to
-  // ~roughly the size of a large library's most-listened artwork. Bump the
-  // cap (or drop the stale period) only if getCacheSize() reports pressure.
-  static const Duration _cacheStalePeriod = Duration(days: 30);
-  static const int _cacheMaxEntries = 500;
 
-  static final CacheManager _cacheManager = CacheManager(
-    Config(
-      _storeKey,
-      stalePeriod: _cacheStalePeriod,
-      maxNrOfCacheObjects: _cacheMaxEntries,
-    ),
-  );
+  // ponytail: artwork lives in the app *support* dir (durable) instead of
+  // flutter_cache_manager's cache dir (OS-evictable). A DB pointer at a file
+  // the OS had evicted was the root cause of art vanishing on reopen. 30-day
+  // age + 500-entry cap bound storage; the tail re-extracts on demand once
+  // pruned, so storage stays bounded without reintroducing the stale-pointer
+  // bug for the common (recently played) set.
+  static const Duration _artworkStalePeriod = Duration(days: 30);
+  static const int _artworkMaxEntries = 500;
+  static const Duration _pruneInterval = Duration(hours: 6);
+
+  Directory? _artworkDir;
+  DateTime _lastPrune = DateTime.fromMillisecondsSinceEpoch(0);
 
   final SongRepository _songRepository = SongRepository();
   final MusicFolderService _musicFolderService = MusicFolderService();
@@ -57,24 +55,24 @@ class AlbumArtService {
         return null;
       }
 
+      // Extension is irrelevant: Flutter's image decoder sniffs magic bytes,
+      // so keying the file on the content hash alone keeps lookup O(1) with
+      // no glob and no raw-vs-normalized format mismatch.
       final cacheKey = _cacheKey(raw);
-      final cached = await _cacheManager.getFileFromCache(cacheKey);
-      final cachedPath = cached?.file.path;
-      if (await _isUsableImagePath(cachedPath)) {
-        unawaited(_persistArtworkPath(audioSourcePath, cachedPath));
-        return cachedPath;
+      final dir = await _ensureArtworkDir();
+      final cachedFile = File('${dir.path}/$cacheKey');
+      if (await _isUsableImagePath(cachedFile.path)) {
+        unawaited(_persistArtworkPath(audioSourcePath, cachedFile.path));
+        unawaited(_pruneIfNeeded(dir));
+        return cachedFile.path;
       }
 
       final bytes = await _normalizeArtworkBytes(raw);
-      final extension = _detectFileExtension(bytes);
-      final file = await _cacheManager.putFile(
-        cacheKey,
-        bytes,
-        fileExtension: extension,
-      );
+      await cachedFile.writeAsBytes(bytes, flush: true);
 
-      await _persistArtworkPath(audioSourcePath, file.path);
-      return file.path;
+      await _persistArtworkPath(audioSourcePath, cachedFile.path);
+      unawaited(_pruneIfNeeded(dir));
+      return cachedFile.path;
     });
 
     try {
@@ -85,39 +83,67 @@ class AlbumArtService {
   }
 
   Future<int> getCacheSize() async {
+    final dir = await _ensureArtworkDir();
     var total = 0;
-    for (final dir in await _candidateCacheRoots()) {
-      for (final name in const [_storeKey, 'libCachedImageData']) {
-        final cacheDir = Directory('${dir.path}/$name');
-        if (!await cacheDir.exists()) continue;
-        try {
-          await for (final entity
-              in cacheDir.list(recursive: true, followLinks: false)) {
-            if (entity is File) total += await entity.length();
-          }
-        } catch (_) {}
+    try {
+      await for (final entity
+          in dir.list(recursive: false, followLinks: false)) {
+        if (entity is File) total += await entity.length();
       }
-    }
+    } catch (_) {}
     return total;
   }
 
   Future<void> clearCache() async {
-    await _cacheManager.emptyCache();
-    await DefaultCacheManager().emptyCache();
+    final dir = await _ensureArtworkDir();
+    try {
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is File) await entity.delete();
+      }
+    } catch (_) {}
   }
 
-  Future<List<Directory>> _candidateCacheRoots() async {
-    final dirs = <Directory>[];
-    for (final future in [
-      getTemporaryDirectory(),
-      getApplicationCacheDirectory(),
-      getApplicationSupportDirectory(),
-    ]) {
-      try {
-        dirs.add(await future);
-      } catch (_) {}
+  Future<Directory> _ensureArtworkDir() async {
+    final cached = _artworkDir;
+    if (cached != null) return cached;
+    final support = await getApplicationSupportDirectory();
+    final artwork = Directory('${support.path}/artwork');
+    if (!await artwork.exists()) {
+      await artwork.create(recursive: true);
     }
-    return dirs;
+    _artworkDir = artwork;
+    return artwork;
+  }
+
+  // ponytail: throttled best-effort prune — newest _artworkMaxEntries survive,
+  // anything older than _artworkStalePeriod goes regardless. Pruned entries
+  // re-extract on next access via the normal self-heal path, so this only
+  // bounds storage, never loses art permanently.
+  Future<void> _pruneIfNeeded(Directory dir) async {
+    final now = DateTime.now();
+    if (now.difference(_lastPrune) < _pruneInterval) return;
+    _lastPrune = now;
+
+    try {
+      final files = <({File file, DateTime modified})>[];
+      await for (final entity in dir.list(followLinks: false)) {
+        if (entity is! File) continue;
+        final stat = await entity.stat();
+        files.add((file: entity, modified: stat.modified));
+      }
+      files.sort((a, b) => b.modified.compareTo(a.modified));
+
+      final staleCut = now.subtract(_artworkStalePeriod);
+      for (var i = 0; i < files.length; i++) {
+        final beyondCap = i >= _artworkMaxEntries;
+        final isStale = files[i].modified.isBefore(staleCut);
+        if (beyondCap || isStale) {
+          try {
+            await files[i].file.delete();
+          } catch (_) {}
+        }
+      }
+    } catch (_) {}
   }
 
   Future<bool> _isUsableImagePath(String? path) async {
@@ -199,48 +225,6 @@ class AlbumArtService {
   String _cacheKey(Uint8List bytes) {
     final digest = md5.convert(bytes);
     return 'embedded-artwork:${digest.toString()}';
-  }
-
-  String _detectFileExtension(Uint8List bytes) {
-    if (bytes.length >= 8 &&
-        bytes[0] == 0x89 &&
-        bytes[1] == 0x50 &&
-        bytes[2] == 0x4E &&
-        bytes[3] == 0x47) {
-      return 'png';
-    }
-
-    if (bytes.length >= 3 &&
-        bytes[0] == 0xFF &&
-        bytes[1] == 0xD8 &&
-        bytes[2] == 0xFF) {
-      return 'jpg';
-    }
-
-    if (bytes.length >= 12 &&
-        bytes[0] == 0x52 &&
-        bytes[1] == 0x49 &&
-        bytes[2] == 0x46 &&
-        bytes[3] == 0x46 &&
-        bytes[8] == 0x57 &&
-        bytes[9] == 0x45 &&
-        bytes[10] == 0x42 &&
-        bytes[11] == 0x50) {
-      return 'webp';
-    }
-
-    if (bytes.length >= 6 &&
-        bytes[0] == 0x47 &&
-        bytes[1] == 0x49 &&
-        bytes[2] == 0x46) {
-      return 'gif';
-    }
-
-    if (bytes.length >= 2 && bytes[0] == 0x42 && bytes[1] == 0x4D) {
-      return 'bmp';
-    }
-
-    return 'jpg';
   }
 }
 

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -2754,12 +2754,16 @@ class PlayerService {
         defaultTargetPlatform == TargetPlatform.android &&
         parsed?.scheme == 'content';
 
-    final normalizedType = _playbackFileType(song);
-    _debugLog(
-      '[WAV-conv] resolve path: file=${song.title} '
-      'normType=$normalizedType engine=$currentEngineType '
-      'isContentUri=$isAndroidContentUri shouldConvert=${_shouldConvertToWav(song)}',
-    );
+    final needsWavWork = isAndroidContentUri ||
+        _shouldConvertToWav(song);
+    if (needsWavWork) {
+      final normalizedType = _playbackFileType(song);
+      _debugLog(
+        '[WAV-conv] resolve path: file=${song.title} '
+        'normType=$normalizedType engine=$currentEngineType '
+        'isContentUri=$isAndroidContentUri shouldConvert=${_shouldConvertToWav(song)}',
+      );
+    }
 
     if (isAndroidContentUri && _shouldStageContentUriForPlayback(song)) {
       final stagedPath = await _stageContentUriForPlayback(
@@ -2785,7 +2789,9 @@ class PlayerService {
       }
     }
 
-    _debugLog('[WAV-conv] final resolved path: $resolvedPath');
+    if (needsWavWork) {
+      _debugLog('[WAV-conv] final resolved path: $resolvedPath');
+    }
     return resolvedPath;
   }
 
@@ -2881,16 +2887,26 @@ class PlayerService {
     }
 
     final playbackUri = _toPlaybackUri(sourcePath);
-    _debugLog(
-      '[WAV-conv] convert check: sourceScheme=${playbackUri.scheme} '
-      'sourcePath=$sourcePath',
-    );
     if (playbackUri.scheme != 'file') {
       _debugLog('[WAV-conv] skipping: not a file: scheme');
       return null;
     }
 
     final localPath = playbackUri.toFilePath();
+
+    // Persistent cache: reuse a previously converted WAV, skipping probe +
+    // conversion. Avoids re-reading/re-converting every launch.
+    final persisted = await AlacConverterService.tryGetCachedWav(localPath);
+    if (persisted != null) {
+      _convertedPlaybackPathCache[sourceKey] = persisted;
+      _debugLog('[WAV-conv] using persisted cache: $persisted');
+      return persisted;
+    }
+
+    _debugLog(
+      '[WAV-conv] convert check: sourceScheme=${playbackUri.scheme} '
+      'sourcePath=$sourcePath',
+    );
     final canConvert = await AlacConverterService.canConvertToWavFile(
       localPath,
     );

--- a/lib/services/sources/network_source_service.dart
+++ b/lib/services/sources/network_source_service.dart
@@ -4,6 +4,7 @@ import '../library_scanner_service.dart' show ScanProgress;
 import 'jellyfin_service.dart';
 import 'smb_service.dart';
 import 'subsonic_service.dart';
+import 'tidal_service.dart';
 import 'upnp_service.dart';
 import 'webdav_service.dart';
 
@@ -74,8 +75,9 @@ class NetworkProtocol {
   static const webdav = 'webdav';
   static const upnp = 'upnp';
   static const smb = 'smb';
+  static const tidal = 'tidal';
 
-  static const all = [subsonic, jellyfin, webdav, upnp, smb];
+  static const all = [subsonic, jellyfin, webdav, upnp, smb, tidal];
 }
 
 final Map<String, NetworkSourceService> _registry = {};
@@ -90,6 +92,7 @@ void _ensureSeeded() {
     WebdavService.instance,
     UpnpService.instance,
     SmbService.instance,
+    TidalService.instance,
   ]) {
     _registry[s.protocol] = s;
   }

--- a/lib/services/sources/tidal_service.dart
+++ b/lib/services/sources/tidal_service.dart
@@ -1,0 +1,682 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/utils/dev_log.dart';
+import '../../data/database.dart';
+import '../../data/repositories/song_repository.dart';
+import '../library_scanner_service.dart' show ScanProgress;
+import '../network_cache_service.dart';
+import 'network_source_service.dart';
+
+/// Tidal client over the reverse-engineered web/OAuth2 surface.
+///
+/// Auth is Tidal's OAuth2 **device-authorization grant**: the app impersonates a
+/// Tidal web/desktop client using its public `clientId` and the user authorizes
+/// on their own device with their own Tidal account. Tokens (access + refresh)
+/// are persisted as a JSON blob in [NetworkServerEntity.token] and refreshed
+/// transparently on expiry, writing the new token back to the DB.
+///
+/// Playback: `/tracks/{id}/playbackinfopostpaywall` returns a `vnd.tidal.bts`
+/// manifest. For `encryptionType: NONE` (HiFi lossless FLAC/ALAC) the contained
+/// CDN url is fed straight to the engine as a ranged HTTP source (or cached).
+/// Encrypted manifests (MQA / HiRes Master / Atmos, `encryptionType != NONE` or
+/// DASH) are **not** decryptable here and fail with a clear error rather than
+/// fake playback — matching the project's "no fake transport" rule. This is the
+/// tradeoff of the no-partner-SDK path the user explicitly accepted.
+///
+/// Tidal rotates the web client credentials; update [clientId]/[clientSecret]
+/// if auth starts returning `invalid_client`.
+class TidalService implements NetworkSourceService {
+  TidalService._({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+    Future<bool> Function(Uri)? urlOpener,
+  })  : _client = client ?? http.Client(),
+        _songRepository = songRepository,
+        _networkCache = networkCache,
+        _urlOpener = urlOpener ?? _defaultOpenUrl;
+
+  static TidalService instance = TidalService._();
+
+  @visibleForTesting
+  static TidalService create({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+    Future<bool> Function(Uri)? urlOpener,
+  }) =>
+      TidalService._(
+        client: client,
+        songRepository: songRepository,
+        networkCache: networkCache,
+        urlOpener: urlOpener,
+      );
+
+  // ponytail: Tidal desktop/TV app OAuth2 client credentials, scraped from the
+  // app and published by the RE community (EbbLabs/python-tidal). NOT an official
+  // API key; Tidal rotates these at will. If auth starts returning
+  // `invalid_client`, pull a fresh client_id/client_secret pair from the same
+  // source.
+  static const String clientId = 'fX2JxdmntZWK0ixT';
+  static const String clientSecret = '1Nn9AfDAjxrgJFJbKNWLeAyKGVGmINuXPPLHVXAvxAg=';
+  static const String _scope = 'r_usr w_usr w_sub';
+
+  static const String _authBase = 'https://auth.tidal.com/v1/oauth2';
+  static const String _apiBase = 'https://api.tidal.com/v1';
+  static const String _coverMarkerScheme = 'tidal-cover://';
+  static const String _coverHost = 'https://resources.tidal.com/images';
+
+  /// Tidal base url is fixed; baseUrl on the entity is cosmetic only.
+  static const String tidalBaseUrl = 'https://tidal.com';
+
+  final http.Client _client;
+  SongRepository? _songRepository;
+  NetworkCacheService? _networkCache;
+  final Future<bool> Function(Uri) _urlOpener;
+
+  SongRepository get _repo => _songRepository ??= SongRepository();
+  NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+
+  static Future<bool> _defaultOpenUrl(Uri url) =>
+      launchUrl(url, mode: LaunchMode.externalApplication);
+
+  @override
+  String get protocol => NetworkProtocol.tidal;
+
+  @override
+  String get coverScheme => _coverMarkerScheme;
+
+  _TidalCreds? _creds(String? token) {
+    if (token == null || token.isEmpty) return null;
+    try {
+      final j = jsonDecode(token) as Map<String, dynamic>;
+      final access = j['access_token'] as String?;
+      if (access == null) return null;
+      return _TidalCreds(
+        accessToken: access,
+        refreshToken: j['refresh_token'] as String?,
+        userId: j['user_id'] as String?,
+        countryCode: (j['country_code'] as String?) ?? 'US',
+        expiresAtMs: (j['expires_at_ms'] as num?)?.toInt(),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // --- OAuth2 device-code login ------------------------------------------
+
+  @override
+  Future<String?> resolveToken(
+    NetworkServerEntity server,
+    String password,
+  ) =>
+      signIn();
+
+  /// OAuth2 device-code sign-in. The browser is auto-launched best-effort; if
+  /// that fails (no browser app / ACTIVITY_NOT_FOUND), [onVerificationLink]
+  /// receives the URI so the caller can offer manual copy/open. Polling
+  /// continues regardless, so authorization completed on any device finishes
+  /// the sign-in. Without a callback, a launch failure fast-fails with the link
+  /// carried on the [TidalException].
+  Future<String?> signIn({
+    void Function(String verificationLink)? onVerificationLink,
+  }) async {
+    final dev = await _postForm('$_authBase/device_authorization', {
+      'client_id': clientId,
+      'scope': _scope,
+    });
+    final deviceCode = dev['deviceCode'] as String?;
+    final rawUri = (dev['verificationUriComplete'] as String?) ??
+        (dev['verificationUri'] as String?);
+    // Tidal returns the verification URL scheme-less (link.tidal.com/CODE);
+    // url_launcher needs https:// or the VIEW intent matches nothing and
+    // throws ACTIVITY_NOT_FOUND.
+    final verificationUri =
+        rawUri == null || rawUri.startsWith('http') ? rawUri : 'https://$rawUri';
+    final intervalSec = (dev['interval'] as num?)?.toInt() ?? 5;
+    final expiresInSec = (dev['expiresIn'] as num?)?.toInt() ?? 300;
+    if (deviceCode == null || verificationUri == null) {
+      throw TidalException('Tidal did not return a sign-in code.');
+    }
+    // Opening the browser can throw (e.g. Android ACTIVITY_NOT_FOUND when no
+    // app handles the link). Treat a throw the same as a false return — with a
+    // callback the device-code flow still works if the user opens the link on
+    // any device; without one we fast-fail carrying the link.
+    var launched = false;
+    try {
+      launched = await _urlOpener(Uri.parse(verificationUri));
+    } catch (e) {
+      devLog('[Tidal] browser launch failed: $e');
+    }
+    if (!launched) {
+      if (onVerificationLink != null) {
+        onVerificationLink(verificationUri);
+      } else {
+        throw TidalException(
+          "Couldn't open the browser automatically. Open this link on any "
+          'device to finish signing in, then tap Sign in again:\n\n'
+          '$verificationUri',
+          verificationUri: verificationUri,
+        );
+      }
+    }
+
+    final deadline = DateTime.now().add(Duration(seconds: expiresInSec));
+    var sleep = intervalSec;
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(Duration(seconds: sleep));
+      final tok = await _postForm('$_authBase/token', {
+        'client_id': clientId,
+        if (clientSecret.isNotEmpty) 'client_secret': clientSecret,
+        'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
+        'device_code': deviceCode,
+        'scope': _scope,
+      }, raw: true);
+
+      final access = tok['access_token'] as String?;
+      if (access != null) {
+        final session = await _fetchSession(access);
+        final expiresAt = DateTime.now().add(
+          Duration(seconds: (tok['expires_in'] as num?)?.toInt() ?? 3600),
+        );
+        return jsonEncode({
+          'access_token': access,
+          'refresh_token': tok['refresh_token'],
+          'user_id': session.userId,
+          'country_code': session.countryCode,
+          'expires_at_ms': expiresAt.millisecondsSinceEpoch,
+        });
+      }
+      switch (tok['error']) {
+        case 'expired_token':
+          throw TidalException('The Tidal sign-in code expired. Try again.');
+        case 'access_denied':
+          throw TidalException('Tidal sign-in was denied.');
+        case 'slow_down':
+          sleep += 5;
+          break;
+        default:
+          break; // authorization_pending — keep polling.
+      }
+    }
+    throw TidalException('Timed out waiting for Tidal sign-in.');
+  }
+
+  /// Resolve the user id + country code from the bearer `/sessions` endpoint.
+  /// The OAuth token response carries neither, so they must be fetched here.
+  Future<({String userId, String countryCode})> _fetchSession(
+    String accessToken,
+  ) async {
+    try {
+      final response = await _client
+          .get(
+            Uri.parse('$_apiBase/sessions'),
+            headers: {'Authorization': 'Bearer $accessToken'},
+          )
+          .timeout(const Duration(seconds: 15));
+      if (response.statusCode == 200) {
+        final j = jsonDecode(response.body) as Map<String, dynamic>;
+        final uid = j['userId']?.toString();
+        final cc = j['countryCode'] as String?;
+        if (uid != null && uid.isNotEmpty) {
+          return (
+            userId: uid,
+            countryCode: (cc != null && cc.isNotEmpty) ? cc : 'US',
+          );
+        }
+      }
+    } catch (_) {/* fall through to defaults */}
+    return (userId: '', countryCode: 'US');
+  }
+
+  // --- Token lifecycle (refresh + persist) -------------------------------
+
+  Future<_TidalCreds> _ensureValidToken(NetworkServerEntity server) async {
+    final creds = _creds(server.token);
+    if (creds == null) {
+      throw TidalException('No Tidal sign-in. Tap "Sign in with Tidal".');
+    }
+    final nearExpiry = creds.expiresAtMs == null ||
+        DateTime.now().millisecondsSinceEpoch > creds.expiresAtMs! - 60000;
+    if (nearExpiry && creds.refreshToken != null) {
+      return _refresh(server, creds);
+    }
+    return creds;
+  }
+
+  Future<_TidalCreds> _refresh(
+    NetworkServerEntity server,
+    _TidalCreds old,
+  ) async {
+    final refresh = old.refreshToken;
+    if (refresh == null) {
+      throw TidalException('Tidal session expired. Please sign in again.');
+    }
+    final tok = await _postForm('$_authBase/token', {
+      'client_id': clientId,
+      if (clientSecret.isNotEmpty) 'client_secret': clientSecret,
+      'grant_type': 'refresh_token',
+      'refresh_token': refresh,
+    });
+    final access = tok['access_token'] as String?;
+    if (access == null) {
+      throw TidalException('Tidal token refresh failed.');
+    }
+    final updated = _TidalCreds(
+      accessToken: access,
+      refreshToken: (tok['refresh_token'] as String?) ?? refresh,
+      userId: old.userId,
+      countryCode: old.countryCode,
+      expiresAtMs: DateTime.now()
+          .add(Duration(seconds: (tok['expires_in'] as num?)?.toInt() ?? 3600))
+          .millisecondsSinceEpoch,
+    );
+    await _persist(server, updated);
+    return updated;
+  }
+
+  Future<void> _persist(NetworkServerEntity server, _TidalCreds creds) async {
+    final token = jsonEncode({
+      'access_token': creds.accessToken,
+      'refresh_token': creds.refreshToken,
+      'user_id': creds.userId,
+      'country_code': creds.countryCode,
+      'expires_at_ms': creds.expiresAtMs,
+    });
+    try {
+      await Database.instance.writeTxn(() async {
+        final stored = await Database.networkServers.get(server.id);
+        if (stored != null) {
+          stored.token = token;
+          await Database.networkServers.put(stored);
+        }
+      });
+    } catch (e) {
+      devLog('Tidal token persist failed: $e');
+    }
+  }
+
+  // --- JSON API ----------------------------------------------------------
+
+  Future<Map<String, dynamic>> _apiGet(
+    NetworkServerEntity server,
+    String path, {
+    Map<String, String>? query,
+    bool retry = true,
+  }) async {
+    final creds = await _ensureValidToken(server);
+    final uri = Uri.parse('$_apiBase$path').replace(queryParameters: {
+      'countryCode': creds.countryCode,
+      ...?query,
+    });
+    final response = await _client.get(uri, headers: {
+      'Authorization': 'Bearer ${creds.accessToken}',
+      'Accept': 'application/json',
+    }).timeout(const Duration(seconds: 20));
+    if (response.statusCode == 401 && retry && creds.refreshToken != null) {
+      await _refresh(server, creds);
+      return _apiGet(server, path, query: query, retry: false);
+    }
+    if (response.statusCode != 200) {
+      throw TidalException('HTTP ${response.statusCode} for $path');
+    }
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> _postForm(
+    String url,
+    Map<String, String> fields, {
+    bool raw = false,
+  }) async {
+    final response = await _client
+        .post(Uri.parse(url), body: fields)
+        .timeout(const Duration(seconds: 20));
+    final body = response.body;
+    Map<String, dynamic>? parsed;
+    if (body.isNotEmpty) {
+      try {
+        parsed = jsonDecode(body) as Map<String, dynamic>;
+      } catch (_) {/* parsed stays null */}
+    }
+    if (response.statusCode != 200 && !raw) {
+      // Raw detail only for developers; the user sees a friendly message.
+      devLog('[Tidal] POST $url -> HTTP ${response.statusCode}: $body');
+      throw TidalException(_friendlyHttp(response.statusCode, parsed));
+    }
+    return parsed ?? <String, dynamic>{};
+  }
+
+  /// Map a raw HTTP failure to a short, user-facing message. The raw body is
+  /// logged separately via [devLog] (developer mode only).
+  static String _friendlyHttp(int status, Map<String, dynamic>? parsed) {
+    final err = parsed?['error'] as String?;
+    if (err == 'invalid_client') {
+      return 'Tidal rejected the app sign-in key. It rotates these — the built-in '
+          'key may be out of date (a known limitation of the unofficial path).';
+    }
+    if (status == 401 || status == 403) {
+      return 'Tidal refused the sign-in. Try again.';
+    }
+    if (status == 429) {
+      return 'Too many Tidal requests. Wait a moment and try again.';
+    }
+    if (status >= 500) {
+      return 'Tidal is unavailable right now. Try again shortly.';
+    }
+    return 'Could not reach Tidal (HTTP $status). Check your connection.';
+  }
+
+  // --- ping --------------------------------------------------------------
+
+  @override
+  Future<bool> ping(NetworkServerEntity server) async {
+    final creds = _creds(server.token);
+    if (creds == null || creds.userId == null || creds.userId!.isEmpty) {
+      devLog('Tidal ping failed: no stored token');
+      return false;
+    }
+    try {
+      await _apiGet(server, '/users/${creds.userId}');
+      return true;
+    } catch (e) {
+      devLog('Tidal ping failed: $e');
+      return false;
+    }
+  }
+
+  // --- Cover art ---------------------------------------------------------
+
+  @override
+  Future<List<int>> getCoverArt(
+    NetworkServerEntity server,
+    String marker,
+  ) async {
+    final url = coverUrl(marker);
+    if (url.isEmpty) {
+      throw TidalException('No Tidal cover for $marker');
+    }
+    final response =
+        await _client.get(Uri.parse(url)).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) {
+      throw TidalException('HTTP ${response.statusCode} for cover $marker');
+    }
+    return response.bodyBytes;
+  }
+
+  /// Build a `resources.tidal.com` cover URL from a Tidal cover uuid.
+  @visibleForTesting
+  static String coverUrl(String coverUuid, {int size = 1280}) {
+    final id = coverUuid.replaceAll('-', '');
+    if (id.length < 5) return '';
+    final part = '${id.substring(0, 2)}/${id.substring(2, 4)}/${id.substring(4)}';
+    return '$_coverHost/$part/${size}x$size.jpg';
+  }
+
+  // --- Stream ----------------------------------------------------------
+
+  @override
+  Future<({String url, Map<String, String> headers})?> streamDescriptor(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+  }) async {
+    final resolved = await _resolveStreamable(server, remoteId);
+    if (resolved == null) return null;
+    return (url: resolved.url, headers: const <String, String>{});
+  }
+
+  @override
+  Future<String> stream(
+    NetworkServerEntity server,
+    String remoteId, {
+    String? extension,
+    void Function(double progress)? onProgress,
+  }) async {
+    final cached = await _cache.getPath(server.id, remoteId, extension: extension);
+    if (cached != null) return cached;
+
+    final resolved = await _resolveStreamable(server, remoteId);
+    if (resolved == null) {
+      throw TidalException('No playable stream for $remoteId.');
+    }
+    final request = http.Request('GET', Uri.parse(resolved.url));
+    final response =
+        await _client.send(request).timeout(const Duration(minutes: 5));
+    if (response.statusCode != 200) {
+      throw TidalException('HTTP ${response.statusCode} for stream $remoteId');
+    }
+    final total = response.contentLength;
+    final builder = BytesBuilder();
+    var received = 0;
+    await for (final chunk in response.stream) {
+      builder.add(chunk);
+      received += chunk.length;
+      if (onProgress != null && total != null && total > 0) {
+        onProgress(received / total);
+      }
+    }
+    return _cache.stash(
+      server.id,
+      remoteId,
+      builder.takeBytes(),
+      extension: resolved.ext ?? extension,
+    );
+  }
+
+  /// Resolve a directly streamable CDN url + extension for a track, or null
+  /// when the content is not in a playable-unencrypted form.
+  Future<({String url, String? ext})?> _resolveStreamable(
+    NetworkServerEntity server,
+    String trackId,
+  ) async {
+    final info = await _apiGet(
+      server,
+      '/tracks/$trackId/playbackinfopostpaywall',
+      query: {'playbackmode': 'STREAM', 'assetpresentation': 'FULL'},
+    );
+    final mime = info['manifestMimeType'] as String?;
+    final manifest = info['manifest'] as String?;
+    if (mime != 'application/vnd.tidal.bts' || manifest == null) {
+      throw TidalException(
+        'Track $trackId uses an unsupported Tidal format (HiRes/MQA/Atmos). '
+        'Only unencrypted HiFi lossless is supported.',
+      );
+    }
+    final Map<String, dynamic> decoded;
+    try {
+      decoded =
+          jsonDecode(utf8.decode(base64Decode(manifest))) as Map<String, dynamic>;
+    } catch (e) {
+      throw TidalException('Could not decode Tidal manifest for $trackId: $e');
+    }
+    if (decoded['encryptionType'] != 'NONE') {
+      throw TidalException(
+        'Track $trackId is encrypted (HiRes/MQA). Only unencrypted HiFi '
+        'lossless is supported.',
+      );
+    }
+    final urls = decoded['urls'] as List<dynamic>?;
+    if (urls == null || urls.isEmpty) {
+      throw TidalException('Track $trackId manifest has no stream URL.');
+    }
+    return (
+      url: urls.first as String,
+      ext: _extFromMime(decoded['mimeType'] as String?),
+    );
+  }
+
+  @visibleForTesting
+  static String? extFromMime(String? mime) => _extFromMime(mime);
+  static String? _extFromMime(String? mime) {
+    switch (mime) {
+      case 'audio/flac':
+      case 'audio/x-flac':
+        return 'flac';
+      case 'audio/mp4':
+      case 'audio/m4a':
+      case 'audio/x-m4a':
+        return 'm4a';
+      case 'audio/mpeg':
+        return 'mp3';
+      default:
+        return null;
+    }
+  }
+
+  // --- Sync --------------------------------------------------------------
+
+  @override
+  Stream<ScanProgress> syncLibrary(NetworkServerEntity server) async* {
+    final creds = _creds(server.token);
+    if (creds == null || creds.userId == null || creds.userId!.isEmpty) {
+      throw TidalException('No Tidal sign-in. Tap "Sign in with Tidal".');
+    }
+    // ponytail: sync the user's favorite tracks (paginated, capped). Favorites
+    // map 1:1 to SongEntity with embedded album/artist metadata. Pulling full
+    // playlists/my-collection is a follow-up; this is the bounded, predictable
+    // surface that fits the existing scan progress UI.
+    const pageSize = 100;
+    const maxTracks = 2000;
+    final syncedRemoteIds = <String>{};
+    var offset = 0;
+    var songsFound = 0;
+    var totalEstimate = 0;
+
+    while (offset < maxTracks) {
+      final Map<String, dynamic> payload;
+      try {
+        payload = await _apiGet(
+          server,
+          '/users/${creds.userId}/favorites/tracks',
+          query: {'limit': '$pageSize', 'offset': '$offset'},
+        );
+      } catch (e) {
+        devLog('Tidal sync page @ $offset failed: $e');
+        break;
+      }
+      final items = (payload['items'] as List<dynamic>?) ?? const [];
+      if (items.isEmpty) break;
+      totalEstimate =
+          (payload['totalNumberOfItems'] as num?)?.toInt() ?? (offset + items.length);
+
+      final entities = <SongEntity>[];
+      for (final raw in items) {
+        final item = (raw as Map<String, dynamic>)['item'] as Map<String, dynamic>?;
+        if (item == null) continue;
+        final entity = buildSongEntity(server, item);
+        if (entity != null) entities.add(entity);
+      }
+      if (entities.isNotEmpty) {
+        await _repo.upsertSongs(entities);
+        syncedRemoteIds.addAll(entities.map((e) => e.remoteId!));
+        songsFound += entities.length;
+      }
+
+      offset += items.length;
+      yield ScanProgress(
+        songsFound: songsFound,
+        totalFiles: totalEstimate,
+        filesProcessed: offset,
+        phase: 'Syncing ${server.label}',
+      );
+      if (items.length < pageSize) break;
+    }
+
+    await purgeAndStampNetworkSync(server, syncedRemoteIds);
+
+    yield ScanProgress(
+      songsFound: songsFound,
+      totalFiles: totalEstimate,
+      filesProcessed: offset,
+      phase: 'Syncing ${server.label}',
+      isComplete: true,
+    );
+  }
+
+  /// Map a Tidal track object to a [SongEntity]. Returns null when the track
+  /// lacks an id. Pure (no network/DB) so it can be unit-tested directly.
+  @visibleForTesting
+  static SongEntity? buildSongEntity(NetworkServerEntity server, Map<String, dynamic> t) {
+    final remoteId = t['id']?.toString();
+    if (remoteId == null) return null;
+    final artists = (t['artists'] as List<dynamic>?)?.cast<Map<String, dynamic>?>();
+    final album = t['album'] as Map<String, dynamic>?;
+    final durationSec = (t['duration'] as num?)?.toInt();
+    final cover = (album?['cover'] as String?) ?? (t['cover'] as String?);
+    return SongEntity()
+      ..filePath = '${NetworkProtocol.tidal}://${server.id}/$remoteId'
+      ..title = (t['title'] as String?) ?? 'Unknown'
+      ..artist = (artists != null && artists.isNotEmpty)
+          ? (artists.first?['name'] as String? ?? 'Unknown')
+          : ((album?['artist'] as Map<String, dynamic>?)?['name'] as String?) ??
+              'Unknown'
+      ..album = (album?['title'] as String?)
+      ..albumArtist =
+          ((album?['artist'] as Map<String, dynamic>?)?['name'] as String?)
+      ..durationMs = durationSec == null ? null : durationSec * 1000
+      ..trackNumber = (t['trackNumber'] as num?)?.toInt()
+      ..discNumber = (t['volumeNumber'] as num?)?.toInt()
+      ..year = _releaseYear(album?['releaseDate'] as String?)
+      ..fileType = _extForQuality(t['audioQuality'] as String?)
+      ..albumArtPath = (cover != null && cover.isNotEmpty)
+          ? '$_coverMarkerScheme$cover'
+          : null
+      ..sourceType = NetworkProtocol.tidal
+      ..remoteId = remoteId
+      ..remoteServerId = server.id
+      ..metadataComplete = true
+      ..dateAdded = DateTime.now()
+      ..lastModified = DateTime.now();
+  }
+
+  static int? _releaseYear(String? isoDate) {
+    if (isoDate == null || isoDate.length < 4) return null;
+    return int.tryParse(isoDate.substring(0, 4));
+  }
+
+  static String? _extForQuality(String? quality) {
+    switch (quality) {
+      case 'HIGH':
+        return 'm4a'; // AAC
+      case 'LOSSLESS':
+      case 'HI_RES_LOSSLESS':
+        return 'flac';
+      case 'HI_RES':
+        return 'flac'; // MQA-in-FLAC; likely unplayable here, surfaced at play.
+      default:
+        return null;
+    }
+  }
+}
+
+class _TidalCreds {
+  const _TidalCreds({
+    required this.accessToken,
+    this.refreshToken,
+    this.userId,
+    required this.countryCode,
+    this.expiresAtMs,
+  });
+  final String accessToken;
+  final String? refreshToken;
+  final String? userId;
+  final String countryCode;
+  final int? expiresAtMs;
+}
+
+class TidalException implements Exception {
+  final String message;
+  /// For device-flow launch failures (no callback path): the verification URL
+  /// the user can open manually to finish signing in.
+  final String? verificationUri;
+  TidalException(this.message, {this.verificationUri});
+  @override
+  String toString() => message;
+}

--- a/test/services/tidal_service_test.dart
+++ b/test/services/tidal_service_test.dart
@@ -1,0 +1,367 @@
+import 'dart:convert';
+
+import 'package:flick/data/entities/network_server_entity.dart';
+import 'package:flick/services/sources/tidal_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+NetworkServerEntity _server({String? token}) {
+  return NetworkServerEntity()
+    ..id = 9
+    ..label = 'Tidal'
+    ..protocol = 'tidal'
+    ..baseUrl = TidalService.tidalBaseUrl
+    ..username = null
+    ..token = token;
+}
+
+/// A far-future token blob so [TidalService._ensureValidToken] skips refresh
+/// (and therefore skips the DB write inside [_persist]).
+String _validToken() => jsonEncode({
+      'access_token': 'acc-xyz',
+      'refresh_token': 'ref-xyz',
+      'user_id': 'user-1',
+      'country_code': 'NO',
+      'expires_at_ms':
+          DateTime.now().add(const Duration(hours: 1)).millisecondsSinceEpoch,
+    });
+
+void main() {
+  group('buildSongEntity', () {
+    test('maps a Tidal track to a SongEntity with tidal:// path + cover marker',
+        () {
+      final server = _server();
+      final track = {
+        'id': 1234567,
+        'title': 'Nightcall',
+        'duration': 250,
+        'trackNumber': 1,
+        'volumeNumber': 1,
+        'artists': [
+          {'name': 'Kavinsky'}
+        ],
+        'album': {
+          'title': 'OutRun',
+          'releaseDate': '2013-02-25',
+          'cover': '1bce0bf4-a3b9-4c0a-9f2e-1234567890ab',
+          'artist': {'name': 'Kavinsky'},
+        },
+        'audioQuality': 'LOSSLESS',
+      };
+
+      final entity = TidalService.buildSongEntity(server, track);
+
+      expect(entity, isNotNull);
+      expect(entity!.filePath, 'tidal://9/1234567');
+      expect(entity.title, 'Nightcall');
+      expect(entity.artist, 'Kavinsky');
+      expect(entity.album, 'OutRun');
+      expect(entity.albumArtist, 'Kavinsky');
+      expect(entity.durationMs, 250000); // seconds -> milliseconds
+      expect(entity.trackNumber, 1);
+      expect(entity.discNumber, 1);
+      expect(entity.year, 2013);
+      expect(entity.fileType, 'flac');
+      expect(entity.albumArtPath, 'tidal-cover://1bce0bf4-a3b9-4c0a-9f2e-1234567890ab');
+      expect(entity.sourceType, 'tidal');
+      expect(entity.remoteId, '1234567');
+      expect(entity.remoteServerId, 9);
+    });
+
+    test('returns null when the track has no id', () {
+      expect(TidalService.buildSongEntity(_server(), {'title': 'x'}), isNull);
+    });
+  });
+
+  group('coverUrl', () {
+    test('slashes the hyphen-stripped uuid into a resources.tidal.com jpg', () {
+      final url = TidalService.coverUrl('1bce0bf4-a3b9-4c0a', size: 640);
+      expect(
+        url,
+        'https://resources.tidal.com/images/1b/ce/0bf4a3b94c0a/640x640.jpg',
+      );
+    });
+
+    test('returns empty for a too-short id', () {
+      expect(TidalService.coverUrl('ab'), '');
+    });
+  });
+
+  group('extFromMime', () {
+    test('maps flac / m4a / mp3', () {
+      expect(TidalService.extFromMime('audio/flac'), 'flac');
+      expect(TidalService.extFromMime('audio/mp4'), 'm4a');
+      expect(TidalService.extFromMime('audio/mpeg'), 'mp3');
+      expect(TidalService.extFromMime('audio/atmos'), isNull);
+    });
+  });
+
+  group('resolveToken (device flow)', () {
+    test('posts device_authorization, opens browser, polls until access_token',
+        () async {
+      var tokenCalls = 0;
+      Uri? openedUrl;
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/device_authorization')) {
+          return http.Response(
+            jsonEncode({
+              'deviceCode': 'dev-1',
+              'userCode': 'AB12CD',
+              'verificationUriComplete':
+                  'https://tidal.com/activate?code=AB12CD',
+              'interval': 0,
+              'expiresIn': 60,
+            }),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/sessions')) {
+          return http.Response(
+            jsonEncode({'userId': 'user-1', 'countryCode': 'NO'}),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/token')) {
+          tokenCalls++;
+          if (tokenCalls == 1) {
+            // Still waiting for the user to authorize.
+            return http.Response(
+              jsonEncode({'error': 'authorization_pending'}),
+              400,
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              'access_token': 'acc-1',
+              'refresh_token': 'ref-1',
+              'expires_in': 3600,
+            }),
+            200,
+          );
+        }
+        return http.Response('', 404);
+      });
+
+      final service = TidalService.create(
+        client: client,
+        urlOpener: (url) async {
+          openedUrl = url;
+          return true;
+        },
+      );
+
+      final token = await service.resolveToken(_server(), '');
+
+      expect(token, isNotNull);
+      final decoded = jsonDecode(token!) as Map<String, dynamic>;
+      expect(decoded['access_token'], 'acc-1');
+      expect(decoded['refresh_token'], 'ref-1');
+      expect(decoded['user_id'], 'user-1');
+      expect(openedUrl?.toString(),
+          'https://tidal.com/activate?code=AB12CD');
+      expect(tokenCalls, 2);
+    });
+
+    test('throws when the browser cannot open', () async {
+      final client = MockClient((request) async => http.Response(
+          jsonEncode({
+            'deviceCode': 'dev-1',
+            'verificationUriComplete': 'https://tidal.com/activate',
+            'interval': 0,
+            'expiresIn': 60,
+          }),
+          200));
+      final service = TidalService.create(
+        client: client,
+        urlOpener: (_) async => false,
+      );
+      expect(
+        () => service.resolveToken(_server(), ''),
+        throwsA(isA<TidalException>()),
+      );
+    });
+
+    test('catches a launcher exception and surfaces the link (not the crash)',
+        () async {
+      final client = MockClient((request) async => http.Response(
+          jsonEncode({
+            'deviceCode': 'dev-1',
+            'verificationUriComplete': 'https://link.tidal.com/AB12CD',
+            'interval': 0,
+            'expiresIn': 60,
+          }),
+          200));
+      // The launcher throws (e.g. Android ACTIVITY_NOT_FOUND PlatformException).
+      final service = TidalService.create(
+        client: client,
+        urlOpener: (_) async => throw Exception('ACTIVITY_NOT_FOUND'),
+      );
+
+      String? message;
+      try {
+        await service.resolveToken(_server(), '');
+      } on TidalException catch (e) {
+        message = e.message;
+      }
+
+      expect(message, isNotNull);
+      expect(message, contains('https://link.tidal.com/AB12CD'));
+      expect(message!.contains('ACTIVITY_NOT_FOUND'), isFalse);
+    });
+
+    test('signIn keeps polling after launch failure and reports the link',
+        () async {
+      var tokenCalls = 0;
+      String? reportedLink;
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/device_authorization')) {
+          return http.Response(
+            jsonEncode({
+              'deviceCode': 'dev-1',
+              'verificationUriComplete': 'https://link.tidal.com/ZZ',
+              'interval': 0,
+              'expiresIn': 60,
+            }),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/sessions')) {
+          return http.Response(
+            jsonEncode({'userId': 'u', 'countryCode': 'US'}),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/token')) {
+          tokenCalls++;
+          if (tokenCalls == 1) {
+            return http.Response(
+              jsonEncode({'error': 'authorization_pending'}),
+              400,
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              'access_token': 'a',
+              'refresh_token': 'r',
+              'expires_in': 3600,
+            }),
+            200,
+          );
+        }
+        return http.Response('', 404);
+      });
+      final service = TidalService.create(
+        client: client,
+        urlOpener: (_) async => throw Exception('ACTIVITY_NOT_FOUND'),
+      );
+
+      final token = await service.signIn(
+        onVerificationLink: (uri) => reportedLink = uri,
+      );
+
+      expect(reportedLink, 'https://link.tidal.com/ZZ');
+      expect(tokenCalls, 2); // one pending, then success
+      final decoded = jsonDecode(token!) as Map<String, dynamic>;
+      expect(decoded['access_token'], 'a');
+    });
+
+    test('shows a friendly error (no raw body/URL) on invalid_client', () async {
+      final client = MockClient((request) async {
+        if (request.url.path.endsWith('/device_authorization')) {
+          return http.Response(
+            jsonEncode({
+              'error': 'invalid_client',
+              'error_description': 'Invalid client id',
+            }),
+            401,
+          );
+        }
+        return http.Response('', 404);
+      });
+      final service = TidalService.create(
+        client: client,
+        urlOpener: (_) async => true,
+      );
+
+      String? message;
+      try {
+        await service.resolveToken(_server(), '');
+      } on TidalException catch (e) {
+        message = e.message;
+      }
+
+      expect(message, isNotNull);
+      expect(message, contains('rejected'));
+      // The raw OAuth error code + endpoint must NOT leak into the UI message.
+      expect(message!.contains('invalid_client'), isFalse);
+      expect(message.contains('POST http'), isFalse);
+      expect(message.contains('auth.tidal.com'), isFalse);
+    });
+  });
+
+  group('streamDescriptor', () {
+    test('decodes a NONE-encryption bts manifest to the CDN url', () async {
+      final manifest = base64Encode(utf8.encode(jsonEncode({
+        'mimeType': 'audio/flac',
+        'codecs': 'flac',
+        'encryptionType': 'NONE',
+        'urls': ['https://cdn.tidal.com/track/flac/abc'],
+      })));
+      final client = MockClient((request) async {
+        expect(request.url.path, contains('/playbackinfopostpaywall'));
+        expect(
+          request.headers['Authorization'],
+          'Bearer acc-xyz',
+        );
+        return http.Response(
+          jsonEncode({
+            'manifest': manifest,
+            'manifestMimeType': 'application/vnd.tidal.bts',
+            'assetPresentation': 'FULL',
+          }),
+          200,
+        );
+      });
+      final service = TidalService.create(client: client);
+
+      final desc = await service.streamDescriptor(
+        _server(token: _validToken()),
+        '1234567',
+      );
+
+      expect(desc, isNotNull);
+      expect(desc!.url, 'https://cdn.tidal.com/track/flac/abc');
+      expect(desc.headers, isEmpty);
+    });
+
+    test('throws a clear error for encrypted (MQA/HiRes) content', () async {
+      final manifest = base64Encode(utf8.encode(jsonEncode({
+        'mimeType': 'audio/flac',
+        'encryptionType': 'OLD',
+        'keyId': 'k1',
+        'urls': ['https://cdn.tidal.com/enc'],
+      })));
+      final client = MockClient((request) async => http.Response(
+          jsonEncode({
+            'manifest': manifest,
+            'manifestMimeType': 'application/vnd.tidal.bts',
+          }),
+          200));
+      final service = TidalService.create(client: client);
+
+      expect(
+        () => service.streamDescriptor(_server(token: _validToken()), '1'),
+        throwsA(isA<TidalException>()),
+      );
+    });
+  });
+
+  group('ping', () {
+    test('returns false when no token is stored', () async {
+      final service =
+          TidalService.create(client: MockClient((_) async => http.Response('{}', 200)));
+      expect(await service.ping(_server(token: null)), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Add Tidal streaming service with full protocol support, network source integration, and server edit configuration
- Add `VIEW` intent queries for Android 11+ package visibility
- Optimize WAV conversion with persistent caching and conditional logging
- Replace `flutter_cache_manager` with custom artwork cache in support directory
- Print dev logs to terminal and gate `AppLog` on dev mode

# Changes

## Tidal Streaming

- Add Tidal streaming service implementation (682 lines)
- Add Tidal protocol support to network sources
- Add Tidal integration to network server edit screen with multi-protocol config (240 insertions)
- Integrate Tidal into network source service
- Add tests for `TidalService` (367 lines)
- Update Tidal documentation and feature requests

## Dev Logs

- Print dev logs to terminal
- Gate `AppLog` logging on dev mode

## Android

- Add `VIEW` intent queries for Android 11+ package visibility in `AndroidManifest`

## WAV Conversion

- Optimize WAV conversion with persistent caching
- Add conditional logging

## Artwork Cache

- Replace `flutter_cache_manager` with custom artwork cache in support directory (174 lines rewritten)

## Files Changed

- `lib/services/sources/tidal_service.dart`
- `lib/services/sources/network_source_service.dart`
- `lib/features/settings/screens/network_server_edit_screen.dart`
- `lib/features/settings/screens/network_sources_screen.dart`
- `lib/services/player_service.dart`
- `lib/services/album_art_service.dart`
- `lib/core/utils/dev_log.dart`
- `lib/data/entities/network_server_entity.dart`
- `lib/data/entities/song_entity.dart`
- `android/app/src/main/AndroidManifest.xml`
- `test/services/tidal_service_test.dart`
- `FEATURE_REQUESTS.md`