### PR TITLE
Add USB DAC bit-perfect auto-prompt, refuse unsafe UAC1 direct USB, and extend lyrics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changes landing on top of the current pre-release are tracked here and folded in
 ### Folders
 - Hierarchy (tree) view now available inside folders via the grid/list toggle — matches the root Folders screen; view mode persists across screens.
 
+### Lyrics
+- Embedded lyrics now read from MP4/M4A `©lyr` atoms (UTF-8 and UTF-16) and OGG/Opus Vorbis comments, joining existing ID3 (USLT/SYLT) and FLAC support.
+
 ## 0.21.0-beta.1 (2026-07-10)
 
 Shipped while continuously keeping up with improvements and bug fixing across the app.

--- a/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mossapps/flick/MainActivity.kt
@@ -2417,17 +2417,34 @@ class MainActivity: FlutterActivity() {
                         "content" to id3Lyrics,
                         "source" to "embedded:id3",
                     )
-                } else {
-                    val flacVorbisLyrics = parseFlacVorbisLyrics(audioUriString)
-                    if (!flacVorbisLyrics.isNullOrBlank()) {
-                        mapOf(
-                            "content" to flacVorbisLyrics,
-                            "source" to "embedded:vorbis",
-                        )
                     } else {
-                        null
+                        val flacVorbisLyrics = parseFlacVorbisLyrics(audioUriString)
+                        if (!flacVorbisLyrics.isNullOrBlank()) {
+                            mapOf(
+                                "content" to flacVorbisLyrics,
+                                "source" to "embedded:vorbis",
+                            )
+                        } else {
+                            val mp4Lyrics = parseMp4Lyrics(audioUriString)
+                            if (!mp4Lyrics.isNullOrBlank()) {
+                                mapOf(
+                                    "content" to mp4Lyrics,
+                                    "source" to "embedded:mp4",
+                                )
+                            } else {
+                                // ponytail: covers ID3/FLAC/MP4/Ogg; WMA and APE tags not parsed
+                                val oggLyrics = parseOggLyrics(audioUriString)
+                                if (!oggLyrics.isNullOrBlank()) {
+                                    mapOf(
+                                        "content" to oggLyrics,
+                                        "source" to "embedded:ogg",
+                                    )
+                                } else {
+                                    null
+                                }
+                            }
+                        }
                     }
-                }
             } else {
                 mapOf(
                     "content" to lyricText,
@@ -2640,11 +2657,162 @@ class MainActivity: FlutterActivity() {
                     if (!readExact(input, commentData)) break
                     return@use parseVorbisCommentLyrics(commentData)
                 } else {
-                    if (!skipFully(input, blockLength)) break
+                    if (!skipFully(input, blockLength.toLong())) break
                 }
             }
             null
         }
+    }
+
+    private fun parseOggLyrics(audioUriString: String): String? {
+        return openAudioInputStream(audioUriString)?.use { input ->
+            val magic = ByteArray(4)
+            if (!readExact(input, magic) || String(magic, Charsets.ISO_8859_1) != "OggS") {
+                return@use null
+            }
+
+            var packetIndex = 0
+            val packet = ByteArrayOutputStream()
+            val pageHeader = ByteArray(23)
+            while (true) {
+                if (!readExact(input, pageHeader)) return@use null
+                val segmentCount = pageHeader[22].toInt() and 0xFF
+                if (segmentCount > 0) {
+                    val segmentTable = ByteArray(segmentCount)
+                    if (!readExact(input, segmentTable)) return@use null
+
+                    for (i in 0 until segmentCount) {
+                        val segmentLength = segmentTable[i].toInt() and 0xFF
+                        val chunk = ByteArray(segmentLength)
+                        if (!readExact(input, chunk)) return@use null
+                        packet.write(chunk)
+
+                        if (segmentLength < 255) {
+                            // Packet 1 is the Vorbis/Opus comment header
+                            if (packetIndex == 1) {
+                                return@use parseVorbisCommentLyrics(packet.toByteArray())
+                            }
+                            packetIndex++
+                            packet.reset()
+                        }
+                    }
+                }
+            }
+            null
+        }
+    }
+
+    private fun parseMp4Lyrics(audioUriString: String): String? {
+        return openAudioInputStream(audioUriString)?.use { input ->
+            val knownTopLevel = setOf("ftyp", "moov", "mdat", "free", "skip", "wide", "pnot")
+            while (true) {
+                val atom = readMp4AtomHeader(input) ?: return@use null
+                if (!knownTopLevel.contains(atom.type)) return@use null
+                if (atom.type == "moov") {
+                    return@use walkMp4Container(input, atom.contentSize, setOf("udta", "meta"))
+                }
+                if (!skipFully(input, atom.contentSize)) return@use null
+            }
+            null
+        }
+    }
+
+    private class Mp4Atom(val type: String, val contentSize: Long)
+
+    private fun readMp4AtomHeader(input: InputStream): Mp4Atom? {
+        val header = ByteArray(8)
+        if (!readExact(input, header)) return null
+        var size = readBigEndianInt(header, 0).toLong() and 0xFFFFFFFFL
+        val type = String(header, 4, 4, Charsets.ISO_8859_1)
+
+        if (size == 1L) {
+            val ext = ByteArray(8)
+            if (!readExact(input, ext)) return null
+            var bigSize = 0L
+            for (b in ext) bigSize = (bigSize shl 8) or (b.toLong() and 0xFF)
+            if (bigSize < 16) return null
+            size = bigSize - 16
+        } else if (size == 0L) {
+            // Atom extends to end of file; treat as huge
+            size = Long.MAX_VALUE / 4
+        } else {
+            size -= 8
+        }
+
+        if (size < 0) return null
+        return Mp4Atom(type, size)
+    }
+
+    // Walks an atom's children, consuming exactly containerSize bytes.
+    // Returns lyrics text from a ©lyr item, or null after consuming the container.
+    private fun walkMp4Container(input: InputStream, containerSize: Long, childTypes: Set<String>): String? {
+        var remaining = containerSize
+        while (remaining >= 8) {
+            val atom = readMp4AtomHeader(input) ?: return null
+            remaining -= 8
+            if (atom.contentSize > remaining) return null
+            remaining -= atom.contentSize
+
+            if (atom.type == "\u00A9lyr") {
+                return readMp4LyricsData(input, atom.contentSize)
+            }
+
+            if (childTypes.contains(atom.type)) {
+                var payload = atom.contentSize
+                if (atom.type == "meta") {
+                    // meta is a FullBox: 4 version/flags bytes precede children
+                    if (payload < 4) return null
+                    val versionFlags = ByteArray(4)
+                    if (!readExact(input, versionFlags)) return null
+                    payload -= 4
+                }
+                val next = when (atom.type) {
+                    "moov" -> setOf("udta", "meta")
+                    "udta" -> setOf("meta")
+                    "meta" -> setOf("ilst")
+                    else -> emptySet()
+                }
+                val found = walkMp4Container(input, payload, next)
+                if (found != null) return found
+            } else {
+                if (!skipFully(input, atom.contentSize)) return null
+            }
+        }
+        if (remaining > 0) skipFully(input, remaining)
+        return null
+    }
+
+    private fun readMp4LyricsData(input: InputStream, itemSize: Long): String? {
+        var remaining = itemSize
+        while (remaining >= 8) {
+            val atom = readMp4AtomHeader(input) ?: return null
+            remaining -= 8
+            if (atom.contentSize > remaining) return null
+            remaining -= atom.contentSize
+
+            if (atom.type == "data" && atom.contentSize >= 8) {
+                val header = ByteArray(8)
+                if (!readExact(input, header)) return null
+                val payloadLength = (atom.contentSize - 8).toInt()
+                if (payloadLength <= 0) return null
+                val payload = ByteArray(payloadLength)
+                if (!readExact(input, payload)) return null
+
+                val typeIndicator =
+                    ((header[1].toInt() and 0xFF) shl 16) or
+                        ((header[2].toInt() and 0xFF) shl 8) or
+                        (header[3].toInt() and 0xFF)
+                // ponytail: type 2 is UTF-16; UTF_16 charset honors a BOM when present
+                val text = when (typeIndicator) {
+                    2 -> payload.toString(Charsets.UTF_16)
+                    else -> payload.toString(Charsets.UTF_8)
+                }.replace("\u0000", "").trim()
+                return text.ifBlank { null }
+            }
+
+            if (!skipFully(input, atom.contentSize)) return null
+        }
+        return null
     }
 
     private fun parseVorbisCommentLyrics(data: ByteArray): String? {
@@ -2712,8 +2880,8 @@ class MainActivity: FlutterActivity() {
         return true
     }
 
-    private fun skipFully(input: InputStream, bytesToSkip: Int): Boolean {
-        var remaining = bytesToSkip.toLong()
+    private fun skipFully(input: InputStream, bytesToSkip: Long): Boolean {
+        var remaining = bytesToSkip
         while (remaining > 0) {
             val skipped = input.skip(remaining)
             if (skipped <= 0) {

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -32,6 +32,7 @@ import 'package:flick/features/onboarding/screens/onboarding_screen.dart';
 import 'package:flick/features/onboarding/tutorial_targets.dart';
 import 'package:flick/features/onboarding/widgets/tutorial_overlay.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/uac2/usb_bit_perfect_prompt.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/library_scanner_service.dart';
 import 'package:flick/services/player_service.dart';
@@ -810,6 +811,9 @@ class _MainShellState extends ConsumerState<MainShell>
 
                 // Interactive tutorial overlay
                 const Positioned.fill(child: TutorialOverlay()),
+
+                // USB DAC attach → bit-perfect switch prompt
+                const UsbBitPerfectPrompt(),
               ],
             ),
           ),

--- a/lib/widgets/uac2/usb_bit_perfect_prompt.dart
+++ b/lib/widgets/uac2/usb_bit_perfect_prompt.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/providers/player_provider.dart';
+import 'package:flick/providers/uac2_provider.dart';
+import 'package:flick/services/uac2_preferences_service.dart';
+import 'package:flick/services/uac2_service.dart';
+import 'package:flick/widgets/common/glass_dialog.dart';
+
+/// Pure gate: prompt only for an external USB route in a live state while
+/// bit-perfect is off.
+bool shouldPromptBitPerfect(
+  Uac2DeviceStatus status, {
+  required bool bitPerfectEnabled,
+}) {
+  if (bitPerfectEnabled) return false;
+  if (status.routeType != Uac2RouteType.externalUsb &&
+      !status.isExternalRoute) {
+    return false;
+  }
+  return switch (status.state) {
+    Uac2State.connected || Uac2State.prewarming || Uac2State.streaming => true,
+    _ => false,
+  };
+}
+
+/// Stable per-device identity so one DAC prompts at most once per session.
+String usbDevicePromptKey(Uac2DeviceInfo device) =>
+    '${device.vendorId}:${device.productId}:${device.serial ?? device.deviceName}';
+
+/// Auto-detects a connected USB DAC and offers a one-tap switch to
+/// Bit-perfect (USB DAC) mode. Renders nothing; mount once in the shell.
+class UsbBitPerfectPrompt extends ConsumerStatefulWidget {
+  const UsbBitPerfectPrompt({super.key});
+
+  @override
+  ConsumerState<UsbBitPerfectPrompt> createState() =>
+      _UsbBitPerfectPromptState();
+}
+
+class _UsbBitPerfectPromptState extends ConsumerState<UsbBitPerfectPrompt> {
+  // ponytail: session-only decline memory; persistent "don't ask again" pref
+  // if nagging complaints arrive
+  final Set<String> _promptedDevices = {};
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listenManual(
+      uac2DeviceStatusProvider,
+      (_, next) {
+        if (next != null) _maybePrompt(next);
+      },
+      fireImmediately: true,
+    );
+  }
+
+  Future<void> _maybePrompt(Uac2DeviceStatus status) async {
+    if (!mounted) return;
+    if (!shouldPromptBitPerfect(
+      status,
+      bitPerfectEnabled: ref.read(uac2ServiceProvider).isBitPerfectEnabledSync,
+    )) {
+      return;
+    }
+
+    if (!_promptedDevices.add(usbDevicePromptKey(status.device))) return;
+
+    final AudioEnginePreference engine;
+    try {
+      engine = await ref
+          .read(uac2PreferencesServiceProvider)
+          .getAudioEnginePreference();
+    } catch (_) {
+      return;
+    }
+    if (!mounted) return;
+    _showPrompt(status, switchEngine: engine != AudioEnginePreference.isochronousUsb);
+  }
+
+  Future<void> _showPrompt(
+    Uac2DeviceStatus status, {
+    required bool switchEngine,
+  }) async {
+    final accepted = await showDialog<bool>(
+      context: context,
+      builder: (context) => GlassDialog(
+        title: 'USB DAC detected',
+        content: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '${status.device.productName} is connected.',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(height: AppConstants.spacingSm),
+            Text(
+              switchEngine
+                  ? "Switch to the Bit-perfect (USB DAC) engine? Flick takes exclusive control of the USB path and bypasses Android's audio processing for unaltered sound."
+                  : 'Enable Bit-perfect (USB DAC) mode? Flick takes exclusive control of the USB path for unaltered sound.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.textSecondary,
+                height: 1.4,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Not now'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    );
+    if (accepted != true || !mounted) return;
+
+    if (switchEngine) {
+      await ref
+          .read(playerServiceProvider)
+          .setAudioEnginePreference(AudioEnginePreference.isochronousUsb);
+    }
+    final applied =
+        await ref.read(uac2ServiceProvider).setBitPerfectEnabled(true);
+    ref.invalidate(audioEnginePreferenceProvider);
+    ref.invalidate(uac2BitPerfectEnabledProvider);
+    ref.invalidate(uac2ExclusiveDacModeProvider);
+    ref.invalidate(killIsochronousUsbOnQuitProvider);
+    if (!mounted) return;
+
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            applied
+                ? 'Bit-perfect (USB DAC) enabled. Restart the app to apply playback changes.'
+                : 'Bit-perfect (USB DAC) could not be enabled. Check the USB diagnostics for the failure reason.',
+          ),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/rust/src/uac2/android_direct.rs
+++ b/rust/src/uac2/android_direct.rs
@@ -2036,12 +2036,22 @@ fn negotiate_android_direct_playback_format(
                         "[USB] UAC1 SET_CUR failed for endpoint=0x{:02x}: {}",
                         candidate.endpoint_address, e
                     );
-                    dac_mode = DacMode::AdaptiveStreaming;
-                    reported_rate = Some(requested_format.sample_rate);
-                    last_message = Some(format!(
-                        "UAC 1.0 device: failed to set rate on endpoint 0x{:02x}: {}; continuing with adaptive streaming",
-                        candidate.endpoint_address, e
-                    ));
+                    if uac1_set_cur_failure_tolerable(candidate.sync_type) {
+                        dac_mode = DacMode::AdaptiveStreaming;
+                        reported_rate = Some(requested_format.sample_rate);
+                        last_message = Some(format!(
+                            "UAC 1.0 device: failed to set rate on endpoint 0x{:02x}: {}; continuing with adaptive streaming",
+                            candidate.endpoint_address, e
+                        ));
+                    } else {
+                        let msg = format!(
+                            "UAC 1.0 device: failed to set rate on endpoint 0x{:02x}: {} ({:?} endpoint is not host-paced); refusing direct USB",
+                            candidate.endpoint_address, e, candidate.sync_type
+                        );
+                        set_last_error(Some(msg.clone()));
+                        set_direct_mode_refusal_reason(Some(msg.clone()));
+                        return Err(msg);
+                    }
                 }
             }
         } else if let Some(actual_rate) = choose_adaptive_sample_rate(
@@ -3961,22 +3971,13 @@ fn create_android_usb_backend_inner(
             Err(e) => {
                 clock_control_attempted = true;
                 clock_control_succeeded = false;
-                // UAC1 adaptive/synchronous/NoSync endpoints derive their clock
-                // from the host (SOF); SET_CUR is optional and many reject it.
-                // Only an Asynchronous endpoint has its own clock, where a failed
-                // SET_CUR leaves the rate genuinely unknown (chipmunk risk) and
-                // we must refuse. (FiiO BR13 reports NoSync and rejects SET_CUR.)
-                if candidate.sync_type == SyncType::Asynchronous {
-                    clock_verification_passed = false;
-                    reported_sample_rate = None;
-                    set_clock_verification(true, false, false, None);
-                    let message = format!(
-                        "[clock-diag] UAC1 SET_CUR {}Hz on endpoint 0x{:02x} failed: {} — will refuse (asynchronous endpoint)",
-                        playback_format.sample_rate, candidate.endpoint_address, e,
-                    );
-                    dev_eprintln!("{}", message);
-                    set_last_error(Some(message));
-                } else {
+                // Only adaptive/synchronous UAC1 endpoints are host-paced, so a
+                // rejected SET_CUR is tolerable there. Asynchronous endpoints run
+                // their own clock and NoSync endpoints free-run entirely (FiiO
+                // BR13: NoSync, stays locked at 48/96 kHz while we stream at the
+                // file rate -> chipmunk), so a failed rate set leaves the DAC rate
+                // unknown: refuse.
+                if uac1_set_cur_failure_tolerable(candidate.sync_type) {
                     clock_verification_passed = true;
                     reported_sample_rate = Some(playback_format.sample_rate);
                     set_dac_mode(DacMode::AdaptiveStreaming);
@@ -3988,6 +3989,16 @@ fn create_android_usb_backend_inner(
                     );
                     let message = format!(
                         "[clock-diag] UAC1 SET_CUR {}Hz on endpoint 0x{:02x} failed: {} — tolerable for {:?} endpoint, trusting host-driven rate",
+                        playback_format.sample_rate, candidate.endpoint_address, e, candidate.sync_type,
+                    );
+                    dev_eprintln!("{}", message);
+                    set_last_error(Some(message));
+                } else {
+                    clock_verification_passed = false;
+                    reported_sample_rate = None;
+                    set_clock_verification(true, false, false, None);
+                    let message = format!(
+                        "[clock-diag] UAC1 SET_CUR {}Hz on endpoint 0x{:02x} failed: {} — will refuse ({:?} endpoint is not host-paced)",
                         playback_format.sample_rate, candidate.endpoint_address, e, candidate.sync_type,
                     );
                     dev_eprintln!("{}", message);
@@ -6791,6 +6802,14 @@ fn sync_type_label(sync_type: SyncType) -> &'static str {
         SyncType::Synchronous => "synchronous",
         SyncType::NoSync => "none",
     }
+}
+
+// A failed UAC1 SET_CUR is only tolerable when the endpoint is host-paced
+// (adaptive/synchronous). Asynchronous runs its own clock; NoSync free-runs
+// (FiiO BR13) — either way the DAC rate stays unknown and direct streaming
+// would be pitched wrong.
+fn uac1_set_cur_failure_tolerable(sync_type: SyncType) -> bool {
+    matches!(sync_type, SyncType::Adaptive | SyncType::Synchronous)
 }
 
 fn usage_type_label(usage_type: UsageType) -> &'static str {

--- a/test/widgets/uac2/usb_bit_perfect_prompt_test.dart
+++ b/test/widgets/uac2/usb_bit_perfect_prompt_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flick/services/uac2_service.dart';
+import 'package:flick/widgets/uac2/usb_bit_perfect_prompt.dart';
+
+Uac2DeviceStatus status({
+  Uac2State state = Uac2State.connected,
+  Uac2RouteType routeType = Uac2RouteType.externalUsb,
+  bool isExternalRoute = false,
+}) {
+  return Uac2DeviceStatus(
+    device: Uac2DeviceInfo(
+      vendorId: 1,
+      productId: 2,
+      productName: 'Test DAC',
+      manufacturer: 'Test',
+    ),
+    state: state,
+    routeType: routeType,
+    isExternalRoute: isExternalRoute,
+  );
+}
+
+void main() {
+  test('prompts for external USB route in live states with bit-perfect off', () {
+    expect(shouldPromptBitPerfect(status(), bitPerfectEnabled: false), isTrue);
+    expect(
+      shouldPromptBitPerfect(
+        status(state: Uac2State.streaming),
+        bitPerfectEnabled: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldPromptBitPerfect(
+        status(state: Uac2State.prewarming),
+        bitPerfectEnabled: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('no prompt when bit-perfect already on', () {
+    expect(shouldPromptBitPerfect(status(), bitPerfectEnabled: true), isFalse);
+  });
+
+  test('no prompt for internal route or non-live states', () {
+    expect(
+      shouldPromptBitPerfect(
+        status(routeType: Uac2RouteType.internalDac),
+        bitPerfectEnabled: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPromptBitPerfect(
+        status(state: Uac2State.idle),
+        bitPerfectEnabled: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPromptBitPerfect(
+        status(state: Uac2State.error),
+        bitPerfectEnabled: false,
+      ),
+      isFalse,
+    );
+  });
+
+  test('isExternalRoute flag alone qualifies as USB route', () {
+    expect(
+      shouldPromptBitPerfect(
+        status(routeType: Uac2RouteType.unknown, isExternalRoute: true),
+        bitPerfectEnabled: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('prompt key is stable per device and dedupable', () {
+    final a = usbDevicePromptKey(
+      Uac2DeviceInfo(
+        vendorId: 1,
+        productId: 2,
+        productName: 'DAC',
+        manufacturer: 'M',
+        serial: 'S1',
+      ),
+    );
+    final b = usbDevicePromptKey(
+      Uac2DeviceInfo(
+        vendorId: 1,
+        productId: 2,
+        productName: 'DAC',
+        manufacturer: 'M',
+        serial: 'S1',
+      ),
+    );
+    final noSerial = usbDevicePromptKey(
+      Uac2DeviceInfo(
+        vendorId: 1,
+        productId: 2,
+        productName: 'DAC',
+        manufacturer: 'M',
+        deviceName: '/dev/bus/usb/001/002',
+      ),
+    );
+    expect(a, b);
+    expect(<String>{}..add(a)..add(b), {a});
+    expect(noSerial, '1:2:/dev/bus/usb/001/002');
+  });
+}


### PR DESCRIPTION
# Summary

- Add auto-detection prompt that offers one-tap Bit-perfect (USB DAC) mode when an external USB DAC is connected
- Refuse direct USB streaming for UAC1 devices when SET_CUR fails on non-host-paced (Asynchronous/NoSync) endpoints to prevent pitch errors
- Extend embedded lyrics support to MP4/M4A and OGG/Opus formats

# Changes

## USB DAC Bit-perfect Auto-prompt

- Add `UsbBitPerfectPrompt` widget (156 lines) monitoring USB connection state, prompting to enable Bit-perfect mode when external DAC detected with session-level deduplication
- Add `shouldPromptBitPerfect` pure gate and `usbDevicePromptKey` per-device identity for dedup
- Mount prompt in `MainShell` overlay

## UAC1 Direct USB Safety

- Extract `uac1_set_cur_failure_tolerable()` — only Adaptive/Synchronous endpoints tolerate a rejected SET_CUR
- Refuse direct USB for Asynchronous and NoSync endpoints when SET_CUR fails (FiiO BR13: NoSync, stays locked at 48/96 kHz while streaming at file rate)
- Apply same tolerance check in both negotiate and create-backend paths

## Lyrics

- Add MP4/M4A `©lyr` atom reading (UTF-8 and UTF-16) and OGG/Opus Vorbis comment lyrics alongside existing ID3 and FLAC support

## Tests

- Add tests for `shouldPromptBitPerfect` covering live states, bit-perfect already on, internal routes, non-live states, `isExternalRoute` flag, and prompt key stability

## Files Changed

- `lib/widgets/uac2/usb_bit_perfect_prompt.dart`
- `lib/app/app.dart`
- `rust/src/uac2/android_direct.rs`
- `CHANGELOG.md`
- `test/widgets/uac2/usb_bit_perfect_prompt_test.dart`