### PR TITLE
Refactor volume authority logic, add compact player layout, and improve audio engine robustness

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:screenOrientation="portrait"
-            android:resizeableActivity="false"
+            android:resizeableActivity="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">

--- a/android/app/src/main/kotlin/com/mossapps/flick/PriorityAnchorService.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/PriorityAnchorService.kt
@@ -130,9 +130,11 @@ class PriorityAnchorService(private val context: Context) {
     private fun findBuiltinAudioDevice(): AudioDeviceInfo? {
         val manager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         val devices = manager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+        // Never claim the earpiece: an active media track pinned there makes it
+        // the active media route, so streams reopened after track end follow it
+        // off the main speaker.
         return devices.firstOrNull {
             it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
-                || it.type == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
         }
     }
 }

--- a/lib/features/player/screens/full_player_screen.dart
+++ b/lib/features/player/screens/full_player_screen.dart
@@ -24,7 +24,6 @@ import 'package:flick/services/favorites_service.dart';
 import 'package:flick/services/lyrics_service.dart';
 import 'package:flick/services/player_screen_mode_preference_service.dart';
 
-
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/uac2/iso_volume_popup.dart';
 import 'package:flick/providers/providers.dart';
@@ -57,6 +56,7 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
     _dismissVolumePopup = null;
     Navigator.of(context).pop();
   }
+
   static const String _topBarTextFontFamily = 'ProductSans';
   static const FontWeight _topBarTextFontWeight = FontWeight.w500;
 
@@ -362,7 +362,8 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                 onVerticalDragStart: (details) {
                   if (_isVinylRotationActive) return;
                   final screenHeight = MediaQuery.sizeOf(context).height;
-                  if (details.globalPosition.dy >= screenHeight - _backGestureEdgeWidth) {
+                  if (details.globalPosition.dy >=
+                      screenHeight - _backGestureEdgeWidth) {
                     _dragOffset = 0.0;
                     return;
                   }
@@ -411,10 +412,13 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                   final screenWidth = MediaQuery.sizeOf(context).width;
                   final screenHeight = MediaQuery.sizeOf(context).height;
                   final nearBottomEdge =
-                      _horizontalDragStartY >= screenHeight - _backGestureEdgeWidth;
-                  final nearLeftEdge = _horizontalDragStartX <= _backGestureEdgeWidth;
+                      _horizontalDragStartY >=
+                      screenHeight - _backGestureEdgeWidth;
+                  final nearLeftEdge =
+                      _horizontalDragStartX <= _backGestureEdgeWidth;
                   final nearRightEdge =
-                      _horizontalDragStartX >= screenWidth - _backGestureEdgeWidth;
+                      _horizontalDragStartX >=
+                      screenWidth - _backGestureEdgeWidth;
                   if (nearLeftEdge || nearRightEdge || nearBottomEdge) return;
 
                   if (details.primaryVelocity! < -500) {
@@ -488,33 +492,35 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
                         _navigation.openAlbumFromSong(context, song),
                     buildFileInfoRow: (song, lyricsMode, mode) =>
                         PlayerActionButtonRow(
-                      song: song,
-                      lyricsMode: lyricsMode,
-                      isVisualizationMode: _isVisualizationMode,
-                      playerScreenMode: mode,
-                      albumColor: albumColor,
-                      albumColorMode: colorMode,
-                      leftTopAction: PlayerActionButtonX.fromStorageValue(
-                        appPrefs.leftTopActionButton,
-                      ),
-                      leftAction: PlayerActionButtonX.fromStorageValue(
-                        appPrefs.leftActionButton,
-                      ),
-                      rightTopAction: PlayerActionButtonX.fromStorageValue(
-                        appPrefs.rightTopActionButton,
-                      ),
-                      rightAction: PlayerActionButtonX.fromStorageValue(
-                        appPrefs.rightActionButton,
-                      ),
-                      playerService: _playerService,
-                      favoritesService: _favoritesService,
-                      onToggleLyrics: () =>
-                          setState(() => _isLyricsMode = !lyricsMode),
-                      onToggleVisualization: (v) => _setVisualizationMode(v),
-                      onOpenQueue: (ctx) => _navigation.openQueue(ctx),
-                      usbVolumeButtonKey: _usbVolumeButtonKey,
-                      onShowUsbVolumePopup: (ctx) => _showUsbVolumePopup(ctx),
-                    ),
+                          song: song,
+                          lyricsMode: lyricsMode,
+                          isVisualizationMode: _isVisualizationMode,
+                          playerScreenMode: mode,
+                          albumColor: albumColor,
+                          albumColorMode: colorMode,
+                          leftTopAction: PlayerActionButtonX.fromStorageValue(
+                            appPrefs.leftTopActionButton,
+                          ),
+                          leftAction: PlayerActionButtonX.fromStorageValue(
+                            appPrefs.leftActionButton,
+                          ),
+                          rightTopAction: PlayerActionButtonX.fromStorageValue(
+                            appPrefs.rightTopActionButton,
+                          ),
+                          rightAction: PlayerActionButtonX.fromStorageValue(
+                            appPrefs.rightActionButton,
+                          ),
+                          playerService: _playerService,
+                          favoritesService: _favoritesService,
+                          onToggleLyrics: () =>
+                              setState(() => _isLyricsMode = !lyricsMode),
+                          onToggleVisualization: (v) =>
+                              _setVisualizationMode(v),
+                          onOpenQueue: (ctx) => _navigation.openQueue(ctx),
+                          usbVolumeButtonKey: _usbVolumeButtonKey,
+                          onShowUsbVolumePopup: (ctx) =>
+                              _showUsbVolumePopup(ctx),
+                        ),
                     visualizerAnimationStyle: visStyle,
                     visualizerFrequencyMode: visFreq,
                     visualizerMovementMode: visMove,
@@ -567,4 +573,3 @@ class _FullPlayerScreenState extends ConsumerState<FullPlayerScreen>
     );
   }
 }
