### PR TITLE
Add cast content server, direct audio track backends, and LAN media streaming

### DIFF
--- a/lib/data/repositories/recently_played_repository.dart
+++ b/lib/data/repositories/recently_played_repository.dart
@@ -717,8 +717,10 @@ class RecentlyPlayedRepository {
     );
   }
 
-  /// Build a resolution string from entity properties.
-  String _buildResolutionString(SongEntity entity) {
+  /// Build a resolution string from entity properties. Null when the source
+  /// sync had no audio metrics (SMB/WebDAV) — callers hide the chip instead
+  /// of showing a placeholder.
+  String? _buildResolutionString(SongEntity entity) {
     final parts = <String>[];
     if (entity.bitDepth != null) {
       parts.add('${entity.bitDepth}-bit');
@@ -734,7 +736,7 @@ class RecentlyPlayedRepository {
     if (bitrateLabel != null) {
       parts.add(bitrateLabel);
     }
-    return parts.isEmpty ? 'Unknown' : parts.join(' / ');
+    return parts.isEmpty ? null : parts.join(' / ');
   }
 
   String _formatSampleRateKhz(int sampleRateHz) {

--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -297,6 +297,32 @@ class SongRepository {
     });
   }
 
+  /// Persist probed audio format for songs whose sync couldn't read tags
+  /// (SMB/WebDAV). Only fills null fields.
+  Future<void> updateAudioFormat(
+    String filePath, {
+    int? sampleRate,
+    int? bitDepth,
+  }) async {
+    await _isar.writeTxn(() async {
+      final existing = await _isar.songEntitys
+          .filter()
+          .filePathEqualTo(filePath)
+          .findFirst();
+      if (existing == null) return;
+      var changed = false;
+      if (sampleRate != null && existing.sampleRate == null) {
+        existing.sampleRate = sampleRate;
+        changed = true;
+      }
+      if (bitDepth != null && existing.bitDepth == null) {
+        existing.bitDepth = bitDepth;
+        changed = true;
+      }
+      if (changed) await _isar.songEntitys.put(existing);
+    });
+  }
+
   /// Count songs in a folder.
   Future<int> countSongsInFolder(String folderUri) async {
     return await _isar.songEntitys.where().folderUriEqualTo(folderUri).count();
@@ -537,8 +563,10 @@ class SongRepository {
     return albumName;
   }
 
-  /// Build a resolution string from entity properties.
-  String _buildResolutionString(SongEntity entity) {
+  /// Build a resolution string from entity properties. Null when the source
+  /// sync had no audio metrics (SMB/WebDAV) — callers hide the chip instead
+  /// of showing a placeholder.
+  String? _buildResolutionString(SongEntity entity) {
     final parts = <String>[];
     if (entity.bitDepth != null) {
       parts.add('${entity.bitDepth}-bit');
@@ -554,7 +582,7 @@ class SongRepository {
     if (bitrateLabel != null) {
       parts.add(bitrateLabel);
     }
-    return parts.isEmpty ? 'Unknown' : parts.join(' / ');
+    return parts.isEmpty ? null : parts.join(' / ');
   }
 
   String _formatSampleRateKhz(int sampleRateHz) {

--- a/lib/features/settings/screens/uac2_preferences_screen.dart
+++ b/lib/features/settings/screens/uac2_preferences_screen.dart
@@ -980,6 +980,10 @@ ref.invalidate(uac2ExclusiveDacModeProvider);
     final modeDescription = switch (diagnostics?.pathManagement) {
       AudioPathManagement.directUsbExperimental =>
         'Exclusive USB is active and bypassing the Android mixer.',
+      AudioPathManagement.alsaDirectDap =>
+        'Direct ALSA output is active and bypassing the Android audio server.',
+      AudioPathManagement.managedDirectExclusive =>
+        'Exclusive direct PCM is active and bypassing the Android mixer at the track\'s native rate.',
       AudioPathManagement.androidManagedLowLatency =>
         'Playback is using Android-managed output and may be resampled.',
       AudioPathManagement.androidManagedShared =>

--- a/lib/models/audio_output_diagnostics.dart
+++ b/lib/models/audio_output_diagnostics.dart
@@ -5,6 +5,8 @@ enum AudioPathManagement {
   androidManagedShared,
   androidManagedLowLatency,
   directUsbExperimental,
+  alsaDirectDap,
+  managedDirectExclusive,
 }
 
 @immutable

--- a/lib/services/casting/cast_content_server.dart
+++ b/lib/services/casting/cast_content_server.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+// ponytail: one-file embedded HTTP server so the renderer can pull bytes from
+// the phone. Covers local files and SMB/cached sources that have no LAN URL.
+// Token paths on a home LAN are enough auth; add TLS/pins if this ever leaves
+// the house.
+class CastContentServer {
+  CastContentServer._();
+  static final instance = CastContentServer._();
+
+  HttpServer? _server;
+  final Map<String, String> _paths = {};
+  final _rand = Random.secure();
+
+  /// Serve [filePath] and return a LAN-reachable URL for it.
+  Future<String> serve(String filePath, {required String filename}) async {
+    final server = _server ??= await _bind();
+    final token = _token();
+    _paths[token] = filePath;
+    final ip = await _lanIp();
+    final safe = Uri.encodeComponent(
+      filename.replaceAll(RegExp(r'[^A-Za-z0-9._\- ]'), ''),
+    );
+    return 'http://$ip:${server.port}/$token/$safe';
+  }
+
+  Future<void> stop() async {
+    _paths.clear();
+    final server = _server;
+    _server = null;
+    await server?.close(force: true);
+  }
+
+  String _token() {
+    final bytes = List<int>.generate(16, (_) => _rand.nextInt(256));
+    return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+
+  Future<HttpServer> _bind() async {
+    final server = await HttpServer.bind(InternetAddress.anyIPv4, 0);
+    server.listen((req) {
+      _handle(req).catchError((_) {
+        try {
+          req.response.close();
+        } catch (_) {}
+      });
+    }, onError: (_) {});
+    return server;
+  }
+
+  Future<String> _lanIp() async {
+    final interfaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+      includeLoopback: false,
+    );
+    for (final it in interfaces) {
+      for (final addr in it.addresses) {
+        final s = addr.address;
+        if (s.startsWith('192.168.') ||
+            s.startsWith('10.') ||
+            RegExp(r'^172\.(1[6-9]|2\d|3[01])\.').hasMatch(s)) {
+          return s;
+        }
+      }
+    }
+    // Virtual/odd adapters only: fall back to the first IPv4 that isn't loopback.
+    return interfaces.first.addresses.first.address;
+  }
+
+  Future<void> _handle(HttpRequest req) async {
+    final token = req.uri.pathSegments.isNotEmpty
+        ? req.uri.pathSegments.first
+        : '';
+    final path = _paths[token];
+    if (path == null) {
+      req.response.statusCode = HttpStatus.notFound;
+      await req.response.close();
+      return;
+    }
+
+    final file = File(path);
+    if (!await file.exists()) {
+      req.response.statusCode = HttpStatus.notFound;
+      await req.response.close();
+      return;
+    }
+    final total = await file.length();
+    final range = req.headers.value(HttpHeaders.rangeHeader);
+
+    var start = 0;
+    var end = total - 1;
+    var status = HttpStatus.ok;
+    if (range != null) {
+      final m = RegExp(r'bytes=(\d*)-(\d*)').firstMatch(range);
+      if (m != null) {
+        if (m.group(1)!.isNotEmpty) start = int.parse(m.group(1)!);
+        if (m.group(2)!.isNotEmpty) end = int.parse(m.group(2)!);
+        if (start >= total) {
+          req.response.statusCode = HttpStatus.requestedRangeNotSatisfiable;
+          req.response.headers.set(
+            HttpHeaders.contentRangeHeader,
+            'bytes */$total',
+          );
+          await req.response.close();
+          return;
+        }
+        if (m.group(2)!.isEmpty) end = total - 1;
+        status = HttpStatus.partialContent;
+      }
+    }
+
+    final length = end - start + 1;
+    req.response.statusCode = status;
+    req.response.headers.contentType = _contentTypeFor(path);
+    req.response.headers.set(HttpHeaders.acceptRangesHeader, 'bytes');
+    req.response.headers.set(HttpHeaders.contentLengthHeader, '$length');
+    if (status == HttpStatus.partialContent) {
+      req.response.headers.set(
+        HttpHeaders.contentRangeHeader,
+        'bytes $start-$end/$total',
+      );
+    }
+
+    // ponytail: chunked manual copy; StreamedResponse plumbing adds nothing
+    // for a LAN-local single consumer.
+    final raf = await file.open();
+    try {
+      await raf.setPosition(start);
+      var remaining = length;
+      const chunk = 64 * 1024;
+      while (remaining > 0) {
+        final read = await raf.read(min(chunk, remaining));
+        if (read.isEmpty) break;
+        req.response.add(read);
+        remaining -= read.length;
+        await req.response.flush();
+      }
+    } finally {
+      await raf.close();
+      await req.response.close();
+    }
+  }
+}
+
+ContentType _contentTypeFor(String path) {
+  final ext = path.lastIndexOf('.') == -1
+      ? ''
+      : path.substring(path.lastIndexOf('.') + 1).toLowerCase();
+  return switch (ext) {
+    'mp3' => ContentType.parse('audio/mpeg'),
+    'flac' => ContentType.parse('audio/flac'),
+    'wav' => ContentType.parse('audio/wav'),
+    'ogg' || 'oga' || 'opus' => ContentType.parse('audio/ogg'),
+    'm4a' || 'mp4' || 'aac' => ContentType.parse('audio/mp4'),
+    'aiff' || 'aif' => ContentType.parse('audio/aiff'),
+    'wv' => ContentType.parse('audio/x-wavpack'),
+    'dsf' || 'dff' => ContentType.parse('audio/dsd'),
+    _ => ContentType.binary,
+  };
+}

--- a/lib/services/casting/casting_service.dart
+++ b/lib/services/casting/casting_service.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
 import '../../models/song.dart';
 import '../player_service.dart';
 import '../remote_source_service.dart';
+import 'cast_content_server.dart';
 import 'cast_device.dart';
 import 'dlna_backend.dart';
 import 'chromecast_backend.dart';
@@ -19,7 +21,8 @@ class CastingService {
 
   final ValueNotifier<List<CastDevice>> devicesNotifier =
       ValueNotifier<List<CastDevice>>(const []);
-  final ValueNotifier<CastDevice?> activeDeviceNotifier = ValueNotifier<CastDevice?>(null);
+  final ValueNotifier<CastDevice?> activeDeviceNotifier =
+      ValueNotifier<CastDevice?>(null);
   final ValueNotifier<bool> isActiveNotifier = ValueNotifier<bool>(false);
   final ValueNotifier<bool> isDiscoveringNotifier = ValueNotifier<bool>(false);
 
@@ -50,7 +53,10 @@ class CastingService {
   void startContinuousDiscovery() {
     if (_discoverCooldown != null) return;
     discover();
-    _discoverCooldown = Timer.periodic(const Duration(seconds: 10), (_) => discover());
+    _discoverCooldown = Timer.periodic(
+      const Duration(seconds: 10),
+      (_) => discover(),
+    );
   }
 
   void stopContinuousDiscovery() {
@@ -76,6 +82,7 @@ class CastingService {
     } else if (_activeDevice != null && _currentSong != null) {
       await _dlna.stop(_controlUrl(_activeDevice!));
     }
+    await CastContentServer.instance.stop();
     _activeDevice = null;
     _currentSong = null;
     activeDeviceNotifier.value = null;
@@ -90,10 +97,12 @@ class CastingService {
     ps.currentSongNotifier.value = song;
     ps.durationNotifier.value = song.duration;
     ps.positionNotifier.value = Duration.zero;
-    final resolved = await RemoteSourceService.instance.resolveHttpPlayback(song);
-    final url = resolved?.url;
+    final resolved = await RemoteSourceService.instance.resolveHttpPlayback(
+      song,
+    );
+    final url = resolved?.url ?? await _serveFromPhone(song);
     if (url == null) {
-      // Local files can't be cast without an embedded HTTP server (deferred).
+      // Content-URI locals and unresolvable sources stay local-only.
       return false;
     }
     final dev = _activeDevice!;
@@ -151,13 +160,43 @@ class CastingService {
   Future<void> delegateSetVolume(double volume) async {
     if (_activeDevice == null) return;
     if (_activeDevice!.backend == CastBackend.dlna) {
-      await _dlna.setVolume(_controlUrl(_activeDevice!), (volume * 100).round().clamp(0, 100));
+      await _dlna.setVolume(
+        _controlUrl(_activeDevice!),
+        (volume * 100).round().clamp(0, 100),
+      );
     } else {
       await _chromecast.setVolume(volume);
     }
   }
 
-  String _controlUrl(CastDevice d) => d.iconUrl!; // DLNA: controlURL stashed here at discovery
+  String _controlUrl(CastDevice d) =>
+      d.iconUrl!; // DLNA: controlURL stashed here at discovery
+
+  /// Last-resort cast source: serve the bytes from this phone via the
+  /// embedded HTTP server. Covers local files, SMB, and cached network songs
+  /// (including formats the local engine can't decode — the renderer decodes).
+  Future<String?> _serveFromPhone(Song song) async {
+    try {
+      String? path;
+      if (song.isNetworkSource) {
+        path = await RemoteSourceService.instance.ensureLocal(song);
+      } else {
+        final p = song.filePath;
+        if (p != null && !p.startsWith('content://') && File(p).existsSync()) {
+          path = p;
+        }
+      }
+      if (path == null) return null;
+      final ext = song.fileType.toLowerCase();
+      final title = song.title.replaceAll(RegExp(r'[^A-Za-z0-9._\- ]'), '');
+      return await CastContentServer.instance.serve(
+        path,
+        filename: '${title.isEmpty ? 'track' : title}.$ext',
+      );
+    } catch (_) {
+      return null;
+    }
+  }
 
   void _startDlnaPolling(String controlUrl) {
     _pollTimer?.cancel();
@@ -167,7 +206,9 @@ class CastingService {
       if (info == null) return;
       final ps = PlayerService();
       ps.positionNotifier.value = info.position;
-      if (info.duration.inMilliseconds > 0) ps.durationNotifier.value = info.duration;
+      if (info.duration.inMilliseconds > 0) {
+        ps.durationNotifier.value = info.duration;
+      }
       ps.isPlayingNotifier.value = info.playing;
     });
   }

--- a/lib/services/casting/dlna_backend.dart
+++ b/lib/services/casting/dlna_backend.dart
@@ -16,15 +16,22 @@ class DlnaBackend {
 
   DlnaBackend();
 
-  Future<List<CastDevice>> discover({Duration timeout = const Duration(seconds: 4)}) async {
-    final socket = await RawDatagramSocket.bind(InternetAddress.anyIPv4, _ssdpPort, reuseAddress: true);
+  Future<List<CastDevice>> discover({
+    Duration timeout = const Duration(seconds: 4),
+  }) async {
+    final socket = await RawDatagramSocket.bind(
+      InternetAddress.anyIPv4,
+      _ssdpPort,
+      reuseAddress: true,
+    );
     final locations = <String>{};
     try {
       socket.multicastLoopback = false;
       try {
         socket.joinMulticast(InternetAddress(_ssdpAddress));
       } catch (_) {}
-      final req = 'M-SEARCH * HTTP/1.1\r\n'
+      final req =
+          'M-SEARCH * HTTP/1.1\r\n'
           'HOST: $_ssdpAddress:$_ssdpPort\r\n'
           'MAN: "ssdp:discover"\r\n'
           'MX: 2\r\n'
@@ -39,7 +46,10 @@ class DlnaBackend {
           final datagram = socket.receive();
           if (datagram == null) return;
           final msg = String.fromCharCodes(datagram.data);
-          final m = RegExp(r'LOCATION: (.+)', caseSensitive: false).firstMatch(msg);
+          final m = RegExp(
+            r'LOCATION: (.+)',
+            caseSensitive: false,
+          ).firstMatch(msg);
           if (m != null) locations.add(m.group(1)!.trim());
         }
       });
@@ -52,20 +62,31 @@ class DlnaBackend {
     }
 
     final devices = <CastDevice>[];
-    await Future.wait(locations.map((loc) async {
-      final dev = await _resolve(loc);
-      if (dev != null) devices.add(dev);
-    }));
+    await Future.wait(
+      locations.map((loc) async {
+        final dev = await _resolve(loc);
+        if (dev != null) devices.add(dev);
+      }),
+    );
     return devices;
   }
 
   Future<CastDevice?> _resolve(String locationUrl) async {
     try {
-      final res = await http.get(Uri.parse(locationUrl)).timeout(const Duration(seconds: 3));
+      final res = await http
+          .get(Uri.parse(locationUrl))
+          .timeout(const Duration(seconds: 3));
       if (res.statusCode != 200) return null;
       final doc = xml.XmlDocument.parse(res.body);
-      final friendlyName = doc.findAllElements('friendlyName', namespace: '*').firstOrNull?.innerText ?? 'Unknown';
-      final udn = doc.findAllElements('UDN', namespace: '*').firstOrNull?.innerText ?? locationUrl;
+      final friendlyName =
+          doc
+              .findAllElements('friendlyName', namespace: '*')
+              .firstOrNull
+              ?.innerText ??
+          'Unknown';
+      final udn =
+          doc.findAllElements('UDN', namespace: '*').firstOrNull?.innerText ??
+          locationUrl;
       String? controlUrl = _findAvTransportControlUrl(doc, locationUrl);
       if (controlUrl == null) return null;
       return CastDevice(
@@ -73,7 +94,8 @@ class DlnaBackend {
         name: friendlyName,
         backend: CastBackend.dlna,
         locationUrl: locationUrl,
-        iconUrl: controlUrl, // ponytail: reuse iconUrl slot for controlURL; renderer session resolves fresh
+        iconUrl:
+            controlUrl, // ponytail: reuse iconUrl slot for controlURL; renderer session resolves fresh
       );
     } catch (_) {
       return null;
@@ -82,45 +104,93 @@ class DlnaBackend {
 
   String? _findAvTransportControlUrl(xml.XmlDocument doc, String locationUrl) {
     for (final svc in doc.findAllElements('service', namespace: '*')) {
-      final st = svc.findElements('serviceType', namespace: '*').firstOrNull?.innerText ?? '';
+      final st =
+          svc
+              .findElements('serviceType', namespace: '*')
+              .firstOrNull
+              ?.innerText ??
+          '';
       if (!st.contains('AVTransport')) continue;
-      final cu = svc.findElements('controlURL', namespace: '*').firstOrNull?.innerText;
+      final cu = svc
+          .findElements('controlURL', namespace: '*')
+          .firstOrNull
+          ?.innerText;
       if (cu == null) continue;
       return Uri.parse(locationUrl).resolve(cu).toString();
     }
     return null;
   }
 
-  Future<void> setUri(String controlUrl, String mediaUrl, {String? title}) async {
-    final current = title != null ? '<dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">${_esc(title)}</dc:title>' : '';
-    final meta = '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
+  Future<void> setUri(
+    String controlUrl,
+    String mediaUrl, {
+    String? title,
+  }) async {
+    final current = title != null
+        ? '<dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">${_esc(title)}</dc:title>'
+        : '';
+    final meta =
+        '<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" '
         'xmlns:dc="http://purl.org/dc/elements/1.1/">'
         '<item id="1" parentID="0" restricted="1">'
         '<res protocolInfo="http-get:*:audio/*:*">${_esc(mediaUrl)}</res>'
         '$current</item></DIDL-Lite>';
-    await _soap(controlUrl, 'SetAVTransportURI',
-        '<InstanceID>0</InstanceID><CurrentURI>${_esc(mediaUrl)}</CurrentURI><CurrentURIMetaData>$meta</CurrentURIMetaData>');
+    await _soap(
+      controlUrl,
+      'SetAVTransportURI',
+      '<InstanceID>0</InstanceID><CurrentURI>${_esc(mediaUrl)}</CurrentURI><CurrentURIMetaData>$meta</CurrentURIMetaData>',
+    );
   }
 
-  Future<void> play(String controlUrl) => _soap(controlUrl, 'Play', '<InstanceID>0</InstanceID><Speed>1</Speed>');
-  Future<void> pause(String controlUrl) => _soap(controlUrl, 'Pause', '<InstanceID>0</InstanceID>');
-  Future<void> stop(String controlUrl) => _soap(controlUrl, 'Stop', '<InstanceID>0</InstanceID>');
+  Future<void> play(String controlUrl) =>
+      _soap(controlUrl, 'Play', '<InstanceID>0</InstanceID><Speed>1</Speed>');
+  Future<void> pause(String controlUrl) =>
+      _soap(controlUrl, 'Pause', '<InstanceID>0</InstanceID>');
+  Future<void> stop(String controlUrl) =>
+      _soap(controlUrl, 'Stop', '<InstanceID>0</InstanceID>');
 
-  Future<void> seek(String controlUrl, Duration position) =>
-      _soap(controlUrl, 'Seek', '<InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>${_fmtTime(position)}</Target>');
+  Future<void> seek(String controlUrl, Duration position) => _soap(
+    controlUrl,
+    'Seek',
+    '<InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>${_fmtTime(position)}</Target>',
+  );
 
-  Future<void> setVolume(String controlUrl, int volume) =>
-      _soap(controlUrl, 'SetVolume', '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>$volume</DesiredVolume>');
+  Future<void> setVolume(String controlUrl, int volume) => _soap(
+    controlUrl,
+    'SetVolume',
+    '<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>$volume</DesiredVolume>',
+  );
 
-  Future<({Duration position, Duration duration, bool playing})?> getPosition(String controlUrl) async {
+  Future<({Duration position, Duration duration, bool playing})?> getPosition(
+    String controlUrl,
+  ) async {
     try {
-      final res = await _soap(controlUrl, 'GetPositionInfo', '<InstanceID>0</InstanceID>');
+      final res = await _soap(
+        controlUrl,
+        'GetPositionInfo',
+        '<InstanceID>0</InstanceID>',
+      );
       final doc = xml.XmlDocument.parse(res);
-      final posStr = doc.findAllElements('RelTime', namespace: '*').firstOrNull?.innerText;
-      final durStr = doc.findAllElements('TrackDuration', namespace: '*').firstOrNull?.innerText;
-      final tiRes = await _soap(controlUrl, 'GetTransportInfo', '<InstanceID>0</InstanceID>');
+      final posStr = doc
+          .findAllElements('RelTime', namespace: '*')
+          .firstOrNull
+          ?.innerText;
+      final durStr = doc
+          .findAllElements('TrackDuration', namespace: '*')
+          .firstOrNull
+          ?.innerText;
+      final tiRes = await _soap(
+        controlUrl,
+        'GetTransportInfo',
+        '<InstanceID>0</InstanceID>',
+      );
       final tiDoc = xml.XmlDocument.parse(tiRes);
-      final state = tiDoc.findAllElements('CurrentTransportState', namespace: '*').firstOrNull?.innerText ?? '';
+      final state =
+          tiDoc
+              .findAllElements('CurrentTransportState', namespace: '*')
+              .firstOrNull
+              ?.innerText ??
+          '';
       return (
         position: _parseTime(posStr) ?? Duration.zero,
         duration: _parseTime(durStr) ?? Duration.zero,
@@ -132,22 +202,39 @@ class DlnaBackend {
   }
 
   Future<String> _soap(String controlUrl, String action, String args) async {
-    final body = '<?xml version="1.0" encoding="utf-8"?>'
+    final body =
+        '<?xml version="1.0" encoding="utf-8"?>'
         '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" '
         's:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
         '<s:Body><u:$action xmlns:u="$_serviceType">$args</u:$action></s:Body></s:Envelope>';
-    final res = await http.post(
-      Uri.parse(controlUrl),
-      headers: {
-        'Content-Type': 'text/xml; charset="utf-8"',
-        'SOAPAction': '"$_serviceType#$action"',
-      },
-      body: body,
-    ).timeout(const Duration(seconds: 5));
+    final res = await http
+        .post(
+          Uri.parse(controlUrl),
+          headers: {
+            'Content-Type': 'text/xml; charset="utf-8"',
+            'SOAPAction': '"$_serviceType#$action"',
+          },
+          body: body,
+        )
+        .timeout(const Duration(seconds: 5));
+    // ponytail: string sniff instead of full fault parse — enough to tell
+    // "renderer rejected it" from "renderer did it".
+    if (res.statusCode != 200 || res.body.contains('faultcode')) {
+      final desc =
+          RegExp(r'<errorDescription>([^<]*)').firstMatch(res.body)?.group(1) ??
+          res.body;
+      throw StateError(
+        'AVTransport $action failed '
+        '(HTTP ${res.statusCode}): $desc',
+      );
+    }
     return res.body;
   }
 
-  String _esc(String s) => s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  String _esc(String s) => s
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
   String _fmtTime(Duration d) {
     final h = d.inHours.toString().padLeft(2, '0');
     final m = (d.inMinutes % 60).toString().padLeft(2, '0');
@@ -156,9 +243,15 @@ class DlnaBackend {
   }
 
   Duration? _parseTime(String? s) {
-    if (s == null || s == 'NOT_IMPLEMENTED' || s == '0:00:00') return s == '0:00:00' ? Duration.zero : null;
+    if (s == null || s == 'NOT_IMPLEMENTED' || s == '0:00:00') {
+      return s == '0:00:00' ? Duration.zero : null;
+    }
     final m = RegExp(r'(\d+):(\d+):(\d+)').firstMatch(s);
     if (m == null) return null;
-    return Duration(hours: int.parse(m.group(1)!), minutes: int.parse(m.group(2)!), seconds: int.parse(m.group(3)!));
+    return Duration(
+      hours: int.parse(m.group(1)!),
+      minutes: int.parse(m.group(2)!),
+      seconds: int.parse(m.group(3)!),
+    );
   }
 }

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1678,8 +1678,12 @@ class PlayerService {
   // ponytail: any Rust/bit-perfect path can be system-invisible to OEM
   // battery AI (Xiaomi/Tecno/Infinix), not just direct USB. Reuses the
   // existing usesRustBackend helper which excludes normalAndroid.
+  // Excluded on DAP_INTERNAL_HIGH_RES: the anchor's Java AudioTrack gets
+  // HiBy-forced onto the sole DIRECT slot, killing our native stream.
   bool get _isAnchorEligiblePath =>
-      Platform.isAndroid && currentEngineType.usesRustBackend;
+      Platform.isAndroid &&
+      currentEngineType.usesRustBackend &&
+      currentEngineType != AudioEngineType.dapInternalHighRes;
 
   void _updatePriorityAnchor() {
     final shouldAnchor =
@@ -1964,6 +1968,10 @@ class PlayerService {
         ? AudioPathManagement.androidManagedShared
         : !usesRustDiagnostics
         ? AudioPathManagement.androidManagedShared
+        : outputSignature?.startsWith('android-alsa:') == true
+        ? AudioPathManagement.alsaDirectDap
+        : outputSignature?.startsWith('android-direct:') == true
+        ? AudioPathManagement.managedDirectExclusive
         : (outputStrategy == 'usb_direct' &&
                   outputSignature?.startsWith('android-uac2:') == true) ||
               outputStrategy == 'usb_dsd_native'
@@ -1971,7 +1979,9 @@ class PlayerService {
         : AudioPathManagement.androidManagedLowLatency;
 
     final isMixerManaged =
-        pathManagement != AudioPathManagement.directUsbExperimental;
+        pathManagement != AudioPathManagement.directUsbExperimental &&
+        pathManagement != AudioPathManagement.alsaDirectDap &&
+        pathManagement != AudioPathManagement.managedDirectExclusive;
     final requestedOutputSampleRate =
         (!usesRustDiagnostics ? trackFormat?.sampleRate : null) ??
         engineRequestedSampleRate ??
@@ -2039,8 +2049,17 @@ class PlayerService {
               'Rust engine via DoP over PCM carrier (verified)',
             'dsd_dop' => 'Rust engine via DoP over PCM carrier',
             'dap_native' when passthroughAllowed =>
-              'Rust engine via native DAP HAL path (verified)',
-            'dap_native' => 'Rust engine via native DAP HAL path',
+              outputSignature?.startsWith('android-direct:') == true
+                  ? 'Rust engine via AudioTrack DIRECT PCM (mixer bypass, verified)'
+                  : outputSignature?.startsWith('android-alsa:') == true
+                  ? 'Rust engine via ALSA direct DAP path (verified)'
+                  : 'Rust engine via native DAP HAL path (verified)',
+            'dap_native' =>
+              outputSignature?.startsWith('android-direct:') == true
+                  ? 'Rust engine via AudioTrack DIRECT PCM (mixer bypass)'
+                  : outputSignature?.startsWith('android-alsa:') == true
+                  ? 'Rust engine via ALSA direct DAP path'
+                  : 'Rust engine via native DAP HAL path',
             'mixer_bit_perfect' =>
               'Rust engine via Android mixer bit-perfect path',
             'mixer_matched' =>

--- a/lib/services/remote_source_service.dart
+++ b/lib/services/remote_source_service.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../core/utils/app_log.dart';
 import '../data/database.dart';
+import '../data/repositories/song_repository.dart';
 import '../models/song.dart';
+import '../src/rust/api/audio_api.dart' as rust_audio;
 import 'sources/network_source_service.dart';
 
 /// Bridges playback/download for network-sourced songs.
@@ -21,6 +25,10 @@ class RemoteSourceService {
 
   /// Progress (0..1) of the interactive playback download, null when idle.
   final ValueNotifier<double?> downloadProgressNotifier = ValueNotifier(null);
+
+  /// Songs whose format probe failed (e.g. AAC-in-M4A Symphonia gap);
+  /// skip retrying them every play.
+  final Set<String> _probeFailed = {};
 
   Future<NetworkServerEntity> _serverFor(Song song) async {
     final serverId = song.remoteServerId;
@@ -51,7 +59,7 @@ class RemoteSourceService {
     }
     final service = networkSourceServiceFor(sourceType);
     try {
-      return await service.stream(
+      final path = await service.stream(
         server,
         remoteId,
         extension: song.fileType,
@@ -59,8 +67,30 @@ class RemoteSourceService {
             ? (p) => downloadProgressNotifier.value = p
             : null,
       );
+      unawaited(_backfillAudioFormat(song, path));
+      return path;
     } finally {
       if (reportProgress) downloadProgressNotifier.value = null;
+    }
+  }
+
+  /// ponytail: probe-once backfill for sources whose sync can't read tags
+  /// (SMB/WebDAV listing has no sampleRate/bitDepth). Runs after the file is
+  /// local either way; HTTP-direct streams skip it. Full tag read at sync time
+  /// is the upgrade path if users want quality labels before first play.
+  Future<void> _backfillAudioFormat(Song song, String localPath) async {
+    if (song.sampleRate != null || song.bitDepth != null) return;
+    if (_probeFailed.contains(song.id)) return;
+    try {
+      final probed = await rust_audio.audioProbeFormat(path: localPath);
+      await SongRepository().updateAudioFormat(
+        song.filePath!,
+        sampleRate: probed.sampleRate,
+        bitDepth: probed.bitsPerSample,
+      );
+    } catch (e) {
+      _probeFailed.add(song.id);
+      AppLog.instance.add('Format backfill failed for "${song.title}": $e');
     }
   }
 

--- a/lib/services/sources/jellyfin_service.dart
+++ b/lib/services/sources/jellyfin_service.dart
@@ -106,7 +106,9 @@ class JellyfinService implements NetworkSourceService {
             'Pw': password,
           }),
         )
-        .timeout(const Duration(seconds: 15));
+        // ponytail: 60s ceiling for LDAP/SSO backends (Authentik et al);
+        // wrong-credential 401s still return as fast as the server sends them.
+        .timeout(const Duration(seconds: 60));
     if (response.statusCode != 200) {
       throw JellyfinNetworkException(
           'Authentication failed (HTTP ${response.statusCode})');

--- a/rust/src/audio/audiotrack_direct.rs
+++ b/rust/src/audio/audiotrack_direct.rs
@@ -1,0 +1,307 @@
+//! Native android::AudioTrack with AUDIO_OUTPUT_FLAG_DIRECT — the UAPP
+//! method for native-rate mixer bypass on HiBy-style DAPs. Symbols reached
+//! via dlopen(libmedia/libOpenSLES) → dlsym dependency chain.
+#![cfg(target_os = "android")]
+
+use crate::audio::commands::AudioEvent;
+use crate::audio::engine::{audio_callback, AudioCallbackData};
+use crossbeam_channel::Sender;
+use std::ffi::{c_void, CStr, CString};
+use std::os::raw::{c_char, c_int};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+const RTLD_LAZY: c_int = 1;
+const RTLD_LOCAL: c_int = 0;
+
+const AUDIO_STREAM_MUSIC: i32 = 3;
+const AUDIO_FORMAT_PCM_32_BIT: u32 = 3;
+const AUDIO_CHANNEL_OUT_STEREO: u32 = 0x3;
+const AUDIO_OUTPUT_FLAG_DIRECT: u32 = 0x1;
+const AUDIO_SESSION_ALLOCATE: i32 = 0;
+// transfer_type: SYNC=3, blocking write(), no callback.
+const TRANSFER_SYNC: i32 = 3;
+const USAGE_MEDIA: u32 = 1;
+const CONTENT_TYPE_MUSIC: u32 = 2;
+
+// ponytail: over-allocate — exact sizes not observable from Rust.
+const AUDIOTRACK_ALLOC_SIZE: usize = 8192;
+const ATTRS_ALLOC_SIZE: usize = 256;
+
+type CtorFn = unsafe extern "C" fn(*mut c_void);
+type DtorFn = unsafe extern "C" fn(*mut c_void);
+type StartFn = unsafe extern "C" fn(*mut c_void) -> i32;
+type WriteFn = unsafe extern "C" fn(*mut c_void, *const c_void, usize, bool) -> i64;
+type GetSampleRateFn = unsafe extern "C" fn(*mut c_void) -> i32;
+type SetFn = unsafe extern "C" fn(
+    *mut c_void,        // this
+    i32,                // streamType
+    u32,                // rate
+    u32,                // format
+    u32,                // channelMask
+    usize,              // frameCount
+    u32,                // flags
+    *mut c_void,        // callback_t cbf
+    *mut c_void,        // void* user
+    i32,                // notificationFrames
+    *const c_void,      // const sp<IMemory>* sharedBuffer
+    bool,               // threadCanCallJava
+    i32,                // sessionId
+    i32,                // transferType
+    *const c_void,      // const audio_offload_info_t*
+    u32,                // uid
+    i32,                // pid
+    *const c_void,      // const audio_attributes_t*
+    bool,               // doNotReconnect
+    f32,                // maxRequiredSpeed
+    i32,                // selectedDeviceId
+) -> i32;
+
+#[repr(C)]
+struct AudioTrackApi {
+    ctor: CtorFn,
+    dtor: DtorFn,
+    set: SetFn,
+    start: StartFn,
+    stop: StartFn,
+    write: WriteFn,
+    get_sample_rate: GetSampleRateFn,
+}
+
+unsafe fn load_api() -> Result<AudioTrackApi, String> {
+    // dlopen libmedia (UAPP's path) or libOpenSLES; dlsym follows the
+    // dependency chain into libaudioclient either way.
+    let mut handle: *mut c_void = std::ptr::null_mut();
+    let mut used = "";
+    for candidate in ["/system/lib64/libmedia.so", "libOpenSLES.so"] {
+        let lib = CString::new(candidate).unwrap();
+        handle = libc::dlopen(lib.as_ptr(), RTLD_LAZY | RTLD_LOCAL);
+        if !handle.is_null() {
+            used = candidate;
+            break;
+        }
+    }
+    if handle.is_null() {
+        let err = libc::dlerror();
+        let msg = if err.is_null() {
+            "unknown dlopen error".to_string()
+        } else {
+            CStr::from_ptr(err).to_string_lossy().into_owned()
+        };
+        return Err(format!("libmedia/libOpenSLES unavailable: {}", msg));
+    }
+    let _ = used;
+
+    macro_rules! sym {
+        ($name:expr) => {{
+            let cname = CString::new($name).unwrap();
+            let p = libc::dlsym(handle, cname.as_ptr());
+            if p.is_null() {
+                return Err(format!("missing symbol {}", $name));
+            }
+            p
+        }};
+    }
+
+    Ok(AudioTrackApi {
+        ctor: std::mem::transmute::<*mut c_void, CtorFn>(sym!(
+            "_ZN7android10AudioTrackC1Ev"
+        )),
+        dtor: std::mem::transmute::<*mut c_void, DtorFn>(sym!(
+            "_ZN7android10AudioTrackD1Ev"
+        )),
+        set: std::mem::transmute::<*mut c_void, SetFn>(sym!(
+            "_ZN7android10AudioTrack3setE19audio_stream_type_tj14audio_format_tjm20audio_output_flags_tPFviPvS4_ES4_iRKNS_2spINS_7IMemoryEEEb15audio_session_tNS0_13transfer_typeEPK20audio_offload_info_tjiPK18audio_attributes_tbfi"
+        )),
+        start: std::mem::transmute::<*mut c_void, StartFn>(sym!(
+            "_ZN7android10AudioTrack5startEv"
+        )),
+        stop: std::mem::transmute::<*mut c_void, StartFn>(sym!(
+            "_ZN7android10AudioTrack4stopEv"
+        )),
+        write: std::mem::transmute::<*mut c_void, WriteFn>(sym!(
+            "_ZN7android10AudioTrack5writeEPKvmb"
+        )),
+        get_sample_rate: std::mem::transmute::<*mut c_void, GetSampleRateFn>(sym!(
+            "_ZNK7android10AudioTrack13getSampleRateEv"
+        )),
+    })
+}
+
+/// Owns one android::AudioTrack constructed in place inside `storage`.
+/// `this` is nulled after teardown so Drop stays idempotent.
+struct RawAudioTrack {
+    api: &'static AudioTrackApi,
+    #[allow(dead_code)]
+    storage: Vec<u8>,
+    this: *mut c_void,
+    started: bool,
+}
+
+unsafe impl Send for RawAudioTrack {}
+
+impl RawAudioTrack {
+    unsafe fn open_direct(api: &'static AudioTrackApi, rate: u32) -> Result<Self, String> {
+        let mut storage = vec![0u8; AUDIOTRACK_ALLOC_SIZE];
+        let this = storage.as_mut_ptr() as *mut c_void;
+        (api.ctor)(this);
+
+        // ~400 ms buffer like UAPP.
+        let frame_count = ((rate as u64 * 400) / 1000).max(256) as usize;
+        let mut attrs = vec![0u8; ATTRS_ALLOC_SIZE];
+        attrs[0..4].copy_from_slice(&CONTENT_TYPE_MUSIC.to_le_bytes());
+        attrs[4..8].copy_from_slice(&USAGE_MEDIA.to_le_bytes());
+
+        // Empty sp<IMemory> — a null reference here is UB and returns -22.
+        static EMPTY_SP: [u64; 1] = [0];
+
+        let status = (api.set)(
+            this,
+            AUDIO_STREAM_MUSIC,
+            rate,
+            AUDIO_FORMAT_PCM_32_BIT,
+            AUDIO_CHANNEL_OUT_STEREO,
+            frame_count,
+            AUDIO_OUTPUT_FLAG_DIRECT,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            EMPTY_SP.as_ptr() as *const c_void,
+            false,
+            AUDIO_SESSION_ALLOCATE,
+            TRANSFER_SYNC,
+            std::ptr::null(),
+            u32::MAX,
+            -1,
+            attrs.as_ptr() as *const c_void,
+            false,
+            1.0,
+            0,
+        );
+        if status != 0 {
+            (api.dtor)(this);
+            return Err(format!("AudioTrack DIRECT open failed (status {})", status));
+        }
+        let opened_rate = (api.get_sample_rate)(this);
+        if opened_rate != rate as i32 {
+            (api.dtor)(this);
+            return Err(format!(
+                "opened at {} Hz instead of requested {} Hz — policy adapted the request (no native direct profile)",
+                opened_rate, rate
+            ));
+        }
+        let status = (api.start)(this);
+        if status != 0 {
+            (api.dtor)(this);
+            return Err(format!("AudioTrack start failed (status {})", status));
+        }
+
+        Ok(Self {
+            api,
+            storage,
+            this,
+            started: true,
+        })
+    }
+
+    fn write_blocking(&mut self, bytes: &[u8]) -> Result<(), String> {
+        let written =
+            unsafe { ((self.api).write)(self.this, bytes.as_ptr() as *const c_void, bytes.len(), true) };
+        if written < 0 {
+            Err(format!("AudioTrack write failed ({})", written))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn close(&mut self) {
+        if self.this.is_null() {
+            return;
+        }
+        unsafe {
+            if self.started {
+                ((self.api).stop)(self.this);
+            }
+            ((self.api).dtor)(self.this);
+        }
+        self.started = false;
+        self.this = std::ptr::null_mut();
+    }
+}
+
+impl Drop for RawAudioTrack {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+/// Render-thread PCM backend into the native DIRECT AudioTrack.
+pub struct AudioTrackDirectBackend {
+    stop: Arc<AtomicBool>,
+    render_thread: Option<JoinHandle<()>>,
+}
+
+impl AudioTrackDirectBackend {
+    pub fn start(
+        callback_data: Arc<AudioCallbackData>,
+        event_tx: Sender<AudioEvent>,
+        sample_rate: u32,
+        channels: usize,
+    ) -> Result<Self, String> {
+        let api: &'static AudioTrackApi = Box::leak(Box::new(unsafe { load_api()? }));
+        // Fail fast before spawning anything.
+        let track = unsafe { RawAudioTrack::open_direct(api, sample_rate)? };
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+        let handle = std::thread::Builder::new()
+            .name("at-direct-render".to_string())
+            .spawn(move || {
+                audiotrack_render_loop(track, callback_data, event_tx, sample_rate, channels, stop_clone);
+            })
+            .map_err(|e| format!("Failed to spawn AudioTrack render thread: {}", e))?;
+        Ok(Self {
+            stop,
+            render_thread: Some(handle),
+        })
+    }
+
+    pub fn stop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.render_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+const AT_DIRECT_CHUNK_MS: u64 = 10;
+
+fn audiotrack_render_loop(
+    mut track: RawAudioTrack,
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    sample_rate: u32,
+    channels: usize,
+    stop: Arc<AtomicBool>,
+) {
+    let chunk_frames = (((sample_rate as u64) * AT_DIRECT_CHUNK_MS) / 1000).max(1) as usize;
+    let chunk_samples = chunk_frames * channels;
+    let mut render_buffer = vec![0.0f32; chunk_samples];
+    let mut pcm_bytes = vec![0u8; chunk_samples * 4];
+
+    while !stop.load(Ordering::Acquire) {
+        audio_callback(&mut render_buffer, &callback_data, &event_tx);
+
+        for (i, sample) in render_buffer.iter().enumerate() {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let value = (clamped * 2_147_483_648.0f32) as i32; // `as` saturates; int24 sources roundtrip exactly
+            pcm_bytes[i * 4..i * 4 + 4].copy_from_slice(&value.to_le_bytes());
+        }
+
+        if let Err(e) = track.write_blocking(&pcm_bytes) {
+            log::error!("[AT-DIRECT] {}", e);
+            break;
+        }
+    }
+    track.close();
+}

--- a/rust/src/audio/dsd_alsa_direct.rs
+++ b/rust/src/audio/dsd_alsa_direct.rs
@@ -28,6 +28,7 @@ mod internal {
     const FMT_DSD_U8: usize = 56;
     const FMT_DSD_U16_LE: usize = 57;
     const FMT_DSD_U32_LE: usize = 58;
+    const FMT_S32_LE: usize = 10;
 
     // Access modes
     const ACCESS_RW_INTERLEAVED: usize = 3;
@@ -117,7 +118,8 @@ mod internal {
             FMT_DSD_U8 => "DSD_U8",
             FMT_DSD_U16_LE => "DSD_U16_LE",
             FMT_DSD_U32_LE => "DSD_U32_LE",
-            _ => "DSD_?",
+            FMT_S32_LE => "S32_LE",
+            _ => "?"
         }
     }
 
@@ -206,37 +208,63 @@ mod internal {
     // ── Open + configure ──────────────────────────────────────────────────
 
     pub fn open(byte_rate: u32, channels: usize) -> bool {
+        open_with_formats(byte_rate, channels, &[FMT_DSD_U8, FMT_DSD_U16_LE, FMT_DSD_U32_LE])
+    }
+
+    pub fn open_pcm(sample_rate: u32, channels: usize) -> Result<i32, String> {
+        open_detail(sample_rate, channels, &[FMT_S32_LE])
+    }
+
+    fn open_with_formats(rate: u32, channels: usize, preferred_formats: &[usize]) -> bool {
+        open_detail(rate, channels, preferred_formats).is_ok()
+    }
+
+    /// Same as open_with_formats but returns the per-device failure reasons,
+    /// so callers can surface exactly why direct ALSA was unavailable
+    /// (EACCES = no /dev/snd permission, EBUSY = audioserver holds the
+    /// device, EINVAL = format/rate rejected).
+    pub fn open_detail(
+        rate: u32,
+        channels: usize,
+        preferred_formats: &[usize],
+    ) -> Result<i32, String> {
         if FD.load(Ordering::Acquire) >= 0 {
-            return true;
+            return Ok(FD.load(Ordering::Acquire));
         }
 
         let devices = discover_playback_devices();
+        let mut failures: Vec<String> = Vec::new();
         for (path, _card, _dev) in &devices {
-            match try_open_device(path, byte_rate, channels) {
+            match try_open_device(path, rate, channels, preferred_formats) {
                 Ok(fd) => {
                     FD.store(fd, Ordering::Release);
                     log::info!(
-                        "[DSD-ALSA] DSD output opened: {} rate={} ch={}",
+                        "[DSD-ALSA] Output opened: {} rate={} ch={}",
                         path,
-                        byte_rate,
+                        rate,
                         channels
                     );
-                    return true;
+                    return Ok(fd);
                 }
                 Err(e) => {
                     log::info!("[DSD-ALSA] {} failed: {}", path, e);
+                    failures.push(format!("{}: {}", path, e));
                 }
             }
         }
-        log::warn!(
-            "[DSD-ALSA] No device accepted DSD at byte_rate={} ch={}",
-            byte_rate,
-            channels
-        );
-        false
+        Err(if failures.is_empty() {
+            "no /dev/snd/pcmC*D*p devices found".to_string()
+        } else {
+            failures.join("; ")
+        })
     }
 
-    fn try_open_device(path: &str, byte_rate: u32, channels: usize) -> Result<i32, String> {
+    fn try_open_device(
+        path: &str,
+        rate: u32,
+        channels: usize,
+        preferred_formats: &[usize],
+    ) -> Result<i32, String> {
         let cpath = CString::new(path).map_err(|e| format!("path: {}", e))?;
         let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDWR | libc::O_CLOEXEC) };
         if fd < 0 {
@@ -277,10 +305,9 @@ mod internal {
             ));
         }
 
-        // Check if DSD_U8 survived refine
-        let dsd_formats = [FMT_DSD_U8, FMT_DSD_U16_LE, FMT_DSD_U32_LE];
+        // Pick the first preferred format that survived refine
         let mut chosen_fmt = None;
-        for &fmt in &dsd_formats {
+        for &fmt in preferred_formats {
             if mask_test(&params.masks[1], fmt) {
                 chosen_fmt = Some(fmt);
                 break;
@@ -289,16 +316,19 @@ mod internal {
 
         let fmt = match chosen_fmt {
             Some(f) => {
-                log::info!("[DSD-ALSA] Driver supports DSD format {}", fmt_name(f));
+                log::info!("[DSD-ALSA] Driver supports format {}", fmt_name(f));
                 f
             }
             None => {
                 unsafe { libc::close(fd) };
-                return Err("Driver does not support any DSD format".into());
+                return Err(format!(
+                    "Driver does not support any of formats {:?}",
+                    preferred_formats
+                ));
             }
         };
 
-        // Narrow params to exact DSD configuration
+        // Narrow params to the exact configuration
         mask_reset(&mut params.masks[0]); // ACCESS
         mask_set(&mut params.masks[0], ACCESS_RW_INTERLEAVED);
         mask_reset(&mut params.masks[1]); // FORMAT
@@ -307,12 +337,12 @@ mod internal {
         mask_set(&mut params.masks[2], SUBFORMAT_STD);
 
         interval_exact(&mut params.intervals[INTERVAL_CHANNELS], channels as u32);
-        interval_exact(&mut params.intervals[INTERVAL_RATE], byte_rate);
+        interval_exact(&mut params.intervals[INTERVAL_RATE], rate);
 
         let sample_bits = match fmt {
             FMT_DSD_U8 => 8,
             FMT_DSD_U16_LE => 16,
-            FMT_DSD_U32_LE => 32,
+            FMT_DSD_U32_LE | FMT_S32_LE => 32,
             _ => 8,
         };
         interval_exact(&mut params.intervals[INTERVAL_SAMPLE_BITS], sample_bits);
@@ -321,7 +351,7 @@ mod internal {
             sample_bits * channels as u32,
         );
 
-        let period = (byte_rate / 8).max(1024);
+        let period = (rate / 8).max(1024);
         interval_exact(&mut params.intervals[INTERVAL_PERIOD_SIZE], period);
         interval_exact(&mut params.intervals[INTERVAL_PERIODS], 4);
 
@@ -362,7 +392,7 @@ mod internal {
             "[DSD-ALSA] AudioFlinger bypassed: direct /dev/snd ioctl path active on {} ({} rate={} ch={})",
             path,
             fmt_name(fmt),
-            byte_rate,
+            rate,
             channels
         );
 
@@ -427,7 +457,10 @@ mod internal {
 // ── Public API ────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "android")]
-pub use internal::{close as dsd_alsa_close, is_open as dsd_alsa_is_open, open as dsd_alsa_open};
+pub use internal::{
+    close as dsd_alsa_close, is_open as dsd_alsa_is_open, open as dsd_alsa_open,
+    open_pcm as pcm_alsa_open,
+};
 
 #[cfg(target_os = "android")]
 pub fn dsd_alsa_probe() -> bool {
@@ -442,6 +475,11 @@ pub fn dsd_alsa_write(data: &[u8]) -> i32 {
 #[cfg(not(target_os = "android"))]
 pub fn dsd_alsa_open(_rate: u32, _channels: usize) -> bool {
     false
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn pcm_alsa_open(_rate: u32, _channels: usize) -> Result<i32, String> {
+    Err("ALSA direct is Android-only".to_string())
 }
 
 #[cfg(not(target_os = "android"))]

--- a/rust/src/audio/dsd_native_backend.rs
+++ b/rust/src/audio/dsd_native_backend.rs
@@ -121,3 +121,102 @@ fn dsd_native_render_loop(
 
     log::info!("[DSD-NATIVE] ALSA render loop ended");
 }
+
+/// Direct PCM output over the raw ALSA ioctl path (same AudioFlinger
+/// bypass as DSD native, but S32_LE PCM at the track's native rate).
+/// Used by the DapNative strategy on DAPs whose HAL resamples shared-mode
+/// streams (e.g. HiBy R4 locks its indicator to 48 kHz while reporting the
+/// requested rate back through AudioTrack/AAudio).
+pub struct PcmAlsaBackend {
+    stop: Arc<AtomicBool>,
+    render_thread: Option<JoinHandle<()>>,
+}
+
+impl PcmAlsaBackend {
+    pub fn start(
+        callback_data: Arc<AudioCallbackData>,
+        event_tx: Sender<AudioEvent>,
+        sample_rate: u32,
+        channels: usize,
+    ) -> Result<Self, String> {
+        log::info!(
+            "[PCM-ALSA] Opening ALSA direct PCM output: rate={} Hz, ch={}",
+            sample_rate,
+            channels,
+        );
+
+        if let Err(e) = super::dsd_alsa_direct::pcm_alsa_open(sample_rate, channels) {
+            return Err(format!("ALSA PCM output unavailable: {}", e));
+        }
+
+        crate::dev_eprintln!(
+            "[PCM-ALSA] ALSA direct PCM output opened at {} Hz ch={} — AudioFlinger bypassed",
+            sample_rate,
+            channels,
+        );
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_clone = Arc::clone(&stop);
+
+        let handle = thread::Builder::new()
+            .name("pcm-alsa-render".to_string())
+            .spawn(move || {
+                pcm_alsa_render_loop(callback_data, event_tx, sample_rate, channels, stop_clone);
+                super::dsd_alsa_direct::dsd_alsa_close();
+            })
+            .map_err(|e| format!("Failed to spawn PCM ALSA render thread: {}", e))?;
+
+        Ok(Self {
+            stop,
+            render_thread: Some(handle),
+        })
+    }
+
+    pub fn stop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(handle) = self.render_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+const PCM_ALSA_CHUNK_MS: u64 = 10;
+
+fn pcm_alsa_render_loop(
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    sample_rate: u32,
+    channels: usize,
+    stop: Arc<AtomicBool>,
+) {
+    let chunk_frames = (((sample_rate as u64) * PCM_ALSA_CHUNK_MS) / 1000).max(1) as usize;
+    let chunk_samples = chunk_frames * channels;
+    let mut render_buffer = vec![0.0f32; chunk_samples];
+    let mut pcm_bytes = vec![0u8; chunk_samples * 4];
+
+    log::info!(
+        "[PCM-ALSA] render loop started: rate={} Hz, ch={}, chunk={} frames ({}ms)",
+        sample_rate,
+        channels,
+        chunk_frames,
+        PCM_ALSA_CHUNK_MS
+    );
+
+    while !stop.load(Ordering::Acquire) {
+        audio_callback(&mut render_buffer, &callback_data, &event_tx);
+
+        for (i, sample) in render_buffer.iter().enumerate() {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let value = (clamped * 2_147_483_648.0f32) as i32; // 2^31; int24 roundtrip is exact, `as` saturates +1.0
+            pcm_bytes[i * 4..i * 4 + 4].copy_from_slice(&value.to_le_bytes());
+        }
+
+        let written = super::dsd_alsa_direct::dsd_alsa_write(&pcm_bytes);
+        if written < 0 {
+            log::error!("[PCM-ALSA] ALSA write failed, stopping render loop");
+            break;
+        }
+    }
+
+    log::info!("[PCM-ALSA] render loop ended");
+}

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -1048,6 +1048,8 @@ fn build_output_runtime_state(
 enum AndroidManagedStreamKind {
     F32(AudioStreamAsync<Output, AndroidOutputCallbackF32>),
     I32(AudioStreamAsync<Output, AndroidOutputCallbackI32>),
+    I32Pcm(AudioStreamAsync<Output, AndroidOutputCallbackI32Pcm>),
+    I16(AudioStreamAsync<Output, AndroidOutputCallbackI16>),
 }
 
 #[cfg(target_os = "android")]
@@ -1055,6 +1057,9 @@ struct AndroidManagedStream {
     kind: AndroidManagedStreamKind,
     actual_sample_rate: u32,
     active_audio_api: &'static str,
+    active_sharing: &'static str,
+    sample_format: &'static str,
+    exclusive_error: Option<String>,
 }
 
 #[cfg(target_os = "android")]
@@ -1063,6 +1068,8 @@ impl AndroidManagedStream {
         match &mut self.kind {
             AndroidManagedStreamKind::F32(s) => s.start(),
             AndroidManagedStreamKind::I32(s) => s.start(),
+            AndroidManagedStreamKind::I32Pcm(s) => s.start(),
+            AndroidManagedStreamKind::I16(s) => s.start(),
         }
     }
 
@@ -1070,6 +1077,8 @@ impl AndroidManagedStream {
         match &mut self.kind {
             AndroidManagedStreamKind::F32(s) => s.stop(),
             AndroidManagedStreamKind::I32(s) => s.stop(),
+            AndroidManagedStreamKind::I32Pcm(s) => s.stop(),
+            AndroidManagedStreamKind::I16(s) => s.stop(),
         }
     }
 }
@@ -1538,6 +1547,15 @@ pub fn create_audio_engine(
 
     let mut dsd_native_backend = None;
 
+    // Raw ALSA S32_LE fallback — /dev/snd direct write (EACCES on HiBy).
+    let mut pcm_alsa_backend = None;
+    let mut dap_alsa_error: Option<String> = None;
+
+    // Native AudioTrack DIRECT — the UAPP mixer-bypass method.
+    #[cfg(target_os = "android")]
+    let mut audiotrack_backend = None;
+    let mut dap_audiotrack_error: Option<String> = None;
+
     let mut final_sample_rate = requested_sample_rate;
     let mut output_runtime = build_output_runtime_state(
         desired_strategy,
@@ -1658,10 +1676,7 @@ pub fn create_audio_engine(
         }
     }
 
-    // DSD Native output: ALSA direct only (raw SNDRV_PCM ioctls on /dev/snd,
-    // bypasses AudioTrack/AudioFlinger entirely). No AudioTrack fallback; on
-    // failure DsdNativeBackend returns DSD_NATIVE_FALLBACK, which the strategy
-    // layer maps to DoP (see api/audio_api.rs).
+    // DSD Native: ALSA direct only; on failure map to DoP via audio_api.rs.
     #[cfg(target_os = "android")]
     if desired_strategy == OutputStrategy::DsdNative && direct_usb_backend.is_none() {
         match crate::audio::dsd_native_backend::DsdNativeBackend::start(
@@ -1706,14 +1721,117 @@ pub fn create_audio_engine(
         }
     }
 
+    // DapNative PCM: mixer-bypassing direct paths first, managed fallback last.
+    #[cfg(target_os = "android")]
+    if desired_strategy == OutputStrategy::DapNative
+        && dap_bit_perfect_enabled
+        && direct_usb_backend.is_none()
+        && dsd_native_backend.is_none()
+    {
+        match crate::audio::audiotrack_direct::AudioTrackDirectBackend::start(
+            Arc::clone(&callback_data_clone),
+            event_tx_clone.clone(),
+            requested_sample_rate,
+            channels,
+        ) {
+            Ok(backend) => {
+                log::info!(
+                    "[ENGINE] DAP native PCM via AudioTrack DIRECT at {} Hz — mixer bypassed",
+                    requested_sample_rate
+                );
+                final_sample_rate = requested_sample_rate;
+                callback_data.reconfigure_sample_rate(final_sample_rate);
+                callback_data.set_pipeline_mode(PipelineMode::Passthrough);
+                output_runtime = build_output_runtime_state(
+                    OutputStrategy::DapNative,
+                    OutputVerification::verify(
+                        requested_sample_rate,
+                        requested_sample_rate,
+                        true,
+                        true,
+                    ),
+                    false,
+                    false,
+                );
+                output_signature = format!("android-direct:dap-native:{}", requested_sample_rate);
+                audiotrack_backend = Some(backend);
+            }
+            Err(error) => {
+                log::info!(
+                    "[ENGINE] DAP native AudioTrack DIRECT unavailable ({}). Trying ALSA direct.",
+                    error
+                );
+                dap_audiotrack_error = Some(error);
+            }
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    if desired_strategy == OutputStrategy::DapNative
+        && dap_bit_perfect_enabled
+        && direct_usb_backend.is_none()
+        && dsd_native_backend.is_none()
+        && audiotrack_backend.is_none()
+    {
+        match crate::audio::dsd_native_backend::PcmAlsaBackend::start(
+            Arc::clone(&callback_data_clone),
+            event_tx_clone.clone(),
+            requested_sample_rate,
+            channels,
+        ) {
+            Ok(backend) => {
+                log::info!(
+                    "[ENGINE] DAP native PCM via ALSA direct at {} Hz — AudioFlinger bypassed",
+                    requested_sample_rate
+                );
+                final_sample_rate = requested_sample_rate;
+                callback_data.reconfigure_sample_rate(final_sample_rate);
+                callback_data.set_pipeline_mode(PipelineMode::Passthrough);
+                output_runtime = build_output_runtime_state(
+                    OutputStrategy::DapNative,
+                    OutputVerification::verify(
+                        requested_sample_rate,
+                        requested_sample_rate,
+                        true,
+                        true,
+                    ),
+                    false,
+                    false,
+                );
+                output_signature = format!("android-alsa:dap-native:{}", requested_sample_rate);
+                pcm_alsa_backend = Some(backend);
+            }
+            Err(error) => {
+                log::info!(
+                    "[ENGINE] DAP native ALSA direct unavailable ({}). Using Android-managed output.",
+                    error
+                );
+                dap_alsa_error = Some(error);
+            }
+        }
+    }
+
     let mut managed_stream = None;
     // Hoisted so the audio thread can reopen the managed Oboe stream with the
     // same parameters after an interruption (preserving the playback position).
     let mut managed_prefer_exclusive = false;
     let mut managed_use_integer = false;
     #[cfg(feature = "uac2")]
+    #[cfg(target_os = "android")]
+    let use_managed_fallback = direct_usb_backend.is_none()
+        && dsd_native_backend.is_none()
+        && pcm_alsa_backend.is_none()
+        && audiotrack_backend.is_none();
+    #[cfg(feature = "uac2")]
+    #[cfg(not(target_os = "android"))]
     let use_managed_fallback = direct_usb_backend.is_none() && dsd_native_backend.is_none();
     #[cfg(not(feature = "uac2"))]
+    #[cfg(target_os = "android")]
+    let use_managed_fallback = dsd_native_backend.is_none()
+        && pcm_alsa_backend.is_none()
+        && audiotrack_backend.is_none();
+    #[cfg(not(feature = "uac2"))]
+    #[cfg(not(target_os = "android"))]
     let use_managed_fallback = dsd_native_backend.is_none();
 
     if use_managed_fallback {
@@ -1738,11 +1856,19 @@ pub fn create_audio_engine(
             managed_use_integer,
             audio_api_pref,
         )?;
+        // Bit-perfect requires Exclusive: Shared goes through the mixer,
+        // which silently resamples to the primary rate on many DAPs.
+        let route_verified = match desired_shared_strategy {
+            OutputStrategy::DapNative | OutputStrategy::DsdDoP => {
+                managed.active_sharing != "shared"
+            }
+            _ => true,
+        };
         let verification = OutputVerification::verify(
             requested_sample_rate,
             managed.actual_sample_rate,
             desired_shared_strategy.requests_passthrough(),
-            true,
+            route_verified,
         );
         let resolved_shared_strategy = verification.resolved_strategy(desired_shared_strategy);
         final_sample_rate = managed.actual_sample_rate;
@@ -1758,6 +1884,30 @@ pub fn create_audio_engine(
         output_runtime =
             build_output_runtime_state(desired_shared_strategy, verification, false, false);
         output_runtime.active_audio_api = Some(managed.active_audio_api.to_string());
+        if desired_shared_strategy == OutputStrategy::DapNative {
+            let alsa_note = dap_alsa_error
+                .as_deref()
+                .map(|e| format!("; ALSA direct: {}", e))
+                .unwrap_or_default();
+            let audiotrack_note = dap_audiotrack_error
+                .as_deref()
+                .map(|e| format!("; AudioTrack direct: {}", e))
+                .unwrap_or_default();
+            let exclusive_note = managed
+                .exclusive_error
+                .as_deref()
+                .map(|e| format!("; exclusive attempts: {}", e))
+                .unwrap_or_default();
+            output_runtime.verification_reason = Some(format!(
+                "managed stream sharing={} pcm={} at {} Hz{}{}{}",
+                managed.active_sharing,
+                managed.sample_format,
+                managed.actual_sample_rate,
+                audiotrack_note,
+                alsa_note,
+                exclusive_note
+            ));
+        }
         if dsd_rate.is_some()
             && effective_dsd_mode == crate::audio::dsd_engine::dsd::DsdOutputMode::Dop
             && dsd_native_backend.is_none()
@@ -1767,13 +1917,22 @@ pub fn create_audio_engine(
                     .to_string(),
             );
         }
-        output_signature =
-            android_output_signature_for_strategy(resolved_shared_strategy, requested_sample_rate);
+        // Verified-exclusive DapNative rides the HAL direct_pcm profile
+        // (mixer bypass); give it its own signature so reuse + diagnostics
+        // can tell it apart from the shared/mixer path.
+        output_signature = if desired_shared_strategy == OutputStrategy::DapNative
+            && resolved_shared_strategy == OutputStrategy::DapNative
+            && managed.active_sharing == "exclusive"
+        {
+            format!("android-direct:dap-native:{}", requested_sample_rate)
+        } else {
+            android_output_signature_for_strategy(resolved_shared_strategy, requested_sample_rate)
+        };
         managed_stream = Some(managed);
     }
 
     log::info!(
-        "[ENGINE] requested_rate_hz={} actual_rate_hz={} strategy={} resampler_active={} passthrough_allowed={} channels={} dap_profile={:?} audio_api_pref={} active_audio_api={:?}",
+        "[ENGINE] requested_rate_hz={} actual_rate_hz={} strategy={} resampler_active={} passthrough_allowed={} channels={} dap_profile={:?} audio_api_pref={} active_audio_api={:?} sharing={}",
         requested_sample_rate,
         final_sample_rate,
         output_runtime.strategy,
@@ -1783,6 +1942,7 @@ pub fn create_audio_engine(
         device_profile.as_ref().map(|profile| &profile.kind),
         audio_api_pref.as_str(),
         output_runtime.active_audio_api,
+        managed_stream.as_ref().map(|s| s.active_sharing).unwrap_or("n/a"),
     );
 
     // Spawn the audio thread (which owns the Oboe stream)
@@ -1792,6 +1952,9 @@ pub fn create_audio_engine(
             #[cfg(feature = "uac2")]
             let mut direct_usb_backend = direct_usb_backend;
             let mut dsd_native_backend = dsd_native_backend;
+            let mut pcm_alsa_backend = pcm_alsa_backend;
+            #[cfg(target_os = "android")]
+            let mut audiotrack_backend = audiotrack_backend;
             let mut managed_stream = managed_stream;
 
             #[cfg(feature = "uac2")]
@@ -1835,6 +1998,48 @@ pub fn create_audio_engine(
             }
             #[cfg(not(target_os = "android"))]
             let _ = dsd_native_backend;
+
+            #[cfg(target_os = "android")]
+            if audiotrack_backend.is_some() {
+                command_processing_loop(
+                    command_rx,
+                    finished_rx,
+                    event_tx,
+                    callback_data_for_thread,
+                    state_clone,
+                    decoders_clone,
+                    final_sample_rate,
+                    shutdown_clone,
+                    None,
+                );
+
+                if let Some(mut backend) = audiotrack_backend.take() {
+                    backend.stop();
+                }
+                return;
+            }
+
+            #[cfg(target_os = "android")]
+            if pcm_alsa_backend.is_some() {
+                command_processing_loop(
+                    command_rx,
+                    finished_rx,
+                    event_tx,
+                    callback_data_for_thread,
+                    state_clone,
+                    decoders_clone,
+                    final_sample_rate,
+                    shutdown_clone,
+                    None,
+                );
+
+                if let Some(mut backend) = pcm_alsa_backend.take() {
+                    backend.stop();
+                }
+                return;
+            }
+            #[cfg(not(target_os = "android"))]
+            let _ = pcm_alsa_backend;
 
             let mut supervisor = match managed_stream.take() {
                 Some(stream) => ManagedStreamSupervisor::new(
@@ -2066,6 +2271,212 @@ impl AudioOutputCallback for AndroidOutputCallbackI32 {
     }
 }
 
+/// Linear PCM i32 callback for direct-PCM output (UAPP-proven on HiBy R4).
+#[cfg(target_os = "android")]
+struct AndroidOutputCallbackI32Pcm {
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    scratch: Vec<f32>,
+}
+
+#[cfg(target_os = "android")]
+impl AndroidOutputCallbackI32Pcm {
+    fn new(callback_data: Arc<AudioCallbackData>, event_tx: Sender<AudioEvent>) -> Self {
+        Self {
+            callback_data,
+            event_tx,
+            scratch: vec![0.0; ANDROID_DIRECT_SCRATCH_SAMPLES],
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn f32_to_i32(sample: f32) -> i32 {
+    // `as` saturates; the clamp only pins +2^31 (not representable) to i32::MAX.
+    let scaled = (sample * 2_147_483_648.0f32).round();
+    if scaled >= 2_147_483_648.0f32 {
+        i32::MAX
+    } else {
+        scaled as i32
+    }
+}
+
+#[cfg(target_os = "android")]
+impl AudioOutputCallback for AndroidOutputCallbackI32Pcm {
+    type FrameType = (i32, Stereo);
+
+    fn on_error_before_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        dev_eprintln!(
+            "Android managed pcm-i32 output error before close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        dev_eprintln!(
+            "Android managed pcm-i32 output error after close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+        self.callback_data.request_stream_restart();
+    }
+
+    fn on_audio_ready(
+        &mut self,
+        _audio_stream: &mut dyn AudioOutputStreamSafe,
+        audio_data: &mut [(i32, i32)],
+    ) -> DataCallbackResult {
+        let required_samples = audio_data.len() * ANDROID_DIRECT_CHANNELS;
+
+        if required_samples > self.scratch.len() {
+            dev_eprintln!(
+                "[oboe-pcm-i32] burst {} frames > scratch {} frames — growing scratch",
+                audio_data.len(),
+                self.scratch.len() / ANDROID_DIRECT_CHANNELS,
+            );
+            self.scratch.resize(required_samples, 0.0);
+        }
+
+        let scratch = &mut self.scratch[..required_samples];
+        audio_callback(scratch, &self.callback_data, &self.event_tx);
+
+        for (frame_index, frame) in audio_data.iter_mut().enumerate() {
+            let sample_index = frame_index * ANDROID_DIRECT_CHANNELS;
+            *frame = (
+                f32_to_i32(scratch[sample_index]),
+                f32_to_i32(scratch[sample_index + 1]),
+            );
+        }
+
+        DataCallbackResult::Continue
+    }
+}
+
+/// Integer i16 callback for exclusive direct-PCM (PCM_16-only direct profiles).
+#[cfg(target_os = "android")]
+struct AndroidOutputCallbackI16 {
+    callback_data: Arc<AudioCallbackData>,
+    event_tx: Sender<AudioEvent>,
+    scratch: Vec<f32>,
+}
+
+#[cfg(target_os = "android")]
+impl AndroidOutputCallbackI16 {
+    fn new(callback_data: Arc<AudioCallbackData>, event_tx: Sender<AudioEvent>) -> Self {
+        Self {
+            callback_data,
+            event_tx,
+            scratch: vec![0.0; ANDROID_DIRECT_SCRATCH_SAMPLES],
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+fn f32_to_i16(sample: f32) -> i16 {
+    (sample * 32768.0).round().clamp(-32768.0, 32767.0) as i16
+}
+
+#[cfg(target_os = "android")]
+impl AudioOutputCallback for AndroidOutputCallbackI16 {
+    type FrameType = (i16, Stereo);
+
+    fn on_error_before_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        dev_eprintln!(
+            "Android managed i16 output error before close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        audio_stream: &mut dyn AudioOutputStreamSafe,
+        error: oboe::Error,
+    ) {
+        dev_eprintln!(
+            "Android managed i16 output error after close: {:?} (device_id={}, sample_rate={} Hz, sharing={:?}, api={:?})",
+            error,
+            audio_stream.get_device_id(),
+            audio_stream.get_sample_rate(),
+            audio_stream.get_sharing_mode(),
+            audio_stream.get_audio_api(),
+        );
+        self.callback_data.request_stream_restart();
+    }
+
+    fn on_audio_ready(
+        &mut self,
+        _audio_stream: &mut dyn AudioOutputStreamSafe,
+        audio_data: &mut [(i16, i16)],
+    ) -> DataCallbackResult {
+        let required_samples = audio_data.len() * ANDROID_DIRECT_CHANNELS;
+
+        if required_samples > self.scratch.len() {
+            dev_eprintln!(
+                "[oboe-i16] burst {} frames > scratch {} frames — growing scratch",
+                audio_data.len(),
+                self.scratch.len() / ANDROID_DIRECT_CHANNELS,
+            );
+            self.scratch.resize(required_samples, 0.0);
+        }
+
+        let scratch = &mut self.scratch[..required_samples];
+        audio_callback(scratch, &self.callback_data, &self.event_tx);
+
+        for (frame_index, frame) in audio_data.iter_mut().enumerate() {
+            let sample_index = frame_index * ANDROID_DIRECT_CHANNELS;
+            *frame = (
+                f32_to_i16(scratch[sample_index]),
+                f32_to_i16(scratch[sample_index + 1]),
+            );
+        }
+
+        DataCallbackResult::Continue
+    }
+}
+
+/// PCM payload variants tried by the managed open loop hunting a direct output.
+#[cfg(target_os = "android")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ManagedPcmFormat {
+    S32,
+    S16,
+    F32,
+}
+
+#[cfg(target_os = "android")]
+impl ManagedPcmFormat {
+    fn label(self) -> &'static str {
+        match self {
+            ManagedPcmFormat::S32 => "pcm-i32",
+            ManagedPcmFormat::S16 => "i16",
+            ManagedPcmFormat::F32 => "f32",
+        }
+    }
+}
+
 #[cfg(target_os = "android")]
 fn open_android_output_stream(
     callback_data: Arc<AudioCallbackData>,
@@ -2107,112 +2518,219 @@ fn open_android_output_stream(
     let mut fallback_kind = None;
     let mut fallback_rate = 0u32;
     let mut fallback_api: Option<&'static str> = None;
+    let mut fallback_sharing: Option<&'static str> = None;
+    let mut fallback_format: Option<&'static str> = None;
+    let mut exclusive_notes: Vec<String> = Vec::new();
 
     for &sharing_mode in sharing_modes {
         for &audio_api in &attempts {
-            let result: Result<AndroidManagedStreamKind, String> = if use_integer_format {
-                let builder = oboe::AudioStreamBuilder::default()
-                    .set_stereo()
-                    .set_format::<i32>()
-                    .set_sample_rate(target_sample_rate as i32)
-                    .set_frames_per_callback(frames_per_callback)
-                    .set_sharing_mode(sharing_mode)
-                    .set_performance_mode(performance_mode)
-                    .set_usage(Usage::Media)
-                    .set_content_type(ContentType::Music)
-                    .set_channel_conversion_allowed(false)
-                    .set_format_conversion_allowed(false)
-                    .set_sample_rate_conversion_quality(SampleRateConversionQuality::None)
-                    .set_audio_api(audio_api);
+            // On a bit-perfect route we try integer formats before f32 when
+            // requesting Exclusive: the HiBy R4 only grants a direct
+            // (mixer-bypassing) output to a PCM_32 request at the native
+            // rate — exactly how UAPP does it — with i16 as a second chance
+            // for PCM_16-only HALs.
+            let try_formats: &[ManagedPcmFormat] = if bit_perfect_route
+                && !use_integer_format
+                && sharing_mode == SharingMode::Exclusive
+            {
+                &[
+                    ManagedPcmFormat::S32,
+                    ManagedPcmFormat::S16,
+                    ManagedPcmFormat::F32,
+                ]
+            } else {
+                &[ManagedPcmFormat::F32]
+            };
+            for &attempt_fmt in try_formats {
+                let result: Result<AndroidManagedStreamKind, String> = if use_integer_format {
+                    let builder = oboe::AudioStreamBuilder::default()
+                        .set_stereo()
+                        .set_format::<i32>()
+                        .set_sample_rate(target_sample_rate as i32)
+                        .set_frames_per_callback(frames_per_callback)
+                        .set_sharing_mode(sharing_mode)
+                        .set_performance_mode(performance_mode)
+                        .set_usage(Usage::Media)
+                        .set_content_type(ContentType::Music)
+                        .set_channel_conversion_allowed(false)
+                        .set_format_conversion_allowed(false)
+                        .set_sample_rate_conversion_quality(SampleRateConversionQuality::None)
+                        .set_audio_api(audio_api);
 
-                let builder = if bit_perfect_route {
-                    builder.set_device_id(selected_device.id)
+                    let builder = if bit_perfect_route {
+                        builder.set_device_id(selected_device.id)
+                    } else {
+                        builder
+                    };
+
+                    match builder
+                        .set_callback(AndroidOutputCallbackI32::new(
+                            Arc::clone(&callback_data),
+                            event_tx.clone(),
+                        ))
+                        .open_stream()
+                    {
+                        Ok(stream) => Ok(AndroidManagedStreamKind::I32(stream)),
+                        Err(error) => Err(format!(
+                            "{} {} open failed on '{}' (id {}, type {:?}): {}",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            selected_device.id,
+                            selected_device.device_type,
+                            error
+                        )),
+                    }
+                } else if attempt_fmt == ManagedPcmFormat::S32 {
+                    // UAPP-style direct request: PCM_32 + DIRECT flag only.
+                    // LowLatency tacks FAST onto the flags and breaks the
+                    // direct_pcm profile match, so this attempt must keep
+                    // PerformanceMode::None.
+                    let builder = oboe::AudioStreamBuilder::default()
+                        .set_stereo()
+                        .set_format::<i32>()
+                        .set_sample_rate(target_sample_rate as i32)
+                        .set_frames_per_callback(frames_per_callback)
+                        .set_sharing_mode(sharing_mode)
+                        .set_performance_mode(PerformanceMode::None)
+                        .set_usage(Usage::Media)
+                        .set_content_type(ContentType::Music)
+                        .set_channel_conversion_allowed(false)
+                        .set_format_conversion_allowed(false)
+                        .set_sample_rate_conversion_quality(SampleRateConversionQuality::None)
+                        .set_audio_api(audio_api)
+                        .set_device_id(selected_device.id);
+
+                    match builder
+                        .set_callback(AndroidOutputCallbackI32Pcm::new(
+                            Arc::clone(&callback_data),
+                            event_tx.clone(),
+                        ))
+                        .open_stream()
+                    {
+                        Ok(stream) => Ok(AndroidManagedStreamKind::I32Pcm(stream)),
+                        Err(error) => Err(format!(
+                            "{} {} pcm-i32 open failed on '{}' (id {}, type {:?}): {}",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            selected_device.id,
+                            selected_device.device_type,
+                            error
+                        )),
+                    }
+                } else if attempt_fmt == ManagedPcmFormat::S16 {
+                    let builder = oboe::AudioStreamBuilder::default()
+                        .set_stereo()
+                        .set_format::<i16>()
+                        .set_sample_rate(target_sample_rate as i32)
+                        .set_frames_per_callback(frames_per_callback)
+                        .set_sharing_mode(sharing_mode)
+                        .set_performance_mode(performance_mode)
+                        .set_usage(Usage::Media)
+                        .set_content_type(ContentType::Music)
+                        .set_channel_conversion_allowed(false)
+                        .set_format_conversion_allowed(false)
+                        .set_sample_rate_conversion_quality(SampleRateConversionQuality::None)
+                        .set_audio_api(audio_api)
+                        .set_device_id(selected_device.id);
+
+                    match builder
+                        .set_callback(AndroidOutputCallbackI16::new(
+                            Arc::clone(&callback_data),
+                            event_tx.clone(),
+                        ))
+                        .open_stream()
+                    {
+                        Ok(stream) => Ok(AndroidManagedStreamKind::I16(stream)),
+                        Err(error) => Err(format!(
+                            "{} {} i16 open failed on '{}' (id {}, type {:?}): {}",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            selected_device.id,
+                            selected_device.device_type,
+                            error
+                        )),
+                    }
                 } else {
-                    builder
+                    let mut builder = oboe::AudioStreamBuilder::default()
+                        .set_stereo()
+                        .set_f32()
+                        .set_sample_rate(target_sample_rate as i32)
+                        .set_frames_per_callback(frames_per_callback)
+                        .set_sharing_mode(sharing_mode)
+                        .set_performance_mode(performance_mode)
+                        .set_usage(Usage::Media)
+                        .set_content_type(ContentType::Music)
+                        .set_channel_conversion_allowed(false)
+                        .set_format_conversion_allowed(true)
+                        .set_sample_rate_conversion_quality(if bit_perfect_route {
+                            SampleRateConversionQuality::None
+                        } else {
+                            SampleRateConversionQuality::Medium
+                        })
+                        .set_audio_api(audio_api);
+
+                    if bit_perfect_route {
+                        builder = builder.set_device_id(selected_device.id);
+                    }
+
+                    match builder
+                        .set_callback(AndroidOutputCallbackF32::new(
+                            Arc::clone(&callback_data),
+                            event_tx.clone(),
+                        ))
+                        .open_stream()
+                    {
+                        Ok(stream) => Ok(AndroidManagedStreamKind::F32(stream)),
+                        Err(error) => Err(format!(
+                            "{} {} open failed on '{}' (id {}, type {:?}): {}",
+                            audio_api_label(audio_api),
+                            sharing_label(sharing_mode),
+                            selected_device.product_name,
+                            selected_device.id,
+                            selected_device.device_type,
+                            error
+                        )),
+                    }
                 };
 
-                match builder
-                    .set_callback(AndroidOutputCallbackI32::new(
-                        Arc::clone(&callback_data),
-                        event_tx.clone(),
-                    ))
-                    .open_stream()
-                {
-                    Ok(stream) => Ok(AndroidManagedStreamKind::I32(stream)),
-                    Err(error) => Err(format!(
-                        "{} {} open failed on '{}' (id {}, type {:?}): {}",
-                        audio_api_label(audio_api),
-                        sharing_label(sharing_mode),
-                        selected_device.product_name,
-                        selected_device.id,
-                        selected_device.device_type,
-                        error
-                    )),
-                }
-            } else {
-                let mut builder = oboe::AudioStreamBuilder::default()
-                    .set_stereo()
-                    .set_f32()
-                    .set_sample_rate(target_sample_rate as i32)
-                    .set_frames_per_callback(frames_per_callback)
-                    .set_sharing_mode(sharing_mode)
-                    .set_performance_mode(performance_mode)
-                    .set_usage(Usage::Media)
-                    .set_content_type(ContentType::Music)
-                    .set_channel_conversion_allowed(false)
-                    .set_format_conversion_allowed(true)
-                    .set_sample_rate_conversion_quality(if bit_perfect_route {
-                        SampleRateConversionQuality::None
-                    } else {
-                        SampleRateConversionQuality::Medium
-                    })
-                    .set_audio_api(audio_api);
+                match result {
+                    Ok(kind) => {
+                        let (actual_rate, actual_api, actual_sharing, actual_format, actual_channels) =
+                            match &kind {
+                                AndroidManagedStreamKind::F32(s) => (
+                                    s.get_sample_rate(),
+                                    s.get_audio_api(),
+                                    s.get_sharing_mode(),
+                                    s.get_format(),
+                                    s.get_channel_count(),
+                                ),
+                                AndroidManagedStreamKind::I32(s) => (
+                                    s.get_sample_rate(),
+                                    s.get_audio_api(),
+                                    s.get_sharing_mode(),
+                                    s.get_format(),
+                                    s.get_channel_count(),
+                                ),
+                                AndroidManagedStreamKind::I32Pcm(s) => (
+                                    s.get_sample_rate(),
+                                    s.get_audio_api(),
+                                    s.get_sharing_mode(),
+                                    s.get_format(),
+                                    s.get_channel_count(),
+                                ),
+                                AndroidManagedStreamKind::I16(s) => (
+                                    s.get_sample_rate(),
+                                    s.get_audio_api(),
+                                    s.get_sharing_mode(),
+                                    s.get_format(),
+                                    s.get_channel_count(),
+                                ),
+                            };
 
-                if bit_perfect_route {
-                    builder = builder.set_device_id(selected_device.id);
-                }
-
-                match builder
-                    .set_callback(AndroidOutputCallbackF32::new(
-                        Arc::clone(&callback_data),
-                        event_tx.clone(),
-                    ))
-                    .open_stream()
-                {
-                    Ok(stream) => Ok(AndroidManagedStreamKind::F32(stream)),
-                    Err(error) => Err(format!(
-                        "{} {} open failed on '{}' (id {}, type {:?}): {}",
-                        audio_api_label(audio_api),
-                        sharing_label(sharing_mode),
-                        selected_device.product_name,
-                        selected_device.id,
-                        selected_device.device_type,
-                        error
-                    )),
-                }
-            };
-
-            match result {
-                Ok(kind) => {
-                    let (actual_rate, actual_api, actual_sharing, actual_format, actual_channels) =
-                        match &kind {
-                            AndroidManagedStreamKind::F32(s) => (
-                                s.get_sample_rate(),
-                                s.get_audio_api(),
-                                s.get_sharing_mode(),
-                                s.get_format(),
-                                s.get_channel_count(),
-                            ),
-                            AndroidManagedStreamKind::I32(s) => (
-                                s.get_sample_rate(),
-                                s.get_audio_api(),
-                                s.get_sharing_mode(),
-                                s.get_format(),
-                                s.get_channel_count(),
-                            ),
-                        };
-
-                    dev_eprintln!(
+                        dev_eprintln!(
                         "Android managed output opened '{}' (id {}, type {:?}) requested {} Hz -> actual {} Hz, api {:?}, sharing {:?}, format {:?}, channels {:?}",
                         selected_device.product_name,
                         selected_device.id,
@@ -2225,44 +2743,90 @@ fn open_android_output_stream(
                         actual_channels,
                     );
 
-                    if actual_channels != ChannelCount::Stereo {
-                        last_error = Some(format!(
-                            "{} {} opened '{}' with {:?} channels instead of {}",
-                            audio_api_label(audio_api),
-                            sharing_label(sharing_mode),
-                            selected_device.product_name,
-                            actual_channels,
-                            ANDROID_DIRECT_CHANNELS,
-                        ));
-                        continue;
-                    }
-
-                    if bit_perfect_route && actual_rate != target_sample_rate as i32 {
-                        last_error = Some(format!(
-                            "{} {} opened '{}' at {} Hz instead of requested {} Hz",
-                            audio_api_label(audio_api),
-                            sharing_label(sharing_mode),
-                            selected_device.product_name,
-                            actual_rate,
-                            target_sample_rate,
-                        ));
-                        if fallback_kind.is_none() {
-                            fallback_kind = Some(kind);
-                            fallback_rate = actual_rate.max(1) as u32;
-                            fallback_api = Some(audio_api_label(actual_api));
+                        // A shared integer stream means the direct-PCM route
+                        // was not granted; it would silently resample through
+                        // the mixer like a shared f32 stream. Close it and
+                        // keep looking (exclusive integer is the only prize).
+                        if attempt_fmt != ManagedPcmFormat::F32
+                            && sharing_label(actual_sharing) == "shared"
+                        {
+                            let note = format!(
+                                "{} exclusive {} downgraded to shared on '{}' — not a direct-PCM route",
+                                audio_api_label(audio_api),
+                                attempt_fmt.label(),
+                                selected_device.product_name,
+                            );
+                            last_error = Some(note.clone());
+                            if sharing_mode == SharingMode::Exclusive {
+                                exclusive_notes.push(note);
+                            }
+                            drop(kind);
+                            continue;
                         }
+
+                        if actual_channels != ChannelCount::Stereo {
+                            last_error = Some(format!(
+                                "{} {} opened '{}' with {:?} channels instead of {}",
+                                audio_api_label(audio_api),
+                                sharing_label(sharing_mode),
+                                selected_device.product_name,
+                                actual_channels,
+                                ANDROID_DIRECT_CHANNELS,
+                            ));
+                            continue;
+                        }
+
+                        if bit_perfect_route && actual_rate != target_sample_rate as i32 {
+                            last_error = Some(format!(
+                                "{} {} opened '{}' at {} Hz instead of requested {} Hz",
+                                audio_api_label(audio_api),
+                                sharing_label(sharing_mode),
+                                selected_device.product_name,
+                                actual_rate,
+                                target_sample_rate,
+                            ));
+                            if fallback_kind.is_none() {
+                                fallback_format = Some(match &kind {
+                                    AndroidManagedStreamKind::F32(_) => "f32",
+                                    AndroidManagedStreamKind::I32(_) => "i32",
+                                    AndroidManagedStreamKind::I32Pcm(_) => "s32",
+                                    AndroidManagedStreamKind::I16(_) => "s16",
+                                });
+                                fallback_kind = Some(kind);
+                                fallback_rate = actual_rate.max(1) as u32;
+                                fallback_api = Some(audio_api_label(actual_api));
+                                fallback_sharing = Some(sharing_label(actual_sharing));
+                            }
+                            continue;
+                        }
+
+                        let sample_format = match &kind {
+                            AndroidManagedStreamKind::F32(_) => "f32",
+                            AndroidManagedStreamKind::I32(_) => "i32",
+                            AndroidManagedStreamKind::I32Pcm(_) => "s32",
+                            AndroidManagedStreamKind::I16(_) => "s16",
+                        };
+                        let exclusive_error = if sharing_label(actual_sharing) == "exclusive" {
+                            None
+                        } else {
+                            (!exclusive_notes.is_empty()).then(|| exclusive_notes.join(" | "))
+                        };
+                        return Ok(AndroidManagedStream {
+                            kind,
+                            actual_sample_rate: actual_rate.max(1) as u32,
+                            active_audio_api: audio_api_label(actual_api),
+                            active_sharing: sharing_label(actual_sharing),
+                            sample_format,
+                            exclusive_error,
+                        });
+                    }
+                    Err(error) => {
+                        if sharing_mode == SharingMode::Exclusive {
+                            exclusive_notes.push(error.clone());
+                        }
+                        last_error = Some(error);
                         continue;
                     }
-
-                    return Ok(AndroidManagedStream {
-                        kind,
-                        actual_sample_rate: actual_rate.max(1) as u32,
-                        active_audio_api: audio_api_label(actual_api),
-                    });
-                }
-                Err(error) => {
-                    last_error = Some(error);
-                    continue;
                 }
             }
         }
@@ -2273,6 +2837,9 @@ fn open_android_output_stream(
             kind,
             actual_sample_rate: fallback_rate.max(1),
             active_audio_api: fallback_api.unwrap_or("Unspecified"),
+            active_sharing: fallback_sharing.unwrap_or("Unspecified"),
+            sample_format: fallback_format.unwrap_or("f32"),
+            exclusive_error: (!exclusive_notes.is_empty()).then(|| exclusive_notes.join(" | ")),
         });
     }
 
@@ -2385,14 +2952,9 @@ fn audio_api_label(audio_api: AudioApi) -> &'static str {
     }
 }
 
-/// Resolve a user audio-API preference into the ordered list of Oboe `AudioApi`
-/// candidates to try when opening the managed output stream.
-///
-/// Bluetooth always defers to Oboe's default (`Unspecified`): exclusive mode is
-/// wrong for the AudioFlinger mixer path, and AAudio/OpenSL selection there has
-/// no benefit. For wired/USB/Internal outputs the explicit preference is tried
-/// first, with `Unspecified` appended as a safety net so audio still plays when
-/// the chosen API is unavailable (e.g. AAudio on API 26, the project minSdk).
+/// Resolve user audio-API preference to ordered Oboe candidates.
+/// Bluetooth always uses Oboe's default — exclusive mode is wrong for the
+/// mixer path. Explicit pref tried first, Unspecified as safety net.
 #[cfg(target_os = "android")]
 fn audio_api_attempts(pref: AudioApiPreference, is_bluetooth: bool) -> Vec<AudioApi> {
     if is_bluetooth {

--- a/rust/src/audio/manager.rs
+++ b/rust/src/audio/manager.rs
@@ -301,9 +301,8 @@ impl EngineManager {
 
                 #[cfg(target_os = "android")]
                 {
-                    // Don't reuse across DSD mode changes: DoP needs PipelineMode::Dop,
-                    // native needs a different backend. A dap-native engine serving a
-                    // DoP track (or vice versa) corrupts the bitstream.
+                    // Don't reuse across DSD mode changes (Dop vs native
+                    // backends corrupt the bitstream).
                     let strategy = handle.output_runtime().strategy.as_str();
                     let desired_dsd_dop = desired_signature.contains(":dsd-dop:");
                     let desired_dsd_native = desired_signature.contains(":dsd-native:");
@@ -314,7 +313,11 @@ impl EngineManager {
                     }
 
                     let requested_rate = preferred_sample_rate.unwrap_or(48_000);
-                    return handle.output_signature().starts_with("android-shared:")
+                    // android-direct: never reuse — the DIRECT AudioTrack
+                    // doesn't survive track transitions (restoreTrack_l churn
+                    // on the sole direct slot); recreate instead.
+                    return (handle.output_signature().starts_with("android-shared:")
+                        || handle.output_signature().starts_with("android-alsa:"))
                         && handle.sample_rate() == requested_rate
                         && (allow_dap_native || strategy != "dap_native")
                         && dap_bit_perfect_enabled == (strategy == "dap_native")

--- a/rust/src/audio/mod.rs
+++ b/rust/src/audio/mod.rs
@@ -33,6 +33,7 @@ pub mod http_source;
 pub mod ir_loader;
 pub mod manager;
 pub mod opus_decoder;
+pub mod audiotrack_direct;
 pub mod pitch_shifter;
 pub mod resampler;
 pub mod source;

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -59,6 +59,7 @@ const USB_DIR_IN: u8 = 0x80;
 const USB_DIR_OUT: u8 = 0x00;
 const USB_TYPE_CLASS: u8 = 0x20;
 const USB_RECIP_INTERFACE: u8 = 0x01;
+const USB_RECIP_ENDPOINT: u8 = 0x02;
 const UAC2_CLOCK_SOURCE: u8 = 0x0a;
 const UAC2_AS_GENERAL: u8 = 0x01;
 const UAC2_FORMAT_TYPE: u8 = 0x02;
@@ -2014,6 +2015,7 @@ fn negotiate_android_direct_playback_format(
         } else if candidate.is_uac1 {
             match set_uac1_sampling_frequency(
                 &claimed_handle.handle,
+                candidate.interface_number,
                 candidate.endpoint_address,
                 requested_format.sample_rate,
             ) {
@@ -3933,6 +3935,7 @@ fn create_android_usb_backend_inner(
         // spec defines as the rate-setting mechanism.
         match set_uac1_sampling_frequency(
             &claimed_handle.handle,
+            candidate.interface_number,
             candidate.endpoint_address,
             playback_format.sample_rate,
         ) {
@@ -4024,6 +4027,41 @@ fn create_android_usb_backend_inner(
         return Err(msg);
     }
     thread::sleep(Duration::from_millis(50));
+
+    // UAC1: endpoint SET_CUR is only reliable once the streaming alt setting
+    // is active. Re-issue it; success here upgrades the clock verdict even if
+    // the pre-alt attempt was rejected.
+    if candidate.is_uac1 {
+        match set_uac1_sampling_frequency(
+            &claimed_handle.handle,
+            candidate.interface_number,
+            candidate.endpoint_address,
+            playback_format.sample_rate,
+        ) {
+            Ok(()) => {
+                clock_control_attempted = true;
+                clock_control_succeeded = true;
+                clock_verification_passed = true;
+                reported_sample_rate = Some(playback_format.sample_rate);
+                set_dac_mode(DacMode::FixedClock);
+                set_clock_verification(true, true, true, reported_sample_rate);
+                let message = format!(
+                    "[clock-diag] UAC1: post-alt SET_CUR {}Hz on endpoint 0x{:02x} succeeded — DAC locked to requested rate",
+                    playback_format.sample_rate, candidate.endpoint_address
+                );
+                dev_eprintln!("{}", message);
+                set_last_error(Some(message));
+            }
+            Err(e) => {
+                let message = format!(
+                    "[clock-diag] UAC1: post-alt SET_CUR {}Hz on endpoint 0x{:02x} failed: {} — keeping prior verdict",
+                    playback_format.sample_rate, candidate.endpoint_address, e,
+                );
+                dev_eprintln!("{}", message);
+                set_last_error(Some(message));
+            }
+        }
+    }
 
     if !claimed_handle
         .claimed_interfaces
@@ -6012,12 +6050,17 @@ fn set_sampling_frequency(
 
 fn set_uac1_sampling_frequency(
     handle: &DeviceHandle<Context>,
+    interface_number: u8,
     endpoint_address: u8,
     sample_rate: u32,
 ) -> Result<(), String> {
-    let request_type = USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+    // UAC1 spec 5.2.3.2.3.2: SAM_FREQ_CONTROL SET_CUR is an endpoint request —
+    // bmRequestType 0x22, wIndex = (interface << 8) | endpoint address.
+    // The old INTERFACE-recipient form (0x21, wIndex = endpoint) gets STALLed
+    // by real hardware (FiiO BR13) and the DAC free-runs at its default rate.
+    let request_type = USB_DIR_OUT | USB_TYPE_CLASS | USB_RECIP_ENDPOINT;
     let value = UAC1_SAM_FREQ_CONTROL;
-    let index = endpoint_address as u16;
+    let index = ((interface_number as u16) << 8) | endpoint_address as u16;
     let data = [
         (sample_rate & 0xFF) as u8,
         ((sample_rate >> 8) & 0xFF) as u8,

--- a/test/services/casting/cast_content_server_test.dart
+++ b/test/services/casting/cast_content_server_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/services/casting/cast_content_server.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('serves full, partial, and rejected ranges', () async {
+    await binding.runAsync(() async {
+      final dir = await Directory.systemTemp.createTemp('cast_server');
+      final file = File('${dir.path}/track.m4a');
+      final bytes = List<int>.generate(100, (i) => i);
+      await file.writeAsBytes(bytes);
+
+      final server = CastContentServer.instance;
+      final url = await server.serve(file.path, filename: 'track.m4a');
+      final uri = Uri.parse(url).replace(host: '127.0.0.1');
+      final client = HttpClient();
+
+      Future<HttpClientResponse> get(Map<String, String> headers) async {
+        final req = await client.getUrl(uri);
+        headers.forEach(req.headers.set);
+        return await req.close();
+      }
+
+      Future<List<int>> body(HttpClientResponse r) =>
+          r.fold<List<int>>([], (p, c) => p..addAll(c));
+
+      final full = await get({});
+      expect(full.statusCode, 200);
+      expect(full.headers.value(HttpHeaders.contentLengthHeader), '100');
+      expect(await body(full), bytes);
+
+      final part = await get({HttpHeaders.rangeHeader: 'bytes=10-19'});
+      expect(part.statusCode, 206);
+      expect(await body(part), bytes.sublist(10, 20));
+      expect(
+        part.headers.value(HttpHeaders.contentRangeHeader),
+        'bytes 10-19/100',
+      );
+
+      final openEnded = await get({HttpHeaders.rangeHeader: 'bytes=90-'});
+      expect(openEnded.statusCode, 206);
+      expect(await body(openEnded), bytes.sublist(90));
+
+      final invalid = await get({HttpHeaders.rangeHeader: 'bytes=500-'});
+      expect(invalid.statusCode, 416);
+
+      final req = await client.getUrl(uri.replace(path: '/deadbeef/x.m4a'));
+      final notFound = await req.close();
+      expect(notFound.statusCode, 404);
+
+      client.close(force: true);
+      await server.stop();
+      await dir.delete(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Add `CastContentServer` for LAN media streaming with range request support and local file serving via embedded HTTP server
- Refactor DLNA backend (137 insertions) and casting service (49 insertions) for robustness
- Add audio track direct backend (307 lines) with I32Pcm/I16 Android streams and DapNative paths
- Add `PcmAlsaBackend` for direct PCM output (99 lines) with S32_LE format support and ALSA open refactor
- Major `engine.rs` refactor (710 insertions) with probe-once audio format backfill, `alsaDirectDap` and `managedDirectExclusive` audio paths
- Use endpoint recipient for UAC1 SET_CUR to prevent STALL
- Handle missing audio metrics for SMB/WebDAV songs

# Changes

## Cast Content Server

- Add `CastContentServer` (162 lines) for LAN media streaming
- Add local file serving via embedded HTTP server
- Add range request tests (58 lines)
- Refactor `dlna_backend` formatting and robustness (137 insertions)
- Refactor casting service delegation (49 insertions)

## Direct Audio Backends

- Add `audiotrack_direct.rs` (307 lines) audio track direct backend
- Add I32Pcm/I16 Android streams and DapNative paths
- Add `PcmAlsaBackend` for direct PCM output (99 lines)
- Add S32_LE format support and refactor ALSA open
- Update Android audio reuse in manager

## Audio Engine

- Major `engine.rs` refactor (858 lines changed, 710 insertions) for direct backends
- Add probe-once audio format backfill
- Exclude `dapInternalHighRes` update from Android paths
- Add `alsaDirectDap` and `managedDirectExclusive` audio path options
- Add audio path management descriptions to diagnostics and UAC2 preferences

## UAC1 Fix

- Use endpoint recipient for UAC1 SET_CUR to prevent STALL

## Network Sources

- Increase Jellyfin service timeout to 60s
- Handle missing audio metrics for SMB/WebDAV songs

## Files Changed

- `lib/services/casting/cast_content_server.dart`
- `lib/services/casting/cast_content_server_test.dart`
- `lib/services/casting/dlna_backend.dart`
- `lib/services/casting/casting_service.dart`
- `lib/services/remote_source_service.dart`
- `lib/services/player_service.dart`
- `lib/services/sources/jellyfin_service.dart`
- `lib/models/audio_output_diagnostics.dart`
- `lib/features/settings/screens/uac2_preferences_screen.dart`
- `lib/data/repositories/song_repository.dart`
- `rust/src/audio/audiotrack_direct.rs`
- `rust/src/audio/dsd_native_backend.rs`
- `rust/src/audio/dsd_alsa_direct.rs`
- `rust/src/audio/engine.rs`
- `rust/src/audio/manager.rs`
- `rust/src/audio/mod.rs`
- `rust/src/uac2/android_direct.rs`