### PR TITLE
Make Cast SDK optional, refactor rotary knob gestures, add equalizer band animations, and init Bluetooth flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bluetooth
+- **Fix:** Hi-Res Direct no longer forces the `dapInternalHighRes` engine on Bluetooth routes. That engine is a wired/internal path and caused reported volume loss (output capped near 35-40% at max volume) and periodic dropouts every 5-10s over A2DP. Bluetooth now keeps the BT-appropriate engine (Rust/Oboe under low-latency, else normal Android). Codec quality remains controlled by the user's per-codec preferences and LDAC bitrate setting.
+- **Fix:** Bluetooth output-mode toggles (Hi-Res Direct, Low-latency Mode) now survive an app restart. Their notifiers were never hydrated from storage at startup, so they appeared reset to off after relaunch.
+
 ## 0.21.0-beta.1 (2026-07-10)
 
 ### Network Sources — Self-Hosted Music Servers
@@ -241,11 +247,10 @@
 ## 0.20.2-beta.3 (2026-06-27)
 
 ### Bluetooth Codec Control
-- **Bluetooth Hi-Res Direct mode** forces highest-quality codec path.
+- **Bluetooth Hi-Res Direct mode** biases route selection toward a high-resolution engine path.
 - Per-codec preference controls with persistence (AAC, aptX, LDAC, etc.).
 - Codec preferences applied on Bluetooth init and connect.
 - Device connection state tracking with codec configuration feedback.
-- Hi-Res Direct mode resolved before low-latency in audio route selection.
 - Bluetooth settings refactored with codec control, device filtering, and UI refinements.
 - Developer mode toggle for advanced codec debugging.
 

--- a/android/app/src/main/kotlin/com/mossapps/flick/CastController.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/CastController.kt
@@ -1,6 +1,7 @@
 package com.mossapps.flick
 
 import android.content.Context
+import android.util.Log
 import androidx.mediarouter.media.MediaRouter
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaMetadata
@@ -15,7 +16,17 @@ import java.util.concurrent.TimeUnit
 // (CastContext creates the session); control = RemoteMediaClient on the session.
 class CastController(private val context: Context) {
     private val mediaRouter: MediaRouter by lazy { MediaRouter.getInstance(context) }
-    private val castContext: CastContext by lazy { CastContext.getSharedInstance(context) }
+    // ponytail: Cast SDK needs Google Play Services; null out on GMS-free
+    // devices (GrapheneOS etc.) so the app runs without Cast instead of
+    // crashing on launch. MediaRouter output routing still works without GMS.
+    private val castContext: CastContext? by lazy {
+        try {
+            CastContext.getSharedInstance(context)
+        } catch (e: Throwable) {
+            Log.w("CastController", "Cast SDK unavailable (no Google Play Services): ${e.message}")
+            null
+        }
+    }
     private val handler = android.os.Handler(android.os.Looper.getMainLooper())
 
     private var eventSink: android.os.Handler? = null
@@ -40,7 +51,7 @@ class CastController(private val context: Context) {
     }
 
     fun start() {
-        castContext.sessionManager.addSessionManagerListener(sessionListener, CastSession::class.java)
+        castContext?.sessionManager?.addSessionManagerListener(sessionListener, CastSession::class.java)
     }
 
     fun discover(): List<Map<String, Any>> {
@@ -68,14 +79,16 @@ class CastController(private val context: Context) {
     }
 
     fun disconnect() {
-        if (castContext.sessionManager.currentCastSession != null) {
-            castContext.sessionManager.endCurrentSession(true)
+        val sessionManager = castContext?.sessionManager
+        if (sessionManager?.currentCastSession != null) {
+            sessionManager.endCurrentSession(true)
         }
         connectedSession = null
     }
 
     private fun client(): RemoteMediaClient? {
-        return connectedSession?.remoteMediaClient ?: castContext.sessionManager.currentCastSession?.remoteMediaClient
+        val sessionManager = castContext?.sessionManager ?: return null
+        return connectedSession?.remoteMediaClient ?: sessionManager.currentCastSession?.remoteMediaClient
     }
 
     fun load(url: String, title: String?, artist: String?) {

--- a/docs/RELEASE_0.20.2-beta.3.md
+++ b/docs/RELEASE_0.20.2-beta.3.md
@@ -16,7 +16,7 @@ This beta adds seven headline features:
 
 ## Highlights
 
-- **Bluetooth codec control**: A Hi-Res Direct mode forces the highest-quality codec (LDAC, aptX HD) for compatible headphones. Per-codec preferences (AAC, aptX, LDAC, SBC, etc.) are persisted and applied on Bluetooth init and device connect. Device connection state is tracked with codec configuration feedback in the UI. Hi-Res Direct mode is resolved before low-latency in audio route selection. Bluetooth settings gained device filtering, UI refinements, and a developer mode toggle for advanced codec debugging.
+- **Bluetooth codec control**: A Hi-Res Direct mode biases audio route selection toward a high-resolution engine path for compatible headphones. Per-codec preferences (AAC, aptX, LDAC, SBC, etc.) are persisted and applied on Bluetooth init and device connect. Device connection state is tracked with codec configuration feedback in the UI. Bluetooth settings gained device filtering, UI refinements, and a developer mode toggle for advanced codec debugging.
 - **Glance cards**: Each Quick Access card (Recently Played, Smart Mixes, Artists, etc.) can now be hidden, shown, or minimized independently. Per-card preferences are persisted. `AlbumsScreen` was migrated to `ConsumerStatefulWidget` (Riverpod) with app preferences. Single-art and empty-art album edge cases are handled, and the album year is displayed on album cards. `AlbumArtPickerBottomSheet` returns a change status for reactive UI updates. A stale song provider after in-place art updates is prevented.
 - **Streak polish**: The animated shimmer streak number on the popup was replaced with static tier-colored text — no more phantom shimmer glitter. Dynamic tier colors and glow effects pulse on the streak banner. Tier color and count helpers were added to `MilestoneCategoryX`. New unit tests cover tier colors and counts.
 - **USB fixes**: Write-only USB clocks (devices that don't support readback on `GET_CUR`) are now supported by trusting the `SET_CUR` value. A USB permission `PendingIntent` failure on devices with restrictive package handling is fixed.
@@ -28,11 +28,10 @@ This beta adds seven headline features:
 
 ### Bluetooth Codec Control
 
-- Hi-Res Direct mode forces highest-quality codec
+- Hi-Res Direct mode biases toward a high-resolution engine path
 - Per-codec preference persistence (AAC, aptX, LDAC, etc.)
 - Codec preferences applied on init and connect
 - Device connection state with codec feedback
-- Hi-Res Direct before low-latency in route resolution
 - Device filtering and UI refinements in Bluetooth settings
 - Developer mode toggle for codec debugging
 

--- a/lib/features/settings/screens/equalizer_screen.dart
+++ b/lib/features/settings/screens/equalizer_screen.dart
@@ -2358,14 +2358,35 @@ class _ParametricEqViewState extends ConsumerState<_ParametricEqView> {
                   _ScrollProgressBar(
                     controller: _bandScrollController,
                   ),
-                  if (_selectedIndex != null &&
-                      _selectedIndex! < bands.length) ...[
-                    const SizedBox(height: AppConstants.spacingMd),
-                    _BandDetailPanel(
-                      index: _selectedIndex!,
-                      enabled: enabled,
-                    ),
-                  ],
+                  AnimatedSize(
+                    duration: AppConstants.animationNormal,
+                    curve: Curves.easeInOutCubic,
+                    alignment: Alignment.topCenter,
+                    child: (_selectedIndex != null &&
+                            _selectedIndex! < bands.length)
+                        ? Padding(
+                            padding: const EdgeInsets.only(
+                              top: AppConstants.spacingMd,
+                            ),
+                            child: TweenAnimationBuilder<double>(
+                              tween: Tween(begin: 0.0, end: 1.0),
+                              duration: AppConstants.animationNormal,
+                              curve: Curves.easeOutCubic,
+                              builder: (context, t, child) => Opacity(
+                                opacity: t,
+                                child: Transform.translate(
+                                  offset: Offset(0, 8 * (1 - t)),
+                                  child: child,
+                                ),
+                              ),
+                              child: _BandDetailPanel(
+                                index: _selectedIndex!,
+                                enabled: enabled,
+                              ),
+                            ),
+                          )
+                        : const SizedBox(width: double.infinity),
+                  ),
                 ],
               ),
             ),

--- a/lib/features/whats_new/data/changelog_data.dart
+++ b/lib/features/whats_new/data/changelog_data.dart
@@ -482,11 +482,10 @@ const List<ChangelogEntry> kChangelogEntries = [
       ChangelogSection(
         title: 'Bluetooth Codec Control',
         bullets: [
-          '**Bluetooth Hi-Res Direct mode** — forces the highest-quality codec path for capable headphones.',
+          '**Bluetooth Hi-Res Direct mode** — biases route selection toward a high-resolution engine path.',
           'Per-codec preference controls with persistence (AAC, aptX, LDAC, etc.).',
           'Codec preferences applied on Bluetooth init and on device connect.',
           'Device connection state tracking with codec configuration feedback.',
-          'Hi-Res Direct mode resolved before low-latency in audio route selection.',
           'Bluetooth settings refactored with codec control, device filtering, and UI refinements.',
           'Developer mode toggle in Bluetooth settings for advanced codec debugging.',
         ],

--- a/lib/services/audio_session_manager.dart
+++ b/lib/services/audio_session_manager.dart
@@ -182,6 +182,7 @@ class AudioSessionManager {
     await _preferencesService.initializeDeveloperModeCache();
     await _preferencesService.initializeKillIsochronousUsbOnQuitCache();
     await _preferencesService.initialize432HzTuningCache();
+    await _preferencesService.initializeBtFlagsCache();
     await _deviceService.initialize();
     selectedModeNotifier.value = await _resolvePreferredMode();
 
@@ -260,15 +261,10 @@ class AudioSessionManager {
     );
 
     if (info.isBluetoothRoute) {
-      final btHiResDirect = await _preferencesService.getBtHiResDirect();
-      if (btHiResDirect) {
-        _debugLog(
-          '[Session] Selected DAP_INTERNAL_HIGH_RES for Bluetooth because '
-          'Hi-Res Direct is enabled '
-          '(${info.routeLabel ?? info.routeType ?? 'unknown'})',
-        );
-        return AudioEngineType.dapInternalHighRes;
-      }
+      // ponytail: Hi-Res Direct no longer swaps the BT engine. dapInternalHighRes
+      // is a wired/internal path; on A2DP it caused level loss + 5-10s dropouts
+      // (link-budget underruns). Codec quality stays driven by the user's codec
+      // prefs (_applyBluetoothCodecPrefs). Hi-Res Direct state is logged above.
       if (Uac2PreferencesService.isBtLowLatencyModeSync) {
         _debugLog(
           '[Session] Selected RUST_OBOE for Bluetooth because Low-latency mode '

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1278,6 +1278,7 @@ class PlayerService {
         _preferencesService.initializeDeveloperModeCache(),
         _preferencesService.initializeKillIsochronousUsbOnQuitCache(),
         _preferencesService.initialize432HzTuningCache(),
+        _preferencesService.initializeBtFlagsCache(),
         _preferencesService.getDsdOutputMode(),
         _sessionManager.initialize(),
         _uac2Service.isBitPerfectEnabled(),

--- a/lib/services/uac2_preferences_service.dart
+++ b/lib/services/uac2_preferences_service.dart
@@ -291,6 +291,13 @@ class Uac2PreferencesService {
     }
   }
 
+  // ponytail: getters hydrate their notifiers as a side effect; this just gives
+  // startup a named entry point so the BT toggles survive an app restart.
+  Future<void> initializeBtFlagsCache() async {
+    await getBtHiResDirect();
+    await getBtLowLatencyMode();
+  }
+
   Future<void> setDeveloperModeEnabled(bool enabled) async {
     try {
       final prefs = await SharedPreferences.getInstance();

--- a/lib/widgets/common/rotary_knob.dart
+++ b/lib/widgets/common/rotary_knob.dart
@@ -9,10 +9,12 @@ import 'package:flick/core/utils/app_haptics.dart';
 
 /// A circular rotary knob for parameter control.
 ///
-/// Uses a custom gesture recognizer that eagerly accepts drag events,
-/// preventing parent scrollables (e.g. PageView, ListView) from
-/// intercepting horizontal/vertical swipes while the user is turning
-/// the knob.
+/// Turns via a rotary gesture: the finger's motion is projected onto the
+/// knob's tangent, so natural circular/arc swipes turn it (clockwise =
+/// increase). Sensitivity is constant regardless of where the knob was
+/// grabbed. A custom gesture recognizer eagerly accepts the pointer so
+/// parent scrollables (PageView, ListView) can't steal the drag, and the
+/// finger can travel beyond the knob while turning.
 class RotaryKnob extends StatefulWidget {
   final double value;
   final double min;
@@ -47,12 +49,9 @@ class _RotaryKnobState extends State<RotaryKnob>
   bool _isDragging = false;
   late AnimationController _animController;
 
-  Offset _lastGlobalPosition = Offset.zero;
-  double _lastAngle = 0.0;
-  // Full turns of arc drag for a full min->max sweep. Tuned for fine control.
-  static const double _fullSweepTurns = 1.5;
-  // Pixels of vertical drag (center fallback) for a full sweep.
+  // Pixels of arc travel for a full min->max sweep.
   static const double _fullSweepPixels = 360.0;
+  Offset _lastLocal = Offset.zero;
 
   @override
   void initState() {
@@ -113,58 +112,43 @@ class _RotaryKnobState extends State<RotaryKnob>
     return math.pi * 0.75 + clampedT * (1.5 * math.pi);
   }
 
+  Offset _localOf(Offset globalPosition) {
+    final box = context.findRenderObject() as RenderBox?;
+    return box?.globalToLocal(globalPosition) ?? Offset.zero;
+  }
+
   void _handleDragStart(Offset globalPosition) {
     if (widget.onChanged == null) return;
     _animController.stop();
     _isDragging = true;
-    _lastGlobalPosition = globalPosition;
-    _lastAngle = _angleFromCenter(globalPosition);
+    _lastLocal = _localOf(globalPosition);
+    _lastHapticValue = _currentValue;
   }
 
-  double _angleFromCenter(Offset globalPosition) {
-    final box = context.findRenderObject() as RenderBox?;
-    if (box == null) return 0.0;
-    final localPos = box.globalToLocal(globalPosition);
-    final center = Offset(widget.size / 2, widget.size / 2);
-    return math.atan2(localPos.dy - center.dy, localPos.dx - center.dx);
-  }
-
-  double _radiusFromCenter(Offset globalPosition) {
-    final box = context.findRenderObject() as RenderBox?;
-    if (box == null) return 0.0;
-    final localPos = box.globalToLocal(globalPosition);
-    final center = Offset(widget.size / 2, widget.size / 2);
-    return (localPos - center).distance;
-  }
-
+  // Rotary gesture via tangent projection: the component of finger motion
+  // along the circle's tangent drives the value. Clockwise = increase,
+  // counterclockwise = decrease (standard knob convention). Value-per-pixel
+  // is constant regardless of where the knob was grabbed, so it stays stable
+  // with natural arc/circular swipes. Near the exact center (where the
+  // tangent direction is undefined) it falls back to vertical drag.
   void _handleDragUpdate(Offset globalPosition) {
     if (widget.onChanged == null || !_isDragging) return;
+    final local = _localOf(globalPosition);
     final range = widget.max - widget.min;
-    final radius = _radiusFromCenter(globalPosition);
+    final center = Offset(widget.size / 2, widget.size / 2);
+    final delta = local - _lastLocal;
+    _lastLocal = local;
 
-    double valueDelta;
-    if (radius > widget.size * 0.15) {
-      final angle = _angleFromCenter(globalPosition);
-      var delta = angle - _lastAngle;
-      // Shortest signed delta, handling the ±π wraparound.
-      if (delta > math.pi) {
-        delta -= 2 * math.pi;
-      } else if (delta < -math.pi) {
-        delta += 2 * math.pi;
-      }
-      _lastAngle = angle;
-      // Clockwise (positive delta in screen coords) = increase.
-      valueDelta = delta / (_fullSweepTurns * 2 * math.pi) * range;
-    } else {
-      final dy = globalPosition.dy - _lastGlobalPosition.dy;
-      _lastAngle = _angleFromCenter(globalPosition);
-      valueDelta = -dy * range / _fullSweepPixels;
-    }
+    final r = local - center;
+    final radius = r.distance;
+    // Clockwise tangent (screen coords) = (-r.dy, r.dx); projecting the
+    // movement onto it yields signed arc travel. Center dead zone uses -dy.
+    final travel = radius > widget.size * 0.2
+        ? (delta.dx * -r.dy + delta.dy * r.dx) / radius
+        : -delta.dy;
 
-    _lastGlobalPosition = globalPosition;
-
-    final newValue =
-        (_currentValue + valueDelta).clamp(widget.min, widget.max);
+    final newValue = (_currentValue + travel * range / _fullSweepPixels)
+        .clamp(widget.min, widget.max);
     final snapped = (newValue * 10).round() / 10.0;
 
     final diff = (snapped - _lastHapticValue).abs();


### PR DESCRIPTION
# Summary

- Make Google Cast SDK optional to support GMS-free devices
- Refactor rotary knob gesture handling to use tangent projection for precise control
- Add smooth animations for band detail panel in equalizer
- Initialize Bluetooth flags cache on startup and remove Hi-Res Direct BT engine swap
- Document Bluetooth fixes in changelog

# Changes

## Cast SDK Optional

- Make Cast SDK optional to support GMS-free devices

## Rotary Knob

- Refactor rotary knob gesture handling to use tangent projection for more precise angular control

## Equalizer

- Add smooth animations for band detail panel in equalizer screen

## Bluetooth

- Initialize Bluetooth flags cache on startup
- Remove Hi-Res Direct Bluetooth engine swap in favor of flags init
- Clarify Bluetooth Hi-Res Direct mode in changelog

## Docs

- Document Bluetooth fixes in Unreleased changelog section

## Files Changed

- `lib/widgets/common/rotary_knob.dart`
- `lib/features/settings/screens/equalizer_screen.dart`
- `lib/services/bluetooth_service.dart`
- `android/app/build.gradle.kts`
- `CHANGELOG.md`