-

--- a/lib/features/player/widgets/animated_song_scene.dart
+++ b/lib/features/player/widgets/animated_song_scene.dart
@@ -24,9 +24,13 @@ import 'package:flick/features/player/widgets/visualizer_art_box.dart';
 import 'package:flick/features/player/widgets/album_art_box.dart';
 import 'package:flick/features/player/widgets/waveform_layer.dart';
 import 'package:flick/features/player/widgets/player_controls.dart';
+import 'package:flick/features/player/widgets/compact_player_info_layout.dart';
 import 'package:flick/features/player/widgets/inline_lyrics_panel.dart';
 import 'package:flick/features/player/widgets/lyrics_mode_waveform_strip.dart';
+
 class AnimatedSongScene extends StatelessWidget {
+  static const double _shortHeightThreshold = 620.0;
+
   final Song song;
   final bool lyricsMode;
   final bool visualizationMode;
@@ -77,7 +81,8 @@ class AnimatedSongScene extends StatelessWidget {
   final bool vinylMode;
   final ValueChanged<bool>? onVinylChanged;
 
-  const AnimatedSongScene({super.key,
+  const AnimatedSongScene({
+    super.key,
     required this.song,
     required this.lyricsMode,
     required this.visualizationMode,
@@ -131,12 +136,13 @@ class AnimatedSongScene extends StatelessWidget {
   Widget build(BuildContext context) {
     final direction = transitionDirection >= 0 ? 1.0 : -1.0;
     final sceneKey = ValueKey('${song.id}_${playerScreenMode.storageValue}');
-    final showVisualizerOnly =
-        visualizationMode &&
-        immersiveFullView &&
-        playerScreenMode == PlayerScreenMode.immersive;
+    final isShortHeight =
+        MediaQuery.sizeOf(context).height < _shortHeightThreshold;
     final showImmersiveFullView =
-        immersiveFullView && playerScreenMode == PlayerScreenMode.immersive;
+        immersiveFullView &&
+        playerScreenMode == PlayerScreenMode.immersive &&
+        !isShortHeight;
+    final showVisualizerOnly = visualizationMode && showImmersiveFullView;
 
     final scene = RepaintBoundary(
       key: sceneKey,
@@ -1082,60 +1088,75 @@ class AnimatedSongScene extends StatelessWidget {
                         )
                       : KeyedSubtree(
                           key: const ValueKey('artwork-default'),
-                          child: Transform.translate(
-                            offset: Offset(0, artworkCardVerticalOffset),
-                            child: Column(
-                              mainAxisAlignment: isVeryShortHeight
-                                  ? MainAxisAlignment.start
-                                  : MainAxisAlignment.center,
-                              children: [
-                                Flexible(
-                                  flex: isVeryShortHeight ? 5 : 7,
-                                  child: Center(
-                                    child: OverflowBox(
-                                      maxWidth: artworkSize,
-                                      maxHeight: artworkSize,
-                                      child: visualizationMode
-                                          ? VisualizerArtBox(
-                                              playerService: playerService,
-                                              size: artworkSize,
-                                              animationStyle:
-                                                  visualizerAnimationStyle,
-                                              frequencyMode:
-                                                  visualizerFrequencyMode,
-                                              movementMode:
-                                                  visualizerMovementMode,
-                                              albumColor: albumColor,
-                                              showFrame: artworkCardShowFrame,
-                                            )
-                                          : AlbumArtBox(
-                                              song: song,
-                                              size: artworkSize,
-                                              playerService: playerService,
-                                              onRotationEnabledChanged:
-                                                  onRotationEnabledChanged,
-                                              initialVinyl: vinylMode,
-                                              onVinylChanged: onVinylChanged,
-                                              showFrame: artworkCardShowFrame,
-                                            ),
-                                    ),
+                          child: isVeryShortHeight
+                              ? Center(
+                                  child: CompactPlayerInfoLayout(
+                                    song: song,
+                                    onNavigateToArtistDetail:
+                                        onNavigateToArtistDetail,
+                                  ),
+                                )
+                              : Transform.translate(
+                                  offset: Offset(0, artworkCardVerticalOffset),
+                                  child: Column(
+                                    mainAxisAlignment: isVeryShortHeight
+                                        ? MainAxisAlignment.start
+                                        : MainAxisAlignment.center,
+                                    children: [
+                                      Flexible(
+                                        flex: isVeryShortHeight ? 5 : 7,
+                                        child: Center(
+                                          child: OverflowBox(
+                                            maxWidth: artworkSize,
+                                            maxHeight: artworkSize,
+                                            child: visualizationMode
+                                                ? VisualizerArtBox(
+                                                    playerService:
+                                                        playerService,
+                                                    size: artworkSize,
+                                                    animationStyle:
+                                                        visualizerAnimationStyle,
+                                                    frequencyMode:
+                                                        visualizerFrequencyMode,
+                                                    movementMode:
+                                                        visualizerMovementMode,
+                                                    albumColor: albumColor,
+                                                    showFrame:
+                                                        artworkCardShowFrame,
+                                                  )
+                                                : AlbumArtBox(
+                                                    song: song,
+                                                    size: artworkSize,
+                                                    playerService:
+                                                        playerService,
+                                                    onRotationEnabledChanged:
+                                                        onRotationEnabledChanged,
+                                                    initialVinyl: vinylMode,
+                                                    onVinylChanged:
+                                                        onVinylChanged,
+                                                    showFrame:
+                                                        artworkCardShowFrame,
+                                                  ),
+                                          ),
+                                        ),
+                                      ),
+                                      SizedBox(height: artworkSpacing),
+                                      Padding(
+                                        padding: EdgeInsets.symmetric(
+                                          horizontal: isVeryShortHeight
+                                              ? 8.0
+                                              : 0.0,
+                                        ),
+                                        child: _buildSongIdentity(
+                                          context,
+                                          compact: isShortHeight,
+                                          veryCompact: isVeryShortHeight,
+                                        ),
+                                      ),
+                                      SizedBox(height: identitySpacing),
+                                    ],
                                   ),
                                 ),
-                                SizedBox(height: artworkSpacing),
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: isVeryShortHeight ? 8.0 : 0.0,
-                                  ),
-                                  child: _buildSongIdentity(
-                                    context,
-                                    compact: isShortHeight,
-                                    veryCompact: isVeryShortHeight,
-                                  ),
-                                ),
-                                SizedBox(height: identitySpacing),
-                              ],
-                            ),
-                          ),
                         ),
                 ),
               ),
@@ -1361,4 +1382,3 @@ class AnimatedSongScene extends StatelessWidget {
     );
   }
 }
-

--- a/lib/features/player/widgets/animated_song_scene.dart
+++ b/lib/features/player/widgets/animated_song_scene.dart
@@ -477,7 +477,7 @@ class AnimatedSongScene extends StatelessWidget {
                       context.responsive(12.0, 14.0, 16.0),
                       context.responsive(6.0, 7.0, 8.0),
                       (!fromLocker && !hideQueueBadge)
-                          ? context.responsive(6.0, 7.0, 8.0)
+                          ? context.responsive(10.0, 11.0, 12.0)
                           : context.responsive(12.0, 14.0, 16.0),
                       context.responsive(6.0, 7.0, 8.0),
                     ),

--- a/lib/features/player/widgets/compact_player_info_layout.dart
+++ b/lib/features/player/widgets/compact_player_info_layout.dart
@@ -3,304 +3,114 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/utils/responsive.dart';
-import 'package:flick/models/shuffle_mode.dart';
 import 'package:flick/models/song.dart';
-import 'package:flick/services/player_service.dart';
-import 'package:flick/services/favorites_service.dart';
-import 'package:flick/features/player/widgets/shuffle_mode_sheet.dart';
-import 'package:flick/features/player/widgets/loop_mode_sheet.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 
-class CompactPlayerInfoLayout extends StatefulWidget {
+/// Compact horizontal player header used when window height is constrained
+/// (split screen / freeform). Artwork left, song info right. File info and
+/// action buttons stay in the default layout below.
+class CompactPlayerInfoLayout extends StatelessWidget {
   final Song song;
-  final Object heroTag;
-  final PlayerService playerService;
-  final FavoritesService favoritesService;
+  final void Function(Song song)? onNavigateToArtistDetail;
 
   const CompactPlayerInfoLayout({
     super.key,
     required this.song,
-    required this.heroTag,
-    required this.playerService,
-    required this.favoritesService,
+    this.onNavigateToArtistDetail,
   });
 
   @override
-  State<CompactPlayerInfoLayout> createState() =>
-      _CompactPlayerInfoLayoutState();
-}
-
-class _CompactPlayerInfoLayoutState extends State<CompactPlayerInfoLayout> {
-  @override
   Widget build(BuildContext context) {
-    final isVeryCompact = context.isCompact || context.screenHeight < 600;
-    final albumArtSize = isVeryCompact
-        ? (MediaQuery.sizeOf(context).height * 0.20).clamp(120.0, 160.0)
-        : (MediaQuery.sizeOf(context).height * 0.25).clamp(140.0, 200.0);
+    final size = MediaQuery.sizeOf(context);
+    final albumArtSize = (size.height * 0.24).clamp(88.0, 132.0);
 
     return Padding(
       padding: EdgeInsets.symmetric(
         horizontal: context.responsive(12.0, 16.0, 20.0),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+      child: Row(
         children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Hero(
-                tag: widget.heroTag,
-                child: Container(
-                  width: albumArtSize,
-                  height: albumArtSize,
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(
-                      context.responsive(14.0, 18.0, 22.0),
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.3),
-                        blurRadius: context.responsive(12.0, 16.0, 20.0),
-                        offset: Offset(0, context.responsive(6.0, 8.0, 10.0)),
-                      ),
-                    ],
+          Container(
+            width: albumArtSize,
+            height: albumArtSize,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(
+                context.responsive(12.0, 14.0, 16.0),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.3),
+                  blurRadius: context.responsive(10.0, 14.0, 18.0),
+                  offset: Offset(0, context.responsive(4.0, 6.0, 8.0)),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(
+                context.responsive(12.0, 14.0, 16.0),
+              ),
+              child: CachedImageWidget(
+                imagePath: song.albumArt,
+                audioSourcePath: song.filePath,
+                fit: BoxFit.cover,
+                placeholder: Container(
+                  color: AppColors.glassBackgroundStrong,
+                  child: Icon(
+                    LucideIcons.music,
+                    size: context.responsive(24.0, 28.0, 32.0),
+                    color: AppColors.textTertiary,
                   ),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(
-                      context.responsive(14.0, 18.0, 22.0),
-                    ),
-                    child: CachedImageWidget(
-                      imagePath: widget.song.albumArt,
-                      audioSourcePath: widget.song.filePath,
-                      fit: BoxFit.cover,
-                      placeholder: Container(
-                        color: AppColors.glassBackgroundStrong,
-                        child: Icon(
-                          LucideIcons.music,
-                          size: context.responsive(28.0, 32.0, 36.0),
-                          color: AppColors.textTertiary,
-                        ),
-                      ),
-                      errorWidget: Container(
-                        color: AppColors.glassBackgroundStrong,
-                        child: Icon(
-                          LucideIcons.music,
-                          size: context.responsive(28.0, 32.0, 36.0),
-                          color: AppColors.textTertiary,
-                        ),
-                      ),
-                    ),
+                ),
+                errorWidget: Container(
+                  color: AppColors.glassBackgroundStrong,
+                  child: Icon(
+                    LucideIcons.music,
+                    size: context.responsive(24.0, 28.0, 32.0),
+                    color: AppColors.textTertiary,
                   ),
                 ),
               ),
-              SizedBox(width: context.responsive(12.0, 16.0, 20.0)),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      widget.song.title,
-                      maxLines: isVeryCompact ? 1 : 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: context.responsiveText(
-                          context.responsive(15.0, 16.0, 17.0),
-                        ),
-                        fontWeight: FontWeight.bold,
-                        color: context.adaptiveTextPrimary,
-                      ),
-                    ),
-                    SizedBox(height: context.responsive(2.0, 3.0, 4.0)),
-                    Text(
-                      widget.song.artist,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontFamily: 'ProductSans',
-                        fontSize: context.responsiveText(
-                          context.responsive(12.0, 13.0, 13.5),
-                        ),
-                        color: context.adaptiveTextSecondary,
-                      ),
-                    ),
-                    SizedBox(height: context.responsive(6.0, 8.0, 10.0)),
-                    Row(
-                      children: [
-                        Container(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: context.responsive(4.0, 5.0, 6.0),
-                            vertical: 2,
-                          ),
-                          decoration: BoxDecoration(
-                            color: context.adaptiveTextTertiary.withValues(
-                              alpha: 0.1,
-                            ),
-                            borderRadius: BorderRadius.circular(3),
-                          ),
-                          child: Text(
-                            widget.song.fileType,
-                            style: TextStyle(
-                              fontFamily: 'ProductSans',
-                              fontSize: context.responsive(8.0, 9.0, 9.5),
-                              fontWeight: FontWeight.w600,
-                              color: context.adaptiveTextSecondary,
-                            ),
-                          ),
-                        ),
-                        if (widget.song.resolution != null) ...[
-                          SizedBox(width: context.responsive(4.0, 5.0, 6.0)),
-                          Flexible(
-                            child: Text(
-                              widget.song.resolution!,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                fontFamily: 'ProductSans',
-                                fontSize: context.responsive(8.0, 9.0, 9.5),
-                                color: context.adaptiveTextTertiary,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ],
+            ),
           ),
-          SizedBox(height: context.responsive(12.0, 16.0, 20.0)),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ValueListenableBuilder<ShuffleMode>(
-                valueListenable: widget.playerService.shuffleModeNotifier,
-                builder: (context, shuffleMode, _) {
-                  final isActive = shuffleMode.isActive;
-                  final icon = switch (shuffleMode) {
-                    ShuffleMode.categories => LucideIcons.layers,
-                    ShuffleMode.random => LucideIcons.dices,
-                    _ => LucideIcons.shuffle,
-                  };
-                  return GestureDetector(
-                    onTap: () {
-                      widget.playerService.toggleShuffle();
-                      final next = widget.playerService.shuffleModeNotifier.value;
-                      ScaffoldMessenger.of(context)
-                        ..hideCurrentSnackBar()
-                        ..showSnackBar(SnackBar(
-                          content: Text('Shuffle: ${next.label}'),
-                          behavior: SnackBarBehavior.floating,
-                          duration: const Duration(seconds: 1),
-                        ));
-                    },
-                    onLongPress: () {
-                      ShuffleModeSheet.show(context, widget.playerService);
-                    },
-                    child: Padding(
-                      padding: EdgeInsets.all(context.responsive(6.0, 8.0, 10.0)),
-                      child: Icon(
-                        icon,
-                        color: isActive
-                            ? context.adaptiveAccent
-                            : context.adaptiveTextTertiary,
-                        size: context.responsive(18.0, 20.0, 22.0),
+          SizedBox(width: context.responsive(12.0, 16.0, 20.0)),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  song.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: context.responsiveText(
+                      context.responsive(15.0, 16.0, 17.0),
+                    ),
+                    fontWeight: FontWeight.bold,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                ),
+                SizedBox(height: context.responsive(2.0, 3.0, 4.0)),
+                GestureDetector(
+                  onTap: onNavigateToArtistDetail == null
+                      ? null
+                      : () => onNavigateToArtistDetail!(song),
+                  child: Text(
+                    song.artist,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontFamily: 'ProductSans',
+                      fontSize: context.responsiveText(
+                        context.responsive(12.0, 13.0, 13.5),
                       ),
+                      color: context.adaptiveTextSecondary,
                     ),
-                  );
-                },
-              ),
-              SizedBox(width: context.responsive(20.0, 24.0, 28.0)),
-              ValueListenableBuilder<LoopMode>(
-                valueListenable: widget.playerService.loopModeNotifier,
-                builder: (context, loopMode, _) {
-                  final icon = LoopModeSheet.iconFor(loopMode);
-                  final isActive = loopMode != LoopMode.off;
-                  final color = isActive
-                      ? context.adaptiveAccent
-                      : context.adaptiveTextTertiary;
-                  return GestureDetector(
-                    onTap: () {
-                      widget.playerService.toggleLoopMode();
-                      final next = widget.playerService.loopModeNotifier.value;
-                      ScaffoldMessenger.of(context)
-                        ..hideCurrentSnackBar()
-                        ..showSnackBar(SnackBar(
-                          content: Text('Repeat: ${next.label}'),
-                          behavior: SnackBarBehavior.floating,
-                          duration: const Duration(seconds: 1),
-                        ));
-                    },
-                    onLongPress: () {
-                      LoopModeSheet.show(context, widget.playerService);
-                    },
-                    child: Padding(
-                      padding: EdgeInsets.all(context.responsive(6.0, 8.0, 10.0)),
-                      child: Stack(
-                        clipBehavior: Clip.none,
-                        alignment: Alignment.center,
-                        children: [
-                          Icon(
-                            icon,
-                            color: color,
-                            size: context.responsive(18.0, 20.0, 22.0),
-                          ),
-                          if (loopMode == LoopMode.all)
-                            Positioned(
-                              bottom: -4,
-                              child: Container(
-                                width: 4,
-                                height: 4,
-                                decoration: BoxDecoration(
-                                  color: context.adaptiveAccent,
-                                  shape: BoxShape.circle,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  );
-                },
-              ),
-              SizedBox(width: context.responsive(20.0, 24.0, 28.0)),
-              FutureBuilder<bool>(
-                future: widget.favoritesService.isFavorite(widget.song.id),
-                builder: (context, snapshot) {
-                  final isFavorite = snapshot.data ?? false;
-                  return IconButton(
-                    onPressed: () async {
-                      final newState = await widget.favoritesService
-                          .toggleFavorite(widget.song.id);
-                      setState(() {});
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              newState
-                                  ? 'Added to favorites'
-                                  : 'Removed from favorites',
-                            ),
-                            duration: const Duration(seconds: 1),
-                          ),
-                        );
-                      }
-                    },
-                    padding: EdgeInsets.all(context.responsive(6.0, 8.0, 10.0)),
-                    constraints: const BoxConstraints(),
-                    icon: Icon(
-                      isFavorite ? Icons.favorite : Icons.favorite_border,
-                      color: isFavorite
-                          ? Colors.red
-                          : context.adaptiveTextTertiary,
-                      size: context.responsive(18.0, 20.0, 22.0),
-                    ),
-                  );
-                },
-              ),
-            ],
+                  ),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1451,6 +1451,13 @@ class PlayerService {
     await _configureAndroidAudioSession();
     final player = just_audio.AudioPlayer();
     _justAudioPlayer = player;
+    int? lastEqSessionId;
+    player.androidAudioSessionIdStream.listen((sessionId) {
+      if (sessionId == null || sessionId == lastEqSessionId) return;
+      if (!identical(_justAudioPlayer, player)) return;
+      lastEqSessionId = sessionId;
+      unawaited(reapplyEqualizer());
+    });
     await player.setVolume(_currentVolume);
     await player.setSpeed(playbackSpeedNotifier.value);
     await _updateLoopMode();

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1726,6 +1726,12 @@ class PlayerService {
   bool get isVolumeAvailable =>
       _determineCurrentTier() != VolumeTier.unavailable;
 
+  /// True when the DAC hardware (Feature Unit) volume is the active volume
+  /// authority; the UI should display the DAC level only then. Otherwise the
+  /// bar shows [currentVolume], which is what [setVolume] actually writes.
+  bool get isHardwareVolumeAuthority =>
+      _determineCurrentTier() == VolumeTier.hardware;
+
   /// Maximum volume the user may select right now. Extended boost (2.0) is
   /// only available on the software and system tiers when the toggle is on;
   /// hardware, passthrough, DoP and casting paths stay clamped at 1.0.

--- a/lib/widgets/uac2/iso_volume_popup.dart
+++ b/lib/widgets/uac2/iso_volume_popup.dart
@@ -184,11 +184,12 @@ class _IsoVolumePopupOverlayState extends ConsumerState<_IsoVolumePopupOverlay>
     final playerService = ref.read(playerServiceProvider);
     final isAvailable = playerService.isVolumeAvailable;
     final playerVolume = playerService.currentVolume;
+    final hardwareAuthority = playerService.isHardwareVolumeAuthority;
     final effectiveVolume =
         _draggingVolume ??
-        ((isSoftwareVolume || !isAvailable)
-            ? playerVolume
-            : (deviceStatus.volume ?? playerVolume));
+        (hardwareAuthority
+            ? (deviceStatus.volume ?? playerVolume)
+            : playerVolume);
     final effectiveMuted = deviceStatus.muted ?? false;
     final volumeControlWritable =
         deviceStatus.volumeControlWritable &&

--- a/lib/widgets/uac2/uac2_volume_control.dart
+++ b/lib/widgets/uac2/uac2_volume_control.dart
@@ -100,11 +100,12 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
     final playerService = ref.read(playerServiceProvider);
     final isAvailable = playerService.isVolumeAvailable;
     final playerVolume = playerService.currentVolume;
+    final hardwareAuthority = playerService.isHardwareVolumeAuthority;
     final effectiveVolume =
         _draggingVolume ??
-        ((isSoftwareVolume || !isAvailable)
-            ? playerVolume
-            : (deviceStatus.volume ?? playerVolume));
+        (hardwareAuthority
+            ? (deviceStatus.volume ?? playerVolume)
+            : playerVolume);
     final effectiveMuted = deviceStatus.muted ?? false;
     final volumeControlWritable =
         deviceStatus.volumeControlWritable &&
@@ -156,9 +157,11 @@ class _Uac2VolumeControlState extends ConsumerState<Uac2VolumeControl> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      deviceStatus.isExternalRoute
-                          ? 'USB Route Volume'
-                          : 'Device DAC Volume',
+                      hardwareAuthority
+                          ? (deviceStatus.isExternalRoute
+                                ? 'USB Route Volume'
+                                : 'Device DAC Volume')
+                          : 'Volume',
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.titleSmall?.copyWith(
                         color: labelColor,

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -2365,9 +2365,9 @@ fn android_output_device_priority(device_type: AudioDeviceType) -> u8 {
         | AudioDeviceType::BleSpeaker
         | AudioDeviceType::HearingAid => 2,
         AudioDeviceType::BuiltinSpeaker => 3,
-        _ => 4,
-        AudioDeviceType::BuiltinEarpiece => 5,
-        AudioDeviceType::BuiltinSpeakerSafe => 6,
+        AudioDeviceType::BuiltinEarpiece => 4,
+        AudioDeviceType::BuiltinSpeakerSafe => 5,
+        _ => 6,
     }
 }
 

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -39,7 +39,7 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use oboe::{
     AudioApi, AudioDeviceDirection, AudioDeviceInfo, AudioDeviceType, AudioFormat,
     AudioOutputCallback, AudioOutputStreamSafe, AudioStream, AudioStreamAsync, AudioStreamBase,
-    AudioStreamSafe, ContentType, DataCallbackResult, Output, PerformanceMode,
+    AudioStreamSafe, ChannelCount, ContentType, DataCallbackResult, Output, PerformanceMode,
     SampleRateConversionQuality, SharingMode, Stereo, Usage,
 };
 use parking_lot::Mutex;
@@ -2159,7 +2159,7 @@ fn open_android_output_stream(
                     .set_performance_mode(performance_mode)
                     .set_usage(Usage::Media)
                     .set_content_type(ContentType::Music)
-                    .set_channel_conversion_allowed(!bit_perfect_route)
+                    .set_channel_conversion_allowed(false)
                     .set_format_conversion_allowed(true)
                     .set_sample_rate_conversion_quality(if bit_perfect_route {
                         SampleRateConversionQuality::None
@@ -2224,6 +2224,18 @@ fn open_android_output_stream(
                         actual_format,
                         actual_channels,
                     );
+
+                    if actual_channels != ChannelCount::Stereo {
+                        last_error = Some(format!(
+                            "{} {} opened '{}' with {:?} channels instead of {}",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            actual_channels,
+                            ANDROID_DIRECT_CHANNELS,
+                        ));
+                        continue;
+                    }
 
                     if bit_perfect_route && actual_rate != target_sample_rate as i32 {
                         last_error = Some(format!(

--- a/rust/src/audio/http_source.rs
+++ b/rust/src/audio/http_source.rs
@@ -8,9 +8,21 @@
 
 use std::collections::HashMap;
 use std::io::{self, Read, Seek, SeekFrom};
+use std::time::Duration;
 use symphonia::core::io::MediaSource;
 
 const BLOCK_SIZE: usize = 1024 * 1024; // 1 MiB
+
+// ponytail: global timeouts so a stalled network can't pin the command thread.
+fn http_agent() -> &'static ureq::Agent {
+    static AGENT: std::sync::OnceLock<ureq::Agent> = std::sync::OnceLock::new();
+    AGENT.get_or_init(|| {
+        ureq::AgentBuilder::new()
+            .timeout_connect(Duration::from_secs(10))
+            .timeout_read(Duration::from_secs(30))
+            .build()
+    })
+}
 
 pub struct HttpMediaSource {
     url: String,
@@ -42,7 +54,7 @@ impl HttpMediaSource {
         }
 
         let end = self.pos + BLOCK_SIZE as u64 - 1;
-        let mut req = ureq::get(&self.url);
+        let mut req = http_agent().get(&self.url);
         for (k, v) in &self.headers {
             req = req.set(k, v);
         }


### PR DESCRIPTION
# Summary

- Refactor volume control to use `hardwareAuthority` with simplified volume authority logic
- Convert `CompactPlayerInfoLayout` to stateless widget with simplified layout (272 lines removed)
- Add compact layout for very short height screens
- Add timeout to HTTP audio source for streaming reliability
- Reapply equalizer on Android audio session change
- Adjust audio device priority to exclude earpiece from auto-selection
- Allow resizable activity

# Changes

## Volume Control

- Refactor volume control to use `hardwareAuthority`
- Simplify volume authority logic in iso volume popup
- Update UAC2 volume control widget to use new authority logic

## Compact Player Layout

- Convert `CompactPlayerInfoLayout` to stateless widget with simplified layout (82 insertions, 272 deletions)
- Add compact layout for very short height screens in animated song scene
- Format full player screen for consistency

## Audio Engine

- Add timeout to HTTP audio source (13 insertions)
- Reapply equalizer on Android audio session change
- Adjust audio device priority to exclude earpiece from auto-selection

## Misc

- Allow resizable activity

## Files Changed

- `lib/features/player/widgets/compact_player_info_layout.dart`
- `lib/features/player/widgets/animated_song_scene.dart`
- `lib/features/player/screens/full_player_screen.dart`
- `lib/widgets/uac2/uac2_volume_control.dart`
- `lib/widgets/uac2/iso_volume_popup.dart`
- `lib/services/player_service.dart`
- `android/app/src/main/AndroidManifest.xml`
- `android/app/src/main/kotlin/com/mossapps/flick/PriorityAnchorService.kt`
- `rust/src/audio/http_source.rs`
- `rust/src/audio/engine.rs`