### PR TITLE
Add FlickArtworkPlaceholder, metadata editor bottom sheet, and root navigator routing

### DIFF
--- a/android/app/src/main/res/drawable/widget_default_art.xml
+++ b/android/app/src/main/res/drawable/widget_default_art.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Placeholder shown when no album art is available. -->
+<!-- Placeholder shown when no album art is available. Flick logo centered, larger and slightly lower. -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
@@ -9,16 +9,8 @@
     </item>
     <item
         android:gravity="center"
-        android:width="40dp"
-        android:height="40dp">
-        <vector
-            android:width="40dp"
-            android:height="40dp"
-            android:viewportWidth="24"
-            android:viewportHeight="24">
-            <path
-                android:fillColor="#888888"
-                android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4V7h4V3h-6z" />
-        </vector>
-    </item>
+        android:width="48dp"
+        android:height="58dp"
+        android:top="4dp"
+        android:drawable="@drawable/widget_flick_logo" />
 </layer-list>

--- a/android/app/src/main/res/drawable/widget_flick_logo.xml
+++ b/android/app/src/main/res/drawable/widget_flick_logo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="58dp"
+    android:viewportWidth="606"
+    android:viewportHeight="734">
+    <path android:fillColor="#F5F5F5" android:pathData="M539.21,603.46 A29.50,29.50 0 1,0 598.21,603.46 A29.50,29.50 0 1,0 539.21,603.46" />
+    <path android:fillColor="#F5F5F5" android:pathData="M445.88,572.49 A29.50,29.50 0 1,0 504.88,572.49 A29.50,29.50 0 1,0 445.88,572.49" />
+    <path android:fillColor="#F5F5F5" android:pathData="M352.56,541.52 A29.50,29.50 0 1,0 411.56,541.52 A29.50,29.50 0 1,0 352.56,541.52" />
+    <path android:fillColor="#F5F5F5" android:pathData="M353.00,253.81 A29.50,29.50 0 1,0 412.00,253.81 A29.50,29.50 0 1,0 353.00,253.81" />
+    <path android:fillColor="#F5F5F5" android:pathData="M353.00,352.14 A29.50,29.50 0 1,0 412.00,352.14 A29.50,29.50 0 1,0 353.00,352.14" />
+    <path android:fillColor="#F5F5F5" android:pathData="M353.00,450.47 A29.50,29.50 0 1,0 412.00,450.47 A29.50,29.50 0 1,0 353.00,450.47" />
+    <path android:fillColor="#F5F5F5" android:pathData="M169.74,89.71 A29.50,29.50 0 1,0 228.74,89.71 A29.50,29.50 0 1,0 169.74,89.71" />
+    <path android:fillColor="#F5F5F5" android:pathData="M261.30,125.56 A29.50,29.50 0 1,0 320.30,125.56 A29.50,29.50 0 1,0 261.30,125.56" />
+    <path android:fillColor="#F5F5F5" android:pathData="M352.86,161.42 A29.50,29.50 0 1,0 411.86,161.42 A29.50,29.50 0 1,0 352.86,161.42" />
+    <path android:fillColor="#F5F5F5" android:pathData="M77.81,144.86 A29.50,29.50 0 1,0 136.81,144.86 A29.50,29.50 0 1,0 77.81,144.86" />
+    <path android:fillColor="#F5F5F5" android:pathData="M169.37,180.72 A29.50,29.50 0 1,0 228.37,180.72 A29.50,29.50 0 1,0 169.37,180.72" />
+    <path android:fillColor="#F5F5F5" android:pathData="M260.93,216.58 A29.50,29.50 0 1,0 319.93,216.58 A29.50,29.50 0 1,0 260.93,216.58" />
+    <path android:fillColor="#F5F5F5" android:pathData="M261.08,315.09 A29.50,29.50 0 1,0 320.08,315.09 A29.50,29.50 0 1,0 261.08,315.09" />
+    <path android:fillColor="#F5F5F5" android:pathData="M84.43,58.46 A29.50,29.50 0 1,0 143.43,58.46 A29.50,29.50 0 1,0 84.43,58.46" />
+    <path android:fillColor="#F5F5F5" android:pathData="M0.00,29.50 A29.50,29.50 0 1,0 59.00,29.50 A29.50,29.50 0 1,0 0.00,29.50" />
+    <path android:fillColor="#F5F5F5" android:pathData="M538.88,696.16 A29.50,29.50 0 1,0 597.88,696.16 A29.50,29.50 0 1,0 538.88,696.16" />
+    <path android:fillColor="#F5F5F5" android:pathData="M445.55,665.19 A29.50,29.50 0 1,0 504.55,665.19 A29.50,29.50 0 1,0 445.55,665.19" />
+    <path android:fillColor="#F5F5F5" android:pathData="M352.23,634.21 A29.50,29.50 0 1,0 411.23,634.21 A29.50,29.50 0 1,0 352.23,634.21" />
+</vector>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -33,6 +33,7 @@ import 'package:flick/features/onboarding/screens/onboarding_screen.dart';
 import 'package:flick/features/onboarding/tutorial_targets.dart';
 import 'package:flick/features/onboarding/widgets/tutorial_overlay.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/uac2/usb_bit_perfect_prompt.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/library_scanner_service.dart';
@@ -1111,11 +1112,18 @@ class _EmbeddedMiniPlayerState extends ConsumerState<_EmbeddedMiniPlayer> {
                           useThumbnail: true,
                           thumbnailWidth: 128,
                           thumbnailHeight: 128,
+                          placeholder: const ColoredBox(
+                            color: AppColors.surface,
+                            child: FlickArtworkPlaceholder(size: 26, opacity: 0.9),
+                          ),
+                          errorWidget: const ColoredBox(
+                            color: AppColors.surface,
+                            child: FlickArtworkPlaceholder(size: 26, opacity: 0.9),
+                          ),
                         )
-                      : const Icon(
-                          LucideIcons.music,
-                          size: 22,
-                          color: AppColors.textTertiary,
+                      : const ColoredBox(
+                          color: AppColors.surface,
+                          child: FlickArtworkPlaceholder(size: 26, opacity: 0.9),
                         ),
                 ),
               ),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -19,6 +19,7 @@ import 'package:flick/features/folders/screens/folders_screen.dart';
 import 'package:flick/features/playlists/screens/playlists_screen.dart';
 import 'package:flick/features/favorites/screens/favorites_screen.dart';
 import 'package:flick/features/search/screens/search_screen.dart';
+import 'package:flick/core/navigation/root_navigator.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/core/utils/responsive.dart';
@@ -66,6 +67,7 @@ class FlickPlayerApp extends StatelessWidget {
       title: 'Flick Player',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.darkTheme,
+      navigatorKey: rootNavigatorKey,
       home: const _RootRouter(),
     );
   }
@@ -108,6 +110,10 @@ class _MainShellState extends ConsumerState<MainShell>
 
   Timer? _idleTimer;
   bool _isBottomBarCollapsed = false;
+
+  final GlobalKey<NavigatorState> _nestedNavigatorKey =
+      GlobalKey<NavigatorState>();
+  static const double _kNestedBarClearance = 150.0;
 
   @override
   void initState() {
@@ -679,6 +685,9 @@ class _MainShellState extends ConsumerState<MainShell>
 
   void _handleBackPress(bool didPop, dynamic result) {
     if (didPop) return;
+    if (_nestedNavigatorKey.currentState?.canPop() == true) {
+      return;
+    }
 
     final now = DateTime.now();
     if (_lastBackPressTime == null ||
@@ -699,10 +708,7 @@ class _MainShellState extends ConsumerState<MainShell>
 
   @override
   Widget build(BuildContext context) {
-    final currentIndex = ref.watch(navigationIndexProvider);
     final backgroundColor = ref.watch(backgroundColorProvider);
-    final navBarConfig = ref.watch(navBarConfigProvider);
-    final pageOrder = _getPageOrder(navBarConfig);
 
     return PopScope(
       canPop: false,
@@ -737,63 +743,130 @@ class _MainShellState extends ConsumerState<MainShell>
                   ),
                 ),
 
-                // Main content area with swipeable page navigation.
-                PageView(
-                  controller: _pageController,
-                  physics: const ClampingScrollPhysics(),
-                  onPageChanged: (position) {
-                    final currentConfig = ref.read(navBarConfigProvider);
-                    final currentOrder = _getPageOrder(currentConfig);
-                    if (position < 0 || position >= currentOrder.length) return;
-                    if (_programmaticPageTarget == null &&
-                        position != _lastHapticPage) {
-                      AppHaptics.selection();
-                    }
-                    _lastHapticPage = position;
-                    final enabledCount = currentConfig.orderedButtons.length;
-                    if (position >= enabledCount) {
-                      if (_programmaticPageTarget == position) {
-                        _programmaticPageTarget = null;
-                        final pageIndex = currentOrder[position].pageIndex;
-                        if (ref.read(navigationIndexProvider) != pageIndex) {
-                          ref
-                              .read(navigationIndexProvider.notifier)
-                              .setIndex(pageIndex);
-                        }
-                        return;
-                      }
-                      // Let disabled-essential pages be reachable by swipe.
-                      // Still pass through silently if a programmatic
-                      // animation is in-flight targeting elsewhere.
-                      if (_programmaticPageTarget != null) {
-                        return;
-                      }
-                      final pageIndex = currentOrder[position].pageIndex;
-                      if (ref.read(navigationIndexProvider) != pageIndex) {
-                        ref
-                            .read(navigationIndexProvider.notifier)
-                            .setIndex(pageIndex);
-                      }
-                      return;
-                    }
-                    // Consume the target only when we land on it.
-                    if (_programmaticPageTarget == position) {
-                      _programmaticPageTarget = null;
-                    }
-                    final pageIndex = currentOrder[position].pageIndex;
-                    if (ref.read(navigationIndexProvider) != pageIndex) {
-                      ref
-                          .read(navigationIndexProvider.notifier)
-                          .setIndex(pageIndex);
-                    }
-                  },
-                  children: pageOrder.map((button) {
-                    return _buildTab(
-                      tabIndex: button.pageIndex,
-                      currentIndex: currentIndex,
-                      child: _buildScreen(button),
-                    );
-                  }).toList(),
+                // Nested navigator: tabs + detail screens below the bar.
+                Positioned.fill(
+                  child: Builder(
+                    builder: (nestedContext) {
+                      final mq = MediaQuery.of(nestedContext);
+                      final inflated = mq.copyWith(
+                        padding: mq.padding.copyWith(
+                          bottom: mq.padding.bottom + _kNestedBarClearance,
+                        ),
+                        viewPadding: mq.viewPadding.copyWith(
+                          bottom:
+                              mq.viewPadding.bottom + _kNestedBarClearance,
+                        ),
+                      );
+                      return MediaQuery(
+                        data: inflated,
+                        child: Navigator(
+                          key: _nestedNavigatorKey,
+                          initialRoute: '/',
+                          onGenerateRoute: (settings) {
+                            if (settings.name == '/') {
+                              return PageRouteBuilder<void>(
+                                settings: settings,
+                                pageBuilder: (routeContext, _, __) =>
+                                    MediaQuery.removePadding(
+                                  context: routeContext,
+                                  removeBottom: true,
+                                  child: Consumer(
+                                    builder: (context, ref, _) {
+                                      final currentIdx =
+                                          ref.watch(navigationIndexProvider);
+                                      final cfg =
+                                          ref.watch(navBarConfigProvider);
+                                      final order = _getPageOrder(cfg);
+                                      return PageView(
+                                        controller: _pageController,
+                                        physics:
+                                            const ClampingScrollPhysics(),
+                                        onPageChanged: (position) {
+                                          final currentConfig = ref.read(
+                                              navBarConfigProvider);
+                                          final currentOrder =
+                                              _getPageOrder(currentConfig);
+                                          if (position < 0 ||
+                                              position >=
+                                                  currentOrder.length) {
+                                            return;
+                                          }
+                                          if (_programmaticPageTarget == null &&
+                                              position != _lastHapticPage) {
+                                            AppHaptics.selection();
+                                          }
+                                          _lastHapticPage = position;
+                                          final enabledCount = currentConfig
+                                              .orderedButtons.length;
+                                          if (position >= enabledCount) {
+                                            if (_programmaticPageTarget ==
+                                                position) {
+                                              _programmaticPageTarget = null;
+                                              final pageIndex =
+                                                  currentOrder[position]
+                                                      .pageIndex;
+                                              if (ref.read(
+                                                      navigationIndexProvider) !=
+                                                  pageIndex) {
+                                                ref
+                                                    .read(
+                                                        navigationIndexProvider
+                                                            .notifier)
+                                                    .setIndex(pageIndex);
+                                              }
+                                              return;
+                                            }
+                                            if (_programmaticPageTarget !=
+                                                null) {
+                                              return;
+                                            }
+                                            final pageIndex =
+                                                currentOrder[position].pageIndex;
+                                            if (ref.read(
+                                                    navigationIndexProvider) !=
+                                                pageIndex) {
+                                              ref
+                                                  .read(navigationIndexProvider
+                                                      .notifier)
+                                                  .setIndex(pageIndex);
+                                            }
+                                            return;
+                                          }
+                                          if (_programmaticPageTarget ==
+                                              position) {
+                                            _programmaticPageTarget = null;
+                                          }
+                                          final pageIndex =
+                                              currentOrder[position].pageIndex;
+                                          if (ref.read(
+                                                  navigationIndexProvider) !=
+                                              pageIndex) {
+                                            ref
+                                                .read(navigationIndexProvider
+                                                    .notifier)
+                                                .setIndex(pageIndex);
+                                          }
+                                        },
+                                        children: order.map((button) {
+                                          return _buildTab(
+                                            tabIndex: button.pageIndex,
+                                            currentIndex: currentIdx,
+                                            child: _buildScreen(button),
+                                          );
+                                        }).toList(),
+                                      );
+                                    },
+                                  ),
+                                ),
+                                transitionDuration: Duration.zero,
+                              );
+                            }
+                            return null;
+                          },
+                        ),
+                      );
+                    },
+                  ),
                 ),
 
                 // Unified Bottom Bar (Mini Player + Navigation)
@@ -889,12 +962,19 @@ class _MainShellState extends ConsumerState<MainShell>
         config: navBarConfig,
         collapsed: collapsed,
         onTap: (index) {
+          final nested = _nestedNavigatorKey.currentState;
+          if (nested != null && nested.canPop()) {
+            nested.popUntil((route) => route.isFirst);
+          }
           if (ref.read(navigationIndexProvider) != index) {
             ref.read(navigationIndexProvider.notifier).setIndex(index);
+          } else if (nested != null && nested.canPop()) {
+            nested.popUntil((route) => route.isFirst);
           }
         },
         onBottomBarSettings: () {
-          Navigator.of(context).push(
+          NavigationHelper.pushOnRoot(
+            context,
             MaterialPageRoute<void>(
               builder: (_) => const BottomBarSettingsScreen(),
             ),

--- a/lib/core/navigation/root_navigator.dart
+++ b/lib/core/navigation/root_navigator.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+/// Global key for the root navigator. Pushing via this key places routes
+/// above the persistent bottom bar (i.e. the bar is hidden). The nested
+/// navigator inside [MainShell] keeps routes below the bar.
+final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();

--- a/lib/core/utils/navigation_helper.dart
+++ b/lib/core/utils/navigation_helper.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/navigation/root_navigator.dart';
 import 'package:flick/features/player/screens/full_player_screen.dart';
 import 'package:flick/features/queue/screens/queue_screen.dart';
 
@@ -67,8 +68,13 @@ class NavigationHelper {
     }
 
     try {
-      // Navigate to full player screen
-      final result = await Navigator.of(context).push<int>(
+      // Navigate to full player screen on the root navigator so it covers
+      // the persistent bottom bar. Falls back to the local navigator during
+      // tests where the root key is not mounted.
+      final navigator = rootNavigatorKey.currentState != null
+          ? rootNavigatorKey.currentState!
+          : Navigator.of(context);
+      final result = await navigator.push<int>(
         PageRouteBuilder(
           pageBuilder: (context, animation, secondaryAnimation) =>
               FullPlayerScreen(heroTag: heroTag),
@@ -116,7 +122,10 @@ class NavigationHelper {
   }
 
   static Future<T?> navigateToQueue<T>(BuildContext context) {
-    return Navigator.of(context).push<T>(
+    final navigator = rootNavigatorKey.currentState != null
+        ? rootNavigatorKey.currentState!
+        : Navigator.of(context);
+    return navigator.push<T>(
       PageRouteBuilder(
         pageBuilder: (context, animation, secondaryAnimation) =>
             const QueueScreen(),
@@ -141,6 +150,13 @@ class NavigationHelper {
         transitionDuration: AppConstants.animationNormal,
       ),
     );
+  }
+
+  /// Push on the root navigator so the persistent bottom bar is hidden.
+  static Future<T?> pushOnRoot<T>(BuildContext context, Route<T> route) {
+    final navigator = rootNavigatorKey.currentState;
+    if (navigator != null) return navigator.push<T>(route);
+    return Navigator.of(context, rootNavigator: true).push<T>(route);
   }
 
   /// Fade-only push for screens that share the persistent blurred background.

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -5,7 +5,6 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/adaptive_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/data/repositories/song_repository.dart';
@@ -479,7 +478,6 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen>
             ),
             ),
             _buildOverlayTopBar(context, resolvedBg),
-            const FloatingMiniPlayer(),
           ],
         );
       },

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
@@ -873,15 +874,13 @@ class _SongTile extends StatelessWidget {
                     imagePath: song.albumArt,
                     audioSourcePath: song.filePath,
                     fit: BoxFit.cover,
-                    placeholder: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    placeholder: const FlickArtworkPlaceholder(
+                      size: 28,
+                      opacity: 0.9,
                     ),
-                    errorWidget: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    errorWidget: const FlickArtworkPlaceholder(
+                      size: 28,
+                      opacity: 0.9,
                     ),
                   ),
                 ),

--- a/lib/features/albums/screens/albums_screen.dart
+++ b/lib/features/albums/screens/albums_screen.dart
@@ -98,6 +98,7 @@ class _AlbumsScreenState extends ConsumerState<AlbumsScreen> {
 
   void _showSortSheet() {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (_) => _AlbumSortSheet(

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -17,6 +17,7 @@ import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
@@ -1090,16 +1091,8 @@ class _MostPlayedCardState extends State<_MostPlayedCard>
                     imagePath: widget.song.albumArt,
                     audioSourcePath: widget.song.filePath,
                     fit: BoxFit.cover,
-                    placeholder: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: 18,
-                    ),
-                    errorWidget: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: 18,
-                    ),
+                    placeholder: const FlickArtworkPlaceholder(size: 22, opacity: 0.9),
+                    errorWidget: const FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                   ),
                 ),
               ),
@@ -1226,16 +1219,8 @@ class _SongTile extends StatelessWidget {
                     imagePath: song.albumArt,
                     audioSourcePath: song.filePath,
                     fit: BoxFit.cover,
-                    placeholder: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
-                    ),
-                    errorWidget: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
-                    ),
+                    placeholder: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+                    errorWidget: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                   ),
                 ),
               ),

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -5,7 +5,6 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/adaptive_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/data/repositories/artist_repository.dart';
@@ -543,7 +542,6 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen>
                 ),
               ),
               _buildOverlayTopBar(context, resolvedBg),
-              const FloatingMiniPlayer(),
             ],
           );
         },

--- a/lib/features/artists/screens/artists_screen.dart
+++ b/lib/features/artists/screens/artists_screen.dart
@@ -155,6 +155,7 @@ class _ArtistsScreenState extends ConsumerState<ArtistsScreen> {
 
   void _showSortSheet() {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (_) => _ArtistSortSheet(

--- a/lib/features/favorites/screens/favorites_screen.dart
+++ b/lib/features/favorites/screens/favorites_screen.dart
@@ -11,6 +11,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/services/favorites_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/player/widgets/ambient_background.dart';
@@ -609,11 +610,10 @@ class _FavoriteSongTile extends StatelessWidget {
   }
 
   Widget _buildPlaceholder(BuildContext context) {
-    return Center(
-      child: Icon(
-        LucideIcons.music,
-        color: context.adaptiveTextTertiary,
-        size: context.responsiveIcon(AppConstants.iconSizeLg),
+    return Container(
+      color: AppColors.surfaceLight,
+      child: const Center(
+        child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
       ),
     );
   }

--- a/lib/features/favorites/screens/favorites_screen.dart
+++ b/lib/features/favorites/screens/favorites_screen.dart
@@ -145,6 +145,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
 
   void _showLongPressSheet(Song song) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (_) => Container(

--- a/lib/features/folders/screens/folders_screen.dart
+++ b/lib/features/folders/screens/folders_screen.dart
@@ -18,6 +18,7 @@ import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 /// Groups songs by immediate subfolder relative to [prefix] within [folderUri].
 ({List<FolderGroup> subfolders, List<Song> songs}) groupByImmediateFolder({
@@ -830,10 +831,8 @@ class _RootFolderCardState extends State<_RootFolderCard>
       borderRadius: BorderRadius.all(Radius.circular(AppConstants.radiusSm)),
       child: Container(
         color: AppColors.surfaceLight,
-        child: const Icon(
-          LucideIcons.music,
-          color: AppColors.textTertiary,
-          size: 18,
+        child: const Center(
+          child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
         ),
       ),
     );
@@ -1662,10 +1661,8 @@ class _SubfolderCardState extends State<_SubfolderCard>
       borderRadius: BorderRadius.all(Radius.circular(AppConstants.radiusSm)),
       child: Container(
         color: AppColors.surfaceLight,
-        child: const Icon(
-          LucideIcons.music,
-          color: AppColors.textTertiary,
-          size: 18,
+        child: const Center(
+          child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
         ),
       ),
     );
@@ -1706,19 +1703,11 @@ class _SongTile extends StatelessWidget {
                     thumbnailHeight: 92,
                     placeholder: const ColoredBox(
                       color: AppColors.surface,
-                      child: Icon(
-                        LucideIcons.music,
-                        color: AppColors.textTertiary,
-                        size: 18,
-                      ),
+                      child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                     ),
                     errorWidget: const ColoredBox(
                       color: AppColors.surface,
-                      child: Icon(
-                        LucideIcons.music,
-                        color: AppColors.textTertiary,
-                        size: 18,
-                      ),
+                      child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                     ),
                   ),
                 ),

--- a/lib/features/folders/screens/folders_screen.dart
+++ b/lib/features/folders/screens/folders_screen.dart
@@ -17,7 +17,6 @@ import 'package:flick/features/player/widgets/ambient_background.dart';
 import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 
 /// Groups songs by immediate subfolder relative to [prefix] within [folderUri].
@@ -230,6 +229,7 @@ class _FoldersScreenState extends ConsumerState<FoldersScreen> {
   void _showSortSheet() {
     final pageSize = ref.read(appPreferencesProvider).folderGridPageSize;
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (_) => _FolderRootSortSheet(
@@ -953,6 +953,7 @@ class _FolderBrowserScreenState extends ConsumerState<FolderBrowserScreen> {
 
   void _showSortSheet() {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (_) => _FolderBrowserSortSheet(
@@ -1074,7 +1075,6 @@ class _FolderBrowserScreenState extends ConsumerState<FolderBrowserScreen> {
             ),
           ),
         ),
-        const FloatingMiniPlayer(),
       ],
     );
   }

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -32,6 +32,7 @@ import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/services/uac2_preferences_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/engine_restart_notice.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
@@ -2295,17 +2296,11 @@ class _HeroFeatureTile extends StatelessWidget {
                 thumbnailHeight: 160,
                 placeholder: Container(
                   color: Colors.white.withValues(alpha: 0.06),
-                  child: Icon(
-                    LucideIcons.music4,
-                    color: Colors.white.withValues(alpha: 0.72),
-                  ),
+                  child: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                 ),
                 errorWidget: Container(
                   color: Colors.white.withValues(alpha: 0.06),
-                  child: Icon(
-                    LucideIcons.music4,
-                    color: Colors.white.withValues(alpha: 0.72),
-                  ),
+                  child: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                 ),
               ),
             ),
@@ -2750,17 +2745,11 @@ class _RecentTrackCard extends StatelessWidget {
                     thumbnailHeight: 240,
                     placeholder: Container(
                       color: AppColors.glassBackgroundStrong,
-                      child: Icon(
-                        LucideIcons.music4,
-                        color: context.adaptiveTextSecondary,
-                      ),
+                      child: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                     ),
                     errorWidget: Container(
                       color: AppColors.glassBackgroundStrong,
-                      child: Icon(
-                        LucideIcons.music4,
-                        color: context.adaptiveTextSecondary,
-                      ),
+                      child: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                     ),
                   ),
                 ),

--- a/lib/features/menu/screens/smart_mix_detail_screen.dart
+++ b/lib/features/menu/screens/smart_mix_detail_screen.dart
@@ -9,7 +9,6 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/adaptive_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/responsive.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
@@ -341,7 +340,6 @@ class _SmartMixDetailScreenState extends ConsumerState<SmartMixDetailScreen>
                 ),
               ),
               _buildOverlayTopBar(context, resolvedBg),
-              const FloatingMiniPlayer(),
             ],
           );
         },

--- a/lib/features/menu/screens/smart_mix_detail_screen.dart
+++ b/lib/features/menu/screens/smart_mix_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/providers/navigation_provider.dart';
 import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
@@ -797,16 +798,8 @@ class _SongTile extends StatelessWidget {
                     imagePath: song.albumArt,
                     audioSourcePath: song.filePath,
                     fit: BoxFit.cover,
-                    placeholder: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
-                    ),
-                    errorWidget: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
-                    ),
+                    placeholder: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+                    errorWidget: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
                   ),
                 ),
               ),

--- a/lib/features/milestone/screens/milestones_screen.dart
+++ b/lib/features/milestone/screens/milestones_screen.dart
@@ -256,6 +256,7 @@ class _MilestonesScreenState extends ConsumerState<MilestonesScreen> {
     final unit = remaining == 1 ? type.category.unitSingular : type.unit;
     if (!mounted) return;
     await showModalBottomSheet<void>(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: false,

--- a/lib/features/player/widgets/add_to_playlist_sheet.dart
+++ b/lib/features/player/widgets/add_to_playlist_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 class AddToPlaylistSheet extends ConsumerWidget {
   final Song song;
@@ -97,9 +98,9 @@ class AddToPlaylistSheet extends ConsumerWidget {
                               color: AppColors.surfaceLight,
                               borderRadius: BorderRadius.circular(8),
                             ),
-                            child: Icon(
-                              LucideIcons.music,
-                              color: context.adaptiveTextSecondary,
+                            child: const FlickArtworkPlaceholder(
+                              size: 22,
+                              opacity: 0.9,
                             ),
                           ),
                           title: Text(

--- a/lib/features/player/widgets/add_to_playlist_sheet.dart
+++ b/lib/features/player/widgets/add_to_playlist_sheet.dart
@@ -12,6 +12,7 @@ class AddToPlaylistSheet extends ConsumerWidget {
 
   static Future<void> show(BuildContext context, Song song) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => AddToPlaylistSheet(song: song),

--- a/lib/features/player/widgets/album_art_box.dart
+++ b/lib/features/player/widgets/album_art_box.dart
@@ -6,8 +6,8 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/core/utils/responsive.dart';
-import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 class AlbumArtBox extends StatefulWidget {
   final Song song;
@@ -18,7 +18,8 @@ class AlbumArtBox extends StatefulWidget {
   final ValueChanged<bool>? onVinylChanged;
   final bool showFrame;
 
-  const AlbumArtBox({super.key,
+  const AlbumArtBox({
+    super.key,
     required this.song,
     this.size,
     this.playerService,
@@ -469,18 +470,22 @@ class _AlbumArtBoxState extends State<AlbumArtBox>
                                 fit: BoxFit.cover,
                                 placeholder: Container(
                                   color: Colors.white.withValues(alpha: 0.05),
-                                  child: Icon(
-                                    LucideIcons.music,
-                                    size: iconSize * (1 - t * 0.5),
-                                    color: Colors.white.withValues(alpha: 0.48),
+                                  child: Transform.translate(
+                                    offset: Offset(0, 6 * (1 - t)),
+                                    child: FlickArtworkPlaceholder(
+                                      size: iconSize * (1 - t * 0.5) * 1.42,
+                                      opacity: 0.92,
+                                    ),
                                   ),
                                 ),
                                 errorWidget: Container(
                                   color: Colors.white.withValues(alpha: 0.05),
-                                  child: Icon(
-                                    LucideIcons.music,
-                                    size: iconSize * (1 - t * 0.5),
-                                    color: Colors.white.withValues(alpha: 0.48),
+                                  child: Transform.translate(
+                                    offset: Offset(0, 6 * (1 - t)),
+                                    child: FlickArtworkPlaceholder(
+                                      size: iconSize * (1 - t * 0.5) * 1.42,
+                                      opacity: 0.92,
+                                    ),
                                   ),
                                 ),
                               ),
@@ -497,18 +502,22 @@ class _AlbumArtBoxState extends State<AlbumArtBox>
                                 fit: BoxFit.cover,
                                 placeholder: Container(
                                   color: Colors.white.withValues(alpha: 0.05),
-                                  child: Icon(
-                                    LucideIcons.music,
-                                    size: iconSize * (1 - t * 0.5),
-                                    color: Colors.white.withValues(alpha: 0.48),
+                                  child: Transform.translate(
+                                    offset: Offset(0, 6 * (1 - t)),
+                                    child: FlickArtworkPlaceholder(
+                                      size: iconSize * (1 - t * 0.5) * 1.42,
+                                      opacity: 0.92,
+                                    ),
                                   ),
                                 ),
                                 errorWidget: Container(
                                   color: Colors.white.withValues(alpha: 0.05),
-                                  child: Icon(
-                                    LucideIcons.music,
-                                    size: iconSize * (1 - t * 0.5),
-                                    color: Colors.white.withValues(alpha: 0.48),
+                                  child: Transform.translate(
+                                    offset: Offset(0, 6 * (1 - t)),
+                                    child: FlickArtworkPlaceholder(
+                                      size: iconSize * (1 - t * 0.5) * 1.42,
+                                      opacity: 0.92,
+                                    ),
                                   ),
                                 ),
                               ),
@@ -749,4 +758,3 @@ class _VinylOutlinePainter extends CustomPainter {
   bool shouldRepaint(covariant _VinylOutlinePainter old) =>
       old.progress != progress;
 }
-

--- a/lib/features/player/widgets/animated_song_scene.dart
+++ b/lib/features/player/widgets/animated_song_scene.dart
@@ -20,6 +20,7 @@ import 'package:flick/features/player/widgets/audio_visualizer.dart';
 import 'package:flick/features/player/widgets/bit_perfect_capsule.dart';
 import 'package:flick/features/player/widgets/bit_perfect_indicator.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/features/player/widgets/visualizer_art_box.dart';
 import 'package:flick/features/player/widgets/album_art_box.dart';
 import 'package:flick/features/player/widgets/waveform_layer.dart';
@@ -313,10 +314,8 @@ class AnimatedSongScene extends StatelessWidget {
                         colors: [Color(0xFF181818), AppColors.background],
                       ),
                     ),
-                    child: Icon(
-                      LucideIcons.music,
-                      size: 120,
-                      color: AppColors.textTertiary.withValues(alpha: 0.2),
+                    child: const Center(
+                      child: FlickArtworkPlaceholder(size: 96, opacity: 0.22),
                     ),
                   ),
           ),
@@ -381,18 +380,14 @@ class AnimatedSongScene extends StatelessWidget {
             fit: BoxFit.cover,
             placeholder: Container(
               color: AppColors.background,
-              child: Icon(
-                LucideIcons.music,
-                size: 120,
-                color: AppColors.textTertiary.withValues(alpha: 0.3),
+              child: const Center(
+                child: FlickArtworkPlaceholder(size: 96, opacity: 0.35),
               ),
             ),
             errorWidget: Container(
               color: AppColors.background,
-              child: Icon(
-                LucideIcons.music,
-                size: 120,
-                color: AppColors.textTertiary.withValues(alpha: 0.3),
+              child: const Center(
+                child: FlickArtworkPlaceholder(size: 96, opacity: 0.35),
               ),
             ),
           ),
@@ -860,18 +855,16 @@ class AnimatedSongScene extends StatelessWidget {
                     fit: BoxFit.cover,
                     placeholder: Container(
                       color: Colors.white.withValues(alpha: 0.05),
-                      child: Icon(
-                        LucideIcons.music,
-                        color: Colors.white.withValues(alpha: 0.5),
+                      child: FlickArtworkPlaceholder(
                         size: artworkSize * 0.44,
+                        opacity: 0.92,
                       ),
                     ),
                     errorWidget: Container(
                       color: Colors.white.withValues(alpha: 0.05),
-                      child: Icon(
-                        LucideIcons.music,
-                        color: Colors.white.withValues(alpha: 0.5),
+                      child: FlickArtworkPlaceholder(
                         size: artworkSize * 0.44,
+                        opacity: 0.92,
                       ),
                     ),
                   ),

--- a/lib/features/player/widgets/bit_perfect_indicator.dart
+++ b/lib/features/player/widgets/bit_perfect_indicator.dart
@@ -144,6 +144,7 @@ class BitPerfectIndicator extends ConsumerWidget {
         AudioPathManagement.directUsbExperimental;
 
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,

--- a/lib/features/player/widgets/compact_player_info_layout.dart
+++ b/lib/features/player/widgets/compact_player_info_layout.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 /// Compact horizontal player header used when window height is constrained
 /// (split screen / freeform). Artwork left, song info right. File info and
@@ -55,18 +55,16 @@ class CompactPlayerInfoLayout extends StatelessWidget {
                 fit: BoxFit.cover,
                 placeholder: Container(
                   color: AppColors.glassBackgroundStrong,
-                  child: Icon(
-                    LucideIcons.music,
-                    size: context.responsive(24.0, 28.0, 32.0),
-                    color: AppColors.textTertiary,
+                  child: FlickArtworkPlaceholder(
+                    size: context.responsive(28.0, 32.0, 36.0),
+                    opacity: 0.92,
                   ),
                 ),
                 errorWidget: Container(
                   color: AppColors.glassBackgroundStrong,
-                  child: Icon(
-                    LucideIcons.music,
-                    size: context.responsive(24.0, 28.0, 32.0),
-                    color: AppColors.textTertiary,
+                  child: FlickArtworkPlaceholder(
+                    size: context.responsive(28.0, 32.0, 36.0),
+                    opacity: 0.92,
                   ),
                 ),
               ),

--- a/lib/features/player/widgets/lyrics_editor_bottom_sheet.dart
+++ b/lib/features/player/widgets/lyrics_editor_bottom_sheet.dart
@@ -45,6 +45,7 @@ class LyricsEditorBottomSheet extends StatefulWidget {
     LyricsData? initialLyrics,
   }) {
     return showModalBottomSheet<LyricsEditorResult>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/player/widgets/mini_player.dart
+++ b/lib/features/player/widgets/mini_player.dart
@@ -8,6 +8,7 @@ import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/uac2/uac2_player_status.dart';
 
 class MiniPlayer extends ConsumerStatefulWidget {
@@ -126,11 +127,14 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                           return Align(
                             alignment: Alignment.bottomLeft,
                             child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 24),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 24,
+                              ),
                               child: FractionallySizedBox(
-                                widthFactor: (position.inMilliseconds /
-                                        duration.inMilliseconds)
-                                    .clamp(0.0, 1.0),
+                                widthFactor:
+                                    (position.inMilliseconds /
+                                            duration.inMilliseconds)
+                                        .clamp(0.0, 1.0),
                                 child: Container(
                                   height: 3,
                                   decoration: BoxDecoration(
@@ -141,7 +145,9 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                                     ),
                                     boxShadow: [
                                       BoxShadow(
-                                        color: AppColors.accent.withValues(alpha: 0.5),
+                                        color: AppColors.accent.withValues(
+                                          alpha: 0.5,
+                                        ),
                                         blurRadius: 6,
                                         offset: const Offset(0, -1),
                                       ),
@@ -162,7 +168,12 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                       Hero(
                         tag: 'mini_player_art',
                         child: Container(
-                          margin: const EdgeInsets.only(left: 8, top: 8, bottom: 8, right: 14),
+                          margin: const EdgeInsets.only(
+                            left: 8,
+                            top: 8,
+                            bottom: 8,
+                            right: 14,
+                          ),
                           width: 56,
                           height: 56,
                           decoration: BoxDecoration(
@@ -185,15 +196,19 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                               useThumbnail: true,
                               thumbnailWidth: 128,
                               thumbnailHeight: 128,
-                              placeholder: const Icon(
-                                LucideIcons.music,
-                                size: 24,
-                                color: AppColors.textTertiary,
+                              placeholder: Container(
+                                color: AppColors.surfaceDark,
+                                child: const FlickArtworkPlaceholder(
+                                  size: 32,
+                                  opacity: 0.88,
+                                ),
                               ),
-                              errorWidget: const Icon(
-                                LucideIcons.music,
-                                size: 24,
-                                color: AppColors.textTertiary,
+                              errorWidget: Container(
+                                color: AppColors.surfaceDark,
+                                child: const FlickArtworkPlaceholder(
+                                  size: 32,
+                                  opacity: 0.88,
+                                ),
                               ),
                             ),
                           ),
@@ -230,7 +245,9 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                                       fontFamily: 'ProductSans',
                                       fontSize: 13.5,
                                       fontWeight: FontWeight.w500,
-                                      color: AppColors.textSecondary.withValues(alpha: 0.9),
+                                      color: AppColors.textSecondary.withValues(
+                                        alpha: 0.9,
+                                      ),
                                     ),
                                   ),
                                 ),
@@ -241,7 +258,9 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                                 ),
                               ],
                             ),
-                            const SizedBox(height: 2), // Spacing for progress bar
+                            const SizedBox(
+                              height: 2,
+                            ), // Spacing for progress bar
                           ],
                         ),
                       ),
@@ -260,7 +279,8 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
 
                       // Play/Pause button with circular background
                       ValueListenableBuilder<bool>(
-                        valueListenable: _playerService.isNetworkLoadingNotifier,
+                        valueListenable:
+                            _playerService.isNetworkLoadingNotifier,
                         builder: (context, isLoading, _) {
                           if (isLoading) {
                             return Container(
@@ -286,12 +306,16 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                                 decoration: BoxDecoration(
                                   shape: BoxShape.circle,
                                   color: isPlaying
-                                    ? AppColors.accent.withValues(alpha: 0.15)
-                                    : AppColors.glassBackgroundStrong,
+                                      ? AppColors.accent.withValues(alpha: 0.15)
+                                      : AppColors.glassBackgroundStrong,
                                   border: Border.all(
                                     color: isPlaying
-                                      ? AppColors.accent.withValues(alpha: 0.3)
-                                      : AppColors.glassBorder.withValues(alpha: 0.2),
+                                        ? AppColors.accent.withValues(
+                                            alpha: 0.3,
+                                          )
+                                        : AppColors.glassBorder.withValues(
+                                            alpha: 0.2,
+                                          ),
                                   ),
                                 ),
                                 child: Material(
@@ -305,8 +329,12 @@ class _MiniPlayerState extends ConsumerState<MiniPlayer> {
                                     child: Padding(
                                       padding: const EdgeInsets.all(10.0),
                                       child: Icon(
-                                        isPlaying ? LucideIcons.pause : LucideIcons.play,
-                                        color: isPlaying ? AppColors.accentLight : AppColors.textPrimary,
+                                        isPlaying
+                                            ? LucideIcons.pause
+                                            : LucideIcons.play,
+                                        color: isPlaying
+                                            ? AppColors.accentLight
+                                            : AppColors.textPrimary,
                                         size: 20,
                                       ),
                                     ),

--- a/lib/features/player/widgets/online_lyrics_search_sheet.dart
+++ b/lib/features/player/widgets/online_lyrics_search_sheet.dart
@@ -25,6 +25,7 @@ class OnlineLyricsSearchSheet extends StatefulWidget {
     required LyricsService lyricsService,
   }) {
     return showModalBottomSheet<bool>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/player/widgets/pitch_bottom_sheet.dart
+++ b/lib/features/player/widgets/pitch_bottom_sheet.dart
@@ -9,6 +9,7 @@ class PitchBottomSheet extends StatelessWidget {
 
   static Future<void> show(BuildContext context, PlayerService playerService) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => PitchBottomSheet(playerService: playerService),

--- a/lib/features/player/widgets/player_action_button_row.dart
+++ b/lib/features/player/widgets/player_action_button_row.dart
@@ -677,6 +677,7 @@ class _PlayerActionButtonRowState extends ConsumerState<PlayerActionButtonRow> {
       child: GestureDetector(
         onTap: () {
           showModalBottomSheet(
+      useRootNavigator: true,
             context: context,
             backgroundColor: Colors.transparent,
             isScrollControlled: true,

--- a/lib/features/player/widgets/player_layout_sheet.dart
+++ b/lib/features/player/widgets/player_layout_sheet.dart
@@ -36,6 +36,7 @@ class PlayerLayoutSheet extends ConsumerStatefulWidget {
     required Song? song,
   }) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/player/widgets/player_layout_sheet.dart
+++ b/lib/features/player/widgets/player_layout_sheet.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
-import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
@@ -13,6 +12,7 @@ import 'package:flick/models/album_color_mode.dart';
 import 'package:flick/models/player_action_button.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 class PlayerLayoutSheet extends ConsumerStatefulWidget {
   final PlayerService playerService;
@@ -1037,10 +1037,11 @@ class _PreviewAlbumArt extends StatelessWidget {
           colors: [Color(0xFF4B3D7A), Color(0xFF111111)],
         ),
       ),
-      child: Icon(
-        LucideIcons.music,
-        color: Colors.white.withValues(alpha: 0.62),
-        size: size.isFinite ? math.max(18, size * 0.38) : 64,
+      child: Center(
+        child: FlickArtworkPlaceholder(
+          size: size.isFinite ? math.max(22, size * 0.42) : 72,
+          opacity: 0.9,
+        ),
       ),
     );
   }

--- a/lib/features/player/widgets/share/share_cards/lyric_share_card.dart
+++ b/lib/features/player/widgets/share/share_cards/lyric_share_card.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flick/models/song.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 class LyricShareCard extends StatelessWidget {
   final Song song;
@@ -139,7 +140,7 @@ class LyricShareCard extends StatelessWidget {
   Widget _fallbackBackground() => Container(
     color: const Color(0xFF1A1A1A),
     child: const Center(
-      child: Icon(Icons.music_note_rounded, color: Color(0xFF404040), size: 64),
+      child: FlickArtworkPlaceholder(size: 56, opacity: 0.9),
     ),
   );
 }

--- a/lib/features/player/widgets/share/share_cards/minimal_share_card.dart
+++ b/lib/features/player/widgets/share/share_cards/minimal_share_card.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/models/song.dart';
@@ -104,10 +105,6 @@ class MinimalShareCard extends StatelessWidget {
       color: AppColors.surface,
       borderRadius: BorderRadius.circular(12),
     ),
-    child: const Icon(
-      Icons.music_note_rounded,
-      color: AppColors.textTertiary,
-      size: 48,
-    ),
+    child: const FlickArtworkPlaceholder(size: 52, opacity: 0.9),
   );
 }

--- a/lib/features/player/widgets/share/share_cards/solid_color_share_card.dart
+++ b/lib/features/player/widgets/share/share_cards/solid_color_share_card.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:ui';
 import 'package:flutter/material.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flick/models/song.dart';
 
@@ -140,10 +141,6 @@ class SolidColorShareCard extends StatelessWidget {
       color: Colors.white.withValues(alpha: 0.08),
       borderRadius: BorderRadius.circular(12),
     ),
-    child: const Icon(
-      Icons.music_note_rounded,
-      color: Colors.white24,
-      size: 48,
-    ),
+    child: const FlickArtworkPlaceholder(size: 62, opacity: 0.9),
   );
 }

--- a/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
+++ b/lib/features/player/widgets/sleep_timer_bottom_sheet.dart
@@ -10,6 +10,7 @@ class SleepTimerBottomSheet extends StatefulWidget {
 
   static Future<void> show(BuildContext context, PlayerService playerService) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => SleepTimerBottomSheet(playerService: playerService),

--- a/lib/features/player/widgets/song_actions_sheet.dart
+++ b/lib/features/player/widgets/song_actions_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
@@ -51,6 +52,7 @@ class SongActionsSheet extends ConsumerWidget {
     required PlayerNavigation navigation,
   }) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -240,14 +242,14 @@ class SongActionsSheet extends ConsumerWidget {
                               label: 'Edit Metadata',
                               onTap: () {
                                 Navigator.pop(sheetContext);
-                                Navigator.of(context)
-                                    .push<bool>(
-                                      MaterialPageRoute(
-                                        builder: (_) => MetadataEditorScreen(
-                                          song: activeSong,
-                                        ),
-                                      ),
-                                    )
+                                NavigationHelper.pushOnRoot<bool>(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => MetadataEditorScreen(
+                                      song: activeSong,
+                                    ),
+                                  ),
+                                )
                                     .then((saved) {
                                       if (saved == true) {
                                         ref.invalidate(songsProvider);
@@ -345,6 +347,7 @@ class SongActionsSheet extends ConsumerWidget {
                             onTap: () {
                               Navigator.pop(sheetContext);
                               showModalBottomSheet(
+      useRootNavigator: true,
                                 context: context,
                                 backgroundColor: Colors.transparent,
                                 isScrollControlled: true,

--- a/lib/features/player/widgets/song_actions_sheet.dart
+++ b/lib/features/player/widgets/song_actions_sheet.dart
@@ -3,14 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
-import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/features/player/widgets/player_navigation.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart';
-import 'package:flick/features/songs/screens/metadata_editor_screen.dart';
+import 'package:flick/features/songs/widgets/metadata_editor_bottom_sheet.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/player/widgets/share/share_bottom_sheet.dart';
 import 'package:flick/features/player/widgets/song_metadata_sheet.dart';
@@ -126,18 +126,16 @@ class SongActionsSheet extends ConsumerWidget {
                             thumbnailHeight: 136,
                             placeholder: Container(
                               color: AppColors.surfaceLight,
-                              child: const Icon(
-                                LucideIcons.music,
-                                color: AppColors.textTertiary,
-                                size: 24,
+                              child: const FlickArtworkPlaceholder(
+                                size: 28,
+                                opacity: 0.9,
                               ),
                             ),
                             errorWidget: Container(
                               color: AppColors.surfaceLight,
-                              child: const Icon(
-                                LucideIcons.music,
-                                color: AppColors.textTertiary,
-                                size: 24,
+                              child: const FlickArtworkPlaceholder(
+                                size: 28,
+                                opacity: 0.9,
                               ),
                             ),
                           ),
@@ -242,19 +240,16 @@ class SongActionsSheet extends ConsumerWidget {
                               label: 'Edit Metadata',
                               onTap: () {
                                 Navigator.pop(sheetContext);
-                                NavigationHelper.pushOnRoot<bool>(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) => MetadataEditorScreen(
-                                      song: activeSong,
-                                    ),
-                                  ),
-                                )
-                                    .then((saved) {
-                                      if (saved == true) {
-                                        ref.invalidate(songsProvider);
-                                      }
-                                    });
+                                Future.delayed(Duration.zero, () async {
+                                  final saved =
+                                      await MetadataEditorBottomSheet.show(
+                                    context,
+                                    activeSong,
+                                  );
+                                  if (saved && context.mounted) {
+                                    ref.invalidate(songsProvider);
+                                  }
+                                });
                               },
                             ),
                           _buildSongActionTile(

--- a/lib/features/player/widgets/song_metadata_sheet.dart
+++ b/lib/features/player/widgets/song_metadata_sheet.dart
@@ -10,6 +10,7 @@ class SongMetadataSheet extends StatelessWidget {
 
   static Future<void> show(BuildContext context, Song song) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,

--- a/lib/features/player/widgets/speed_bottom_sheet.dart
+++ b/lib/features/player/widgets/speed_bottom_sheet.dart
@@ -9,6 +9,7 @@ class SpeedBottomSheet extends StatelessWidget {
 
   static Future<void> show(BuildContext context, PlayerService playerService) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => SpeedBottomSheet(playerService: playerService),

--- a/lib/features/player/widgets/volume_bottom_sheet.dart
+++ b/lib/features/player/widgets/volume_bottom_sheet.dart
@@ -9,6 +9,7 @@ class VolumeBottomSheet extends StatelessWidget {
 
   static Future<void> show(BuildContext context, PlayerService playerService) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => VolumeBottomSheet(playerService: playerService),

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -13,6 +13,7 @@ import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/models/playlist.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
@@ -1046,15 +1047,13 @@ class _SongTile extends StatelessWidget {
                     imagePath: song.albumArt,
                     audioSourcePath: song.filePath,
                     fit: BoxFit.cover,
-                    placeholder: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    placeholder: const FlickArtworkPlaceholder(
+                      size: 28,
+                      opacity: 0.9,
                     ),
-                    errorWidget: Icon(
-                      LucideIcons.music,
-                      color: context.adaptiveTextTertiary,
-                      size: context.responsiveIcon(AppConstants.iconSizeMd),
+                    errorWidget: const FlickArtworkPlaceholder(
+                      size: 28,
+                      opacity: 0.9,
                     ),
                   ),
                 ),

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -9,7 +9,6 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/adaptive_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/responsive.dart';
-import 'package:flick/widgets/common/floating_mini_player.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
@@ -599,7 +598,6 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen>
               ),
             ),
             _buildOverlayTopBar(context, resolvedBg),
-            const FloatingMiniPlayer(),
           ],
         );
       },

--- a/lib/features/playlists/screens/playlists_screen.dart
+++ b/lib/features/playlists/screens/playlists_screen.dart
@@ -12,6 +12,7 @@ import 'package:flick/providers/songs_provider.dart';
 import 'package:flick/providers/navigation_provider.dart';
 import 'package:flick/services/sources/network_source_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:flick/features/playlists/screens/playlist_detail_screen.dart';
 import 'package:flick/features/player/widgets/ambient_background.dart';
@@ -745,11 +746,7 @@ class _PlaylistCover extends ConsumerWidget {
         borderRadius: BorderRadius.circular(AppConstants.radiusMd),
         border: Border.all(color: AppColors.surfaceDark),
       ),
-      child: Icon(
-        LucideIcons.music,
-        color: context.adaptiveTextSecondary,
-        size: context.responsiveIcon(AppConstants.iconSizeLg),
-      ),
+      child: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
     );
   }
 
@@ -804,10 +801,8 @@ class _PlaylistCover extends ConsumerWidget {
   Widget _buildPlaceholderIcon(BuildContext context) {
     return Container(
       color: AppColors.surfaceLight,
-      child: Icon(
-        LucideIcons.music,
-        color: context.adaptiveTextSecondary,
-        size: context.responsiveIcon(AppConstants.iconSizeLg),
+      child: const Center(
+        child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
       ),
     );
   }

--- a/lib/features/playlists/widgets/playlist_sort_bottom_sheet.dart
+++ b/lib/features/playlists/widgets/playlist_sort_bottom_sheet.dart
@@ -152,6 +152,7 @@ class PlaylistSortBottomSheet extends StatelessWidget {
     required ValueChanged<PlaylistSortOption> onSortChanged,
   }) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,

--- a/lib/features/queue/screens/queue_screen.dart
+++ b/lib/features/queue/screens/queue_screen.dart
@@ -8,6 +8,7 @@ import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/blurred_song_background.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 
 class QueueScreen extends ConsumerStatefulWidget {
@@ -902,19 +903,11 @@ class _Artwork extends StatelessWidget {
           thumbnailHeight: 96,
           placeholder: const ColoredBox(
             color: AppColors.surface,
-            child: Icon(
-              LucideIcons.music,
-              color: AppColors.textTertiary,
-              size: 18,
-            ),
+            child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
           ),
           errorWidget: const ColoredBox(
             color: AppColors.surface,
-            child: Icon(
-              LucideIcons.music,
-              color: AppColors.textTertiary,
-              size: 18,
-            ),
+            child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
           ),
         ),
       ),

--- a/lib/features/recap/screens/listening_recap_screen.dart
+++ b/lib/features/recap/screens/listening_recap_screen.dart
@@ -13,6 +13,7 @@ import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/services/csv_export_service.dart';
 import 'package:flick/services/gallery_save_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -1842,22 +1843,14 @@ class _PosterAlbumArtFeature extends StatelessWidget {
           child: imagePath == null || imagePath!.isEmpty
               ? ColoredBox(
                   color: Colors.white.withValues(alpha: 0.1),
-                  child: Icon(
-                    Icons.music_note_rounded,
-                    size: 62,
-                    color: Colors.white.withValues(alpha: 0.78),
-                  ),
+                  child: const FlickArtworkPlaceholder(size: 80, opacity: 0.9),
                 )
               : CachedImageWidget(
                   imagePath: imagePath,
                   fit: BoxFit.cover,
                   errorWidget: ColoredBox(
                     color: Colors.white.withValues(alpha: 0.1),
-                    child: Icon(
-                      Icons.music_note_rounded,
-                      size: 62,
-                      color: Colors.white.withValues(alpha: 0.78),
-                    ),
+                    child: const FlickArtworkPlaceholder(size: 80, opacity: 0.9),
                   ),
                 ),
         ),
@@ -2459,10 +2452,9 @@ class _PosterArtThumb extends StatelessWidget {
         child: imagePath == null || imagePath!.isEmpty
             ? Container(
                 color: Colors.white.withValues(alpha: 0.08),
-                child: Icon(
-                  Icons.music_note_rounded,
-                  size: size * 0.34,
-                  color: Colors.white.withValues(alpha: 0.78),
+                child: FlickArtworkPlaceholder(
+                  size: size * 0.38,
+                  opacity: 0.9,
                 ),
               )
             : CachedImageWidget(imagePath: imagePath!, fit: BoxFit.cover),

--- a/lib/features/recently_added/screens/recently_added_screen.dart
+++ b/lib/features/recently_added/screens/recently_added_screen.dart
@@ -13,6 +13,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 
 /// Number of songs fetched per page.
@@ -660,11 +661,10 @@ class _RecentlyAddedTileState extends State<_RecentlyAddedTile>
   }
 
   Widget _buildPlaceholder(BuildContext context) {
-    return Center(
-      child: Icon(
-        LucideIcons.music,
-        size: context.responsiveIcon(AppConstants.iconSizeLg),
-        color: context.adaptiveTextTertiary.withValues(alpha: 0.5),
+    return Container(
+      color: AppColors.surfaceLight,
+      child: const Center(
+        child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
       ),
     );
   }

--- a/lib/features/recently_played/screens/recently_played_screen.dart
+++ b/lib/features/recently_played/screens/recently_played_screen.dart
@@ -13,6 +13,7 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/glass_dialog.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 
@@ -704,11 +705,10 @@ class _RecentlyPlayedTileState extends State<_RecentlyPlayedTile>
   }
 
   Widget _buildPlaceholder(BuildContext context) {
-    return Center(
-      child: Icon(
-        LucideIcons.music,
-        size: context.responsiveIcon(AppConstants.iconSizeLg),
-        color: context.adaptiveTextTertiary.withValues(alpha: 0.5),
+    return Container(
+      color: AppColors.surfaceLight,
+      child: const Center(
+        child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
       ),
     );
   }

--- a/lib/features/search/screens/search_screen.dart
+++ b/lib/features/search/screens/search_screen.dart
@@ -8,6 +8,7 @@ import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/features/songs/widgets/song_actions_bottom_sheet.dart';
 import 'package:flick/models/nav_bar_config.dart';
 import 'package:flick/providers/providers.dart';
@@ -228,19 +229,11 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
                   thumbnailHeight: 96,
                   placeholder: const ColoredBox(
                     color: AppColors.surface,
-                    child: Icon(
-                      LucideIcons.music,
-                      color: AppColors.textTertiary,
-                      size: 18,
-                    ),
+                    child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                   ),
                   errorWidget: const ColoredBox(
                     color: AppColors.surface,
-                    child: Icon(
-                      LucideIcons.music,
-                      color: AppColors.textTertiary,
-                      size: 18,
-                    ),
+                    child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                   ),
                 ),
               ),

--- a/lib/features/settings/screens/app_info_settings_screen.dart
+++ b/lib/features/settings/screens/app_info_settings_screen.dart
@@ -384,7 +384,9 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
                         color: context.adaptiveTextTertiary,
                         fontStyle: FontStyle.italic,
                       ),
-                      tableBorder: TableBorder.all(color: AppColors.glassBorder),
+                      tableBorder: TableBorder.all(
+                        color: AppColors.glassBorder,
+                      ),
                       tableHead: const TextStyle(fontWeight: FontWeight.w700),
                     ),
                     selectable: true,
@@ -480,9 +482,8 @@ class _AppInfoSettingsScreenState extends ConsumerState<AppInfoSettingsScreen>
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton.icon(
-                onPressed: () => _launchUrl(
-                  'https://github.com/moss-apps/Flick',
-                ),
+                onPressed: () =>
+                    _launchUrl('https://github.com/moss-apps/Flick'),
                 icon: const Icon(LucideIcons.squareCode, size: 18),
                 label: const Text(
                   'GitHub',

--- a/lib/features/settings/screens/player_layout_settings_screen.dart
+++ b/lib/features/settings/screens/player_layout_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 String _placementLabel(double value) {
   if (value == 0) return 'Center';
@@ -893,10 +894,8 @@ class _AlbumArtThumb extends StatelessWidget {
                 colors: [Color(0xFF4B3D7A), Color(0xFF111111)],
               ),
             ),
-            child: const Icon(
-              Icons.music_note_rounded,
-              color: Color(0xFF555555),
-              size: 32,
+            child: const Center(
+              child: FlickArtworkPlaceholder(size: 36, opacity: 0.9),
             ),
           ),
           errorWidget: Container(
@@ -907,10 +906,8 @@ class _AlbumArtThumb extends StatelessWidget {
                 colors: [Color(0xFF4B3D7A), Color(0xFF111111)],
               ),
             ),
-            child: const Icon(
-              Icons.music_note_rounded,
-              color: Color(0xFF555555),
-              size: 32,
+            child: const Center(
+              child: FlickArtworkPlaceholder(size: 36, opacity: 0.9),
             ),
           ),
         ),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -17,6 +17,7 @@ import 'package:flick/features/settings/screens/network_sources_screen.dart';
 import 'package:flick/features/settings/screens/player_layout_settings_screen.dart';
 import 'package:flick/features/settings/screens/widget_settings_screen.dart';
 import 'package:flick/features/settings/screens/support_flick_screen.dart';
+import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 import 'package:flick/features/milestone/screens/milestones_screen.dart';
 import 'package:flick/features/manual/screens/manual_screen.dart';
@@ -318,7 +319,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           IconButton(
             onPressed: () {
-              Navigator.of(context).push(
+              NavigationHelper.pushOnRoot(
+                context,
                 MaterialPageRoute<void>(
                   builder: (_) => const SupportFlickScreen(),
                 ),
@@ -350,7 +352,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   void _navigate(BuildContext context, Widget screen) {
-    Navigator.of(context).push(MaterialPageRoute<void>(builder: (_) => screen));
+    NavigationHelper.pushOnRoot(
+      context,
+      MaterialPageRoute<void>(builder: (_) => screen),
+    );
   }
 }
 

--- a/lib/features/settings/screens/widgets/autoeq_search_sheet.dart
+++ b/lib/features/settings/screens/widgets/autoeq_search_sheet.dart
@@ -10,6 +10,7 @@ import 'package:flick/widgets/common/glass_bottom_sheet.dart';
 /// dismissed. The caller applies the result to the equalizer.
 Future<AutoEqEntry?> showAutoEqSearchSheet(BuildContext context) {
   return showModalBottomSheet<AutoEqEntry>(
+      useRootNavigator: true,
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,

--- a/lib/features/settings/widgets/lastfm_settings_tile.dart
+++ b/lib/features/settings/widgets/lastfm_settings_tile.dart
@@ -106,6 +106,7 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
   Future<void> _disconnect() async {
     final confirmed = await showModalBottomSheet<bool>(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (ctx) => Container(
@@ -289,6 +290,7 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
     try {
       await showModalBottomSheet(
+      useRootNavigator: true,
         context: context,
         isScrollControlled: true,
         backgroundColor: Colors.transparent,
@@ -777,6 +779,7 @@ class _LastFmSettingsTileState extends ConsumerState<LastFmSettingsTile>
 
   Future<void> _showConnectedBottomSheet(String username) async {
     await showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (ctx) => Container(

--- a/lib/features/settings/widgets/listenbrainz_settings_tile.dart
+++ b/lib/features/settings/widgets/listenbrainz_settings_tile.dart
@@ -30,6 +30,7 @@ class _ListenBrainzSettingsTileState
     if (!mounted) return;
 
     await showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -47,6 +48,7 @@ class _ListenBrainzSettingsTileState
 
   Future<void> _disconnect() async {
     final confirmed = await showModalBottomSheet<bool>(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (ctx) => Container(
@@ -210,6 +212,7 @@ class _ListenBrainzSettingsTileState
 
   Future<void> _showConnectedBottomSheet(String username) async {
     await showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       builder: (ctx) => Container(

--- a/lib/features/songs/screens/metadata_editor_screen.dart
+++ b/lib/features/songs/screens/metadata_editor_screen.dart
@@ -5,10 +5,19 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/metadata_editor_service.dart';
+import 'package:flick/services/player_service.dart';
 import 'package:flick/src/rust/api/metadata_editor.dart' as rust_metadata;
 import 'package:flick/providers/providers.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
+/// Deprecated: use [MetadataEditorBottomSheet] (`lib/features/songs/widgets/metadata_editor_bottom_sheet.dart:12`).
+///
+/// Kept temporarily for backward compatibility; will be deleted once the
+/// bottom-sheet rollout is confirmed. New code should call
+/// `MetadataEditorBottomSheet.show(context, song)`.
+@Deprecated(
+  'Use MetadataEditorBottomSheet.show instead – full-screen editor will be removed',
+)
 class MetadataEditorScreen extends ConsumerStatefulWidget {
   final Song song;
 
@@ -155,6 +164,20 @@ class _MetadataEditorScreenState extends ConsumerState<MetadataEditorScreen> {
 
     if (result.saved) {
       final messenger = ScaffoldMessenger.of(context);
+      final path = widget.song.filePath;
+      if (path != null && path.isNotEmpty) {
+        PlayerService().syncSongMetadata(
+          filePath: path,
+          title: fields.title,
+          artist: fields.artist,
+          album: fields.album,
+          albumArtist: fields.albumArtist,
+          genre: fields.genre,
+          year: fields.year,
+          trackNumber: fields.trackNumber,
+          discNumber: fields.discNumber,
+        );
+      }
       ref.invalidate(songsProvider);
       Navigator.of(context).pop(true);
       if (result.verified) {

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -29,6 +29,7 @@ import 'package:flick/models/nav_bar_config.dart';
 import 'package:flick/widgets/common/glass_search_bar.dart';
 import 'package:flick/widgets/common/display_mode_wrapper.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/glass_bottom_sheet.dart';
 import 'package:flick/widgets/common/surface_icon_button.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -2227,19 +2228,11 @@ class _SongListTile extends StatelessWidget {
                     thumbnailHeight: 92,
                     placeholder: const ColoredBox(
                       color: AppColors.surface,
-                      child: Icon(
-                        LucideIcons.music,
-                        color: AppColors.textTertiary,
-                        size: 18,
-                      ),
+                      child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                     ),
                     errorWidget: const ColoredBox(
                       color: AppColors.surface,
-                      child: Icon(
-                        LucideIcons.music,
-                        color: AppColors.textTertiary,
-                        size: 18,
-                      ),
+                      child: FlickArtworkPlaceholder(size: 22, opacity: 0.9),
                     ),
                   ),
                 ),

--- a/lib/features/songs/screens/songs_screen.dart
+++ b/lib/features/songs/screens/songs_screen.dart
@@ -1361,6 +1361,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
     if (songs.isEmpty || !mounted) return;
 
     await showModalBottomSheet<void>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -1545,6 +1546,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
     if (!mounted) return;
 
     await showModalBottomSheet<void>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -2052,6 +2054,7 @@ class _SongsScreenState extends ConsumerState<SongsScreen>
     SongFileTypeFilter currentFilter,
   ) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
+++ b/lib/features/songs/widgets/album_art_picker_bottom_sheet.dart
@@ -21,6 +21,7 @@ class AlbumArtPickerBottomSheet extends StatefulWidget {
   static Future<bool> show(BuildContext context, Song song) async {
     final messenger = ScaffoldMessenger.maybeOf(context);
     final result = await showModalBottomSheet<_AlbumArtSheetResult>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/songs/widgets/metadata_editor_bottom_sheet.dart
+++ b/lib/features/songs/widgets/metadata_editor_bottom_sheet.dart
@@ -1,0 +1,654 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/models/song.dart';
+import 'package:flick/providers/providers.dart';
+import 'package:flick/services/metadata_editor_service.dart';
+import 'package:flick/services/player_service.dart';
+import 'package:flick/src/rust/api/metadata_editor.dart' as rust_metadata;
+import 'package:flick/widgets/common/glass_bottom_sheet.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+class _MetadataEditorSheetResult {
+  const _MetadataEditorSheetResult({
+    required this.saved,
+    required this.verified,
+    this.message,
+  });
+
+  final bool saved;
+  final bool verified;
+  final String? message;
+}
+
+class MetadataEditorBottomSheet extends ConsumerStatefulWidget {
+  final Song song;
+
+  const MetadataEditorBottomSheet({super.key, required this.song});
+
+  static Future<bool> show(BuildContext context, Song song) async {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final result = await showModalBottomSheet<_MetadataEditorSheetResult>(
+      useRootNavigator: true,
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(sheetContext).viewInsets.bottom,
+        ),
+        child: AppBottomSheetSurface(
+          maxHeightRatio: 0.85,
+          child: MetadataEditorBottomSheet(song: song),
+        ),
+      ),
+    );
+
+    final saved = result?.saved ?? false;
+    if (!context.mounted || messenger == null || result == null) {
+      return saved;
+    }
+
+    // ScaffoldMessenger after pop – per spec, show after sheet is dismissed
+    // using the caller's messenger so it survives the sheet's context disposal.
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            result.verified
+                ? 'Saved and verified'
+                : (result.message ?? 'Saved (verification pending)'),
+          ),
+          behavior: SnackBarBehavior.floating,
+          duration: Duration(seconds: result.verified ? 2 : 4),
+        ),
+      );
+    return saved;
+  }
+
+  @override
+  ConsumerState<MetadataEditorBottomSheet> createState() =>
+      _MetadataEditorBottomSheetState();
+}
+
+class _MetadataEditorBottomSheetState
+    extends ConsumerState<MetadataEditorBottomSheet> {
+  late TextEditingController _titleController;
+  late TextEditingController _artistController;
+  late TextEditingController _albumController;
+  late TextEditingController _albumArtistController;
+  late TextEditingController _genreController;
+  late TextEditingController _yearController;
+  late TextEditingController _trackNumberController;
+  late TextEditingController _discNumberController;
+
+  late FocusNode _titleFocus;
+  bool _isSaving = false;
+  String? _error;
+
+  bool get _isEditable =>
+      widget.song.filePath != null &&
+      widget.song.startOffsetMs == null &&
+      !widget.song.isExternal;
+
+  @override
+  void initState() {
+    super.initState();
+    final s = widget.song;
+    _titleController = TextEditingController(text: s.title);
+    _artistController = TextEditingController(text: s.artist);
+    _albumController = TextEditingController(text: s.album ?? '');
+    _albumArtistController =
+        TextEditingController(text: s.albumArtist ?? '');
+    _genreController = TextEditingController(text: s.genre ?? '');
+    _yearController =
+        TextEditingController(text: s.year?.toString() ?? '');
+    _trackNumberController =
+        TextEditingController(text: s.trackNumber?.toString() ?? '');
+    _discNumberController =
+        TextEditingController(text: s.discNumber?.toString() ?? '');
+
+    _titleFocus = FocusNode();
+
+    for (final c in [
+      _titleController,
+      _artistController,
+      _albumController,
+      _albumArtistController,
+      _genreController,
+      _yearController,
+      _trackNumberController,
+      _discNumberController,
+    ]) {
+      c.addListener(() {
+        if (mounted) setState(() {});
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _artistController.dispose();
+    _albumController.dispose();
+    _albumArtistController.dispose();
+    _genreController.dispose();
+    _yearController.dispose();
+    _trackNumberController.dispose();
+    _discNumberController.dispose();
+    _titleFocus.dispose();
+    super.dispose();
+  }
+
+  bool get _hasChanges {
+    final s = widget.song;
+    return _titleController.text != s.title ||
+        _artistController.text != s.artist ||
+        _albumController.text != (s.album ?? '') ||
+        _albumArtistController.text != (s.albumArtist ?? '') ||
+        _genreController.text != (s.genre ?? '') ||
+        _yearController.text != (s.year?.toString() ?? '') ||
+        _trackNumberController.text != (s.trackNumber?.toString() ?? '') ||
+        _discNumberController.text != (s.discNumber?.toString() ?? '');
+  }
+
+  String? _yearError() {
+    final t = _yearController.text.trim();
+    if (t.isEmpty) return null;
+    final n = int.tryParse(t);
+    if (n == null || n < 1 || n > 9999) return 'Enter a year (1–9999)';
+    return null;
+  }
+
+  String? _trackError() =>
+      _positiveIntError(_trackNumberController, 'track');
+  String? _discError() =>
+      _positiveIntError(_discNumberController, 'disc');
+
+  String? _positiveIntError(TextEditingController c, String label) {
+    final t = c.text.trim();
+    if (t.isEmpty) return null;
+    final n = int.tryParse(t);
+    if (n == null || n < 0) return 'Enter a valid $label number';
+    return null;
+  }
+
+  bool get _hasInvalidFields =>
+      _yearError() != null || _trackError() != null || _discError() != null;
+
+  Future<void> _save() async {
+    if (!_hasChanges || _isSaving || _hasInvalidFields) return;
+    if (!_isEditable) return;
+    setState(() {
+      _isSaving = true;
+      _error = null;
+    });
+
+    final fields = rust_metadata.TagEditFields(
+      title: _titleController.text.trim().isNotEmpty
+          ? _titleController.text.trim()
+          : null,
+      artist: _artistController.text.trim().isNotEmpty
+          ? _artistController.text.trim()
+          : null,
+      album: _albumController.text.trim().isNotEmpty
+          ? _albumController.text.trim()
+          : null,
+      albumArtist: _albumArtistController.text.trim().isNotEmpty
+          ? _albumArtistController.text.trim()
+          : null,
+      genre: _genreController.text.trim().isNotEmpty
+          ? _genreController.text.trim()
+          : null,
+      year: int.tryParse(_yearController.text.trim()),
+      trackNumber: int.tryParse(_trackNumberController.text.trim()),
+      discNumber: int.tryParse(_discNumberController.text.trim()),
+    );
+
+    final result =
+        await MetadataEditorService.instance.writeTags(widget.song, fields);
+
+    if (!mounted) return;
+
+    if (result.saved) {
+      final path = widget.song.filePath;
+      if (path != null && path.isNotEmpty) {
+        // Immediate in-memory mirror so mini/full player, queue and notification
+        // update without waiting for DB watch or track change.
+        PlayerService().syncSongMetadata(
+          filePath: path,
+          title: fields.title,
+          artist: fields.artist,
+          album: fields.album,
+          albumArtist: fields.albumArtist,
+          genre: fields.genre,
+          year: fields.year,
+          trackNumber: fields.trackNumber,
+          discNumber: fields.discNumber,
+        );
+      }
+      ref.invalidate(songsProvider);
+
+      final verified = result.verified;
+      final message = verified ? null : result.message;
+      if (!mounted) return;
+      // Pop with result; static show() will handle ScaffoldMessenger after pop.
+      Navigator.of(context).pop(
+        _MetadataEditorSheetResult(
+          saved: true,
+          verified: verified,
+          message: message,
+        ),
+      );
+    } else {
+      setState(() {
+        _isSaving = false;
+        _error = result.message ?? 'Failed to save metadata.';
+      });
+    }
+  }
+
+  void _handleClose() {
+    if (_isSaving) return;
+    if (_hasChanges) {
+      _showDiscardDialog(context);
+    } else {
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = context.adaptiveTextPrimary;
+    final canSave =
+        _isEditable && _hasChanges && !_isSaving && !_hasInvalidFields;
+
+    // PopScope to intercept system back / drag dismiss when there are changes.
+    // Header (drag handle + "Edit Metadata" + X) is kept outside the scroll
+    // view so it persists while the form fields scroll underneath.
+    return PopScope(
+      canPop: !_isSaving && !_hasChanges,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && _hasChanges && !_isSaving) {
+          _showDiscardDialog(context);
+        }
+      },
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildDragHandle(),
+          const SizedBox(height: AppConstants.spacingMd),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Edit Metadata',
+                  style: TextStyle(
+                    fontFamily: 'ProductSans',
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                    color: accent,
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: _isSaving ? null : _handleClose,
+                child: Container(
+                  padding: const EdgeInsets.all(AppConstants.spacingXs),
+                  decoration: BoxDecoration(
+                    color: AppColors.surfaceLight,
+                    borderRadius:
+                        BorderRadius.circular(AppConstants.radiusMd),
+                    border: Border.all(color: AppColors.glassBorder),
+                  ),
+                  child: const Icon(
+                    LucideIcons.x,
+                    color: AppColors.textSecondary,
+                    size: 16,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingMd),
+          Flexible(
+            fit: FlexFit.loose,
+            child: SingleChildScrollView(
+              keyboardDismissBehavior:
+                  ScrollViewKeyboardDismissBehavior.onDrag,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (!_isEditable) ...[
+                    _buildLockBanner(context),
+                    const SizedBox(height: AppConstants.spacingLg),
+                  ],
+                  if (_error != null) ...[
+                    _buildErrorBanner(context),
+                    const SizedBox(height: AppConstants.spacingMd),
+                  ],
+                  _buildField(context, 'Title', _titleController,
+                      focusNode: _titleFocus,
+                      enabled: _isEditable && !_isSaving),
+                  _buildField(context, 'Artist', _artistController,
+                      enabled: _isEditable && !_isSaving),
+                  _buildField(context, 'Album', _albumController,
+                      enabled: _isEditable && !_isSaving),
+                  _buildField(context, 'Album Artist',
+                      _albumArtistController,
+                      enabled: _isEditable && !_isSaving),
+                  _buildField(context, 'Genre', _genreController,
+                      enabled: _isEditable && !_isSaving),
+                  _buildField(context, 'Year', _yearController,
+                      enabled: _isEditable && !_isSaving,
+                      keyboardType: TextInputType.number,
+                      errorText: _yearError()),
+                  _buildField(context, 'Track #', _trackNumberController,
+                      enabled: _isEditable && !_isSaving,
+                      keyboardType: TextInputType.number,
+                      errorText: _trackError()),
+                  _buildField(context, 'Disc #', _discNumberController,
+                      enabled: _isEditable && !_isSaving,
+                      keyboardType: TextInputType.number,
+                      errorText: _discError()),
+                  const SizedBox(height: AppConstants.spacingLg),
+                  _buildReadOnlyInfo(context),
+                  const SizedBox(height: AppConstants.spacingSm),
+                ],
+              ),
+            ),
+          ),
+          if (_isEditable) ...[
+            const SizedBox(height: AppConstants.spacingMd),
+            _buildSaveButton(context, canSave),
+            const SizedBox(height: AppConstants.spacingSm),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDragHandle() {
+    return Center(
+      child: Container(
+        width: 40,
+        height: 4,
+        decoration: BoxDecoration(
+          color: AppColors.glassBorderStrong,
+          borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLockBanner(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceLight,
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+        border: Border.all(color: AppColors.glassBorder),
+      ),
+      child: Row(
+        children: [
+          Icon(LucideIcons.lock, size: 16, color: AppColors.textTertiary),
+          const SizedBox(width: AppConstants.spacingSm),
+          Expanded(
+            child: Text(
+              widget.song.isExternal
+                  ? 'External songs cannot be edited'
+                  : 'CUE sheet tracks cannot be edited',
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 13,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorBanner(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppConstants.spacingMd),
+      decoration: BoxDecoration(
+        color: Colors.redAccent.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+      ),
+      child: Row(
+        children: [
+          Icon(LucideIcons.circleAlert, size: 16, color: Colors.redAccent),
+          const SizedBox(width: AppConstants.spacingSm),
+          Expanded(
+            child: Text(
+              _error!,
+              style: const TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 13,
+                color: Colors.redAccent,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildField(
+    BuildContext context,
+    String label,
+    TextEditingController controller, {
+    FocusNode? focusNode,
+    bool enabled = true,
+    TextInputType keyboardType = TextInputType.text,
+    String? errorText,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppConstants.spacingMd),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: context.adaptiveTextSecondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          TextField(
+            controller: controller,
+            focusNode: focusNode,
+            enabled: enabled,
+            keyboardType: keyboardType,
+            textInputAction: label == 'Title' ? TextInputAction.next : null,
+            style: TextStyle(
+              fontFamily: 'ProductSans',
+              fontSize: 15,
+              color: enabled
+                  ? context.adaptiveTextPrimary
+                  : AppColors.textTertiary,
+            ),
+            decoration: InputDecoration(
+              filled: true,
+              fillColor: enabled
+                  ? AppColors.surfaceLight
+                  : AppColors.surfaceLight.withValues(alpha: 0.5),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppConstants.spacingMd,
+                vertical: AppConstants.spacingSm + 2,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                borderSide: BorderSide.none,
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                borderSide: BorderSide(color: AppColors.accent, width: 1.5),
+              ),
+              disabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                borderSide: BorderSide(color: AppColors.glassBorder),
+              ),
+              errorText: errorText,
+              errorBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                borderSide: BorderSide(color: Colors.redAccent, width: 1.2),
+              ),
+              focusedErrorBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+                borderSide: BorderSide(color: Colors.redAccent, width: 1.5),
+              ),
+              errorStyle: const TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 11,
+                color: Colors.redAccent,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildReadOnlyInfo(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Divider(height: 1, color: AppColors.glassBorderStrong),
+        const SizedBox(height: AppConstants.spacingLg),
+        Text(
+          'File Information',
+          style: TextStyle(
+            fontFamily: 'ProductSans',
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: context.adaptiveTextSecondary,
+          ),
+        ),
+        const SizedBox(height: AppConstants.spacingSm),
+        _buildInfoRow(context, 'Duration', widget.song.formattedDuration),
+        _buildInfoRow(
+            context, 'Format', widget.song.fileType.toUpperCase()),
+        if (widget.song.resolution != null)
+          _buildInfoRow(context, 'Resolution', widget.song.resolution!),
+        if (widget.song.filePath != null)
+          _buildInfoRow(context, 'File Path', widget.song.filePath!),
+      ],
+    );
+  }
+
+  Widget _buildInfoRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 96,
+            child: Text(
+              label,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: context.adaptiveTextSecondary,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(
+                fontFamily: 'ProductSans',
+                fontSize: 13,
+                color: context.adaptiveTextPrimary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSaveButton(BuildContext context, bool canSave) {
+    return SizedBox(
+      width: double.infinity,
+      height: 48,
+      child: FilledButton(
+        onPressed: canSave ? _save : null,
+        style: FilledButton.styleFrom(
+          backgroundColor: AppColors.accent,
+          disabledBackgroundColor:
+              AppColors.surfaceLight.withValues(alpha: 0.6),
+          foregroundColor: AppColors.background,
+          disabledForegroundColor: AppColors.textTertiary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppConstants.radiusMd),
+          ),
+          padding: EdgeInsets.zero,
+        ),
+        child: _isSaving
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.5,
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(AppColors.background),
+                ),
+              )
+            : Text(
+                'Save Changes',
+                style: TextStyle(
+                  fontFamily: 'ProductSans',
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+      ),
+    );
+  }
+
+  void _showDiscardDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppColors.surfaceLight,
+        title: Text('Discard Changes?',
+            style: TextStyle(
+                fontFamily: 'ProductSans',
+                color: context.adaptiveTextPrimary)),
+        content: Text(
+          'You have unsaved changes. Are you sure you want to discard them?',
+          style: TextStyle(
+              fontFamily: 'ProductSans',
+              color: context.adaptiveTextSecondary),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              Navigator.of(context).pop();
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.redAccent),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -6,9 +6,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/core/utils/navigation_helper.dart';
-import 'package:flick/features/songs/screens/metadata_editor_screen.dart';
 import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart';
+import 'package:flick/features/songs/widgets/metadata_editor_bottom_sheet.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/services/music_folder_service.dart';
@@ -141,13 +141,12 @@ class SongActionsBottomSheet extends ConsumerWidget {
               label: 'Edit Metadata',
               onTap: () {
                 Navigator.pop(context);
-                NavigationHelper.pushOnRoot<bool>(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => MetadataEditorScreen(song: song),
-                  ),
-                ).then((saved) {
-                  if (saved == true && rootContext.mounted) {
+                Future.delayed(Duration.zero, () async {
+                  final saved = await MetadataEditorBottomSheet.show(
+                    rootContext,
+                    song,
+                  );
+                  if (saved && rootContext.mounted) {
                     ref.invalidate(songsProvider);
                   }
                 });
@@ -218,19 +217,11 @@ class SongActionsBottomSheet extends ConsumerWidget {
               thumbnailHeight: 136,
               placeholder: const ColoredBox(
                 color: AppColors.surfaceLight,
-                child: Icon(
-                  LucideIcons.music,
-                  color: AppColors.textTertiary,
-                  size: 24,
-                ),
+                child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
               ),
               errorWidget: const ColoredBox(
                 color: AppColors.surfaceLight,
-                child: Icon(
-                  LucideIcons.music,
-                  color: AppColors.textTertiary,
-                  size: 24,
-                ),
+                child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
               ),
             ),
           ),

--- a/lib/features/songs/widgets/song_actions_bottom_sheet.dart
+++ b/lib/features/songs/widgets/song_actions_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/features/songs/screens/metadata_editor_screen.dart';
 import 'package:flick/features/songs/widgets/album_art_picker_bottom_sheet.dart';
 import 'package:flick/models/song.dart';
@@ -37,6 +38,7 @@ class SongActionsBottomSheet extends ConsumerWidget {
     VoidCallback? onSelect,
   }) {
     return showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -139,7 +141,8 @@ class SongActionsBottomSheet extends ConsumerWidget {
               label: 'Edit Metadata',
               onTap: () {
                 Navigator.pop(context);
-                Navigator.of(context).push<bool>(
+                NavigationHelper.pushOnRoot<bool>(
+                  context,
                   MaterialPageRoute(
                     builder: (_) => MetadataEditorScreen(song: song),
                   ),
@@ -355,6 +358,7 @@ class SongActionsBottomSheet extends ConsumerWidget {
 
   void _showAddToPlaylistSheet(BuildContext context) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -570,6 +574,7 @@ class SongActionsBottomSheet extends ConsumerWidget {
 
   void _showMetadataSheet(BuildContext context) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -7,6 +7,7 @@ import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/widgets/common/marquee_widget.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 /// Song card widget for displaying in the orbit scroll.
 class SongCard extends StatefulWidget {
@@ -388,11 +389,7 @@ class _SongCardState extends State<SongCard> {
         ),
       ),
       child: const Center(
-        child: Icon(
-          Icons.music_note_rounded,
-          color: AppColors.textTertiary,
-          size: 28,
-        ),
+        child: FlickArtworkPlaceholder(size: 36, opacity: 0.9),
       ),
     );
   }

--- a/lib/features/songs/widgets/sort_filter_bottom_sheet.dart
+++ b/lib/features/songs/widgets/sort_filter_bottom_sheet.dart
@@ -26,6 +26,7 @@ class SortFilterBottomSheet extends StatelessWidget {
     required ValueChanged<SongFileTypeFilter> onFilterChanged,
   }) {
     showModalBottomSheet(
+      useRootNavigator: true,
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -1159,6 +1159,10 @@ class PlayerService {
       resolution: song.resolution,
       sampleRate: song.sampleRate,
       bitDepth: song.bitDepth,
+      replaygainTrackGain: song.replaygainTrackGain,
+      replaygainTrackPeak: song.replaygainTrackPeak,
+      replaygainAlbumGain: song.replaygainAlbumGain,
+      replaygainAlbumPeak: song.replaygainAlbumPeak,
       startOffsetMs: song.startOffsetMs,
       endOffsetMs: song.endOffsetMs,
       ripper: song.ripper,
@@ -1170,13 +1174,150 @@ class PlayerService {
       albumArtist: song.albumArtist,
       trackNumber: song.trackNumber,
       discNumber: song.discNumber,
+      year: song.year,
+      genre: song.genre,
       filePath: song.filePath,
       folderUri: song.folderUri,
       dateAdded: song.dateAdded,
+      isExternal: song.isExternal,
+      sourcePackage: song.sourcePackage,
       sourceType: song.sourceType,
       remoteId: song.remoteId,
       remoteServerId: song.remoteServerId,
     );
+  }
+
+  /// Immediately reflects edited metadata in the in-memory playback state so
+  /// the UI (mini/full player, notification, queue) updates without waiting
+  /// for a DB watch tick or a track change.
+  ///
+  /// Fields with `null` mean “unchanged” (mirrors `SongRepository.updateSongMetadata`
+  /// and `MetadataEditorService` semantics). Only `filePath`-matched songs are patched.
+  void syncSongMetadata({
+    required String filePath,
+    String? title,
+    String? artist,
+    String? album,
+    String? albumArtist,
+    String? genre,
+    int? year,
+    int? trackNumber,
+    int? discNumber,
+  }) {
+    if (filePath.isEmpty) return;
+    final hasChange =
+        title != null ||
+        artist != null ||
+        album != null ||
+        albumArtist != null ||
+        genre != null ||
+        year != null ||
+        trackNumber != null ||
+        discNumber != null;
+    if (!hasChange) return;
+
+    Song syncSong(Song song) {
+      if (song.filePath != filePath) return song;
+      // Detect if anything would actually change.
+      final nextTitle = title ?? song.title;
+      final nextArtist = artist ?? song.artist;
+      final nextAlbum = album ?? song.album;
+      final nextAlbumArtist = albumArtist ?? song.albumArtist;
+      final nextGenre = genre ?? song.genre;
+      final nextYear = year ?? song.year;
+      final nextTrack = trackNumber ?? song.trackNumber;
+      final nextDisc = discNumber ?? song.discNumber;
+      if (nextTitle == song.title &&
+          nextArtist == song.artist &&
+          nextAlbum == song.album &&
+          nextAlbumArtist == song.albumArtist &&
+          nextGenre == song.genre &&
+          nextYear == song.year &&
+          nextTrack == song.trackNumber &&
+          nextDisc == song.discNumber) {
+        return song;
+      }
+      return Song(
+        id: song.id,
+        title: nextTitle,
+        artist: nextArtist,
+        albumArt: song.albumArt,
+        duration: song.duration,
+        fileType: song.fileType,
+        resolution: song.resolution,
+        sampleRate: song.sampleRate,
+        bitDepth: song.bitDepth,
+        replaygainTrackGain: song.replaygainTrackGain,
+        replaygainTrackPeak: song.replaygainTrackPeak,
+        replaygainAlbumGain: song.replaygainAlbumGain,
+        replaygainAlbumPeak: song.replaygainAlbumPeak,
+        startOffsetMs: song.startOffsetMs,
+        endOffsetMs: song.endOffsetMs,
+        ripper: song.ripper,
+        readMode: song.readMode,
+        accurateRip: song.accurateRip,
+        testCrc: song.testCrc,
+        copyCrc: song.copyCrc,
+        album: nextAlbum,
+        albumArtist: nextAlbumArtist,
+        trackNumber: nextTrack,
+        discNumber: nextDisc,
+        year: nextYear,
+        genre: nextGenre,
+        filePath: song.filePath,
+        folderUri: song.folderUri,
+        dateAdded: song.dateAdded,
+        isExternal: song.isExternal,
+        sourcePackage: song.sourcePackage,
+        sourceType: song.sourceType,
+        remoteId: song.remoteId,
+        remoteServerId: song.remoteServerId,
+      );
+    }
+
+    var queueChanged = false;
+
+    for (var i = 0; i < _playlist.length; i++) {
+      final updated = syncSong(_playlist[i]);
+      if (!identical(updated, _playlist[i])) {
+        _playlist[i] = updated;
+      }
+    }
+
+    for (var i = 0; i < _originalPlaylist.length; i++) {
+      final updated = syncSong(_originalPlaylist[i]);
+      if (!identical(updated, _originalPlaylist[i])) {
+        _originalPlaylist[i] = updated;
+      }
+    }
+
+    for (var i = 0; i < _queuedEntries.length; i++) {
+      final entry = _queuedEntries[i];
+      final updatedSong = syncSong(entry.song);
+      if (!identical(updatedSong, entry.song)) {
+        _queuedEntries[i] = _QueueEntry(id: entry.id, song: updatedSong);
+        queueChanged = true;
+      }
+    }
+
+    var currentSongUpdated = false;
+    final currentSong = currentSongNotifier.value;
+    if (currentSong != null) {
+      final updatedCurrentSong = syncSong(currentSong);
+      if (!identical(updatedCurrentSong, currentSong)) {
+        currentSongNotifier.value = updatedCurrentSong;
+        currentSongUpdated = true;
+      }
+    }
+
+    if (queueChanged) {
+      _notifyQueueChanged();
+    }
+    _notifyUpNextChanged();
+
+    if (currentSongUpdated) {
+      _updateNotificationState();
+    }
   }
 
   void _insertQueuedEntriesAfterCurrent() {

--- a/lib/widgets/common/cached_image_widget.dart
+++ b/lib/widgets/common/cached_image_widget.dart
@@ -7,6 +7,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/artwork_gate.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 export 'package:flick/services/artwork_gate.dart';
 
@@ -68,11 +69,7 @@ class CachedImageWidget extends StatefulWidget {
         ),
       ),
       child: const Center(
-        child: Icon(
-          Icons.music_note_rounded,
-          color: AppColors.textTertiary,
-          size: 28,
-        ),
+        child: FlickArtworkPlaceholder(size: 42, opacity: 0.9),
       ),
     );
   }
@@ -85,8 +82,6 @@ class CachedImageWidget extends StatefulWidget {
   @override
   State<CachedImageWidget> createState() => _CachedImageWidgetState();
 }
-
-
 
 class _CachedImageWidgetState extends State<CachedImageWidget> {
   // ponytail: cache only confirmed-existing paths to keep fast-scroll stat()

--- a/lib/widgets/common/flick_artwork_placeholder.dart
+++ b/lib/widgets/common/flick_artwork_placeholder.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Centered Flick logo used when album art is missing.
+///
+/// Used as placeholder/errorWidget inside [CachedImageWidget] fallbacks.
+/// The SVG `assets/icons/flicklogo_svg.svg` is white `#F5F5F5` on
+/// transparent, so it is rendered on a dark surface and dimmed via
+/// [opacity] to match the previous `Icon(..., white 0.48)` look.
+class FlickArtworkPlaceholder extends StatelessWidget {
+  const FlickArtworkPlaceholder({
+    super.key,
+    this.size = 48,
+    this.opacity = 1.0,
+    this.color,
+  });
+
+  final double size;
+  final double opacity;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    // SVG viewBox is 606×734 (0.826 ratio). Constrain both axes so layout
+    // stays square and centered regardless of parent constraints.
+    final logo = SvgPicture.asset(
+      'assets/icons/flicklogo_svg.svg',
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      colorFilter: color != null
+          ? ColorFilter.mode(color!, BlendMode.srcIn)
+          : null,
+    );
+
+    if (opacity >= 1.0) {
+      return Center(child: logo);
+    }
+    return Center(
+      child: Opacity(opacity: opacity, child: logo),
+    );
+  }
+}

--- a/lib/widgets/common/floating_mini_player.dart
+++ b/lib/widgets/common/floating_mini_player.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/features/player/screens/full_player_screen.dart';
 import 'package:flick/features/player/widgets/audio_visualizer.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
 class FloatingMiniPlayer extends ConsumerStatefulWidget {
   const FloatingMiniPlayer({super.key});
@@ -90,7 +90,10 @@ class _FloatingMiniPlayerState extends ConsumerState<FloatingMiniPlayer>
             const begin = Offset(0.0, 1.0);
             const end = Offset.zero;
             const curve = Curves.easeOutCubic;
-            var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+            var tween = Tween(
+              begin: begin,
+              end: end,
+            ).chain(CurveTween(curve: curve));
             return SlideTransition(
               position: animation.drive(tween),
               child: child,
@@ -182,8 +185,7 @@ class _FloatingMiniPlayerState extends ConsumerState<FloatingMiniPlayer>
         screenSize.height - height - safeArea.bottom - safeArea.top - 16;
     final double absTop = safeArea.top + 8 + _offset.dy;
     final bool nearTop = absTop < screenSize.height * 0.25;
-    final bool nearBottom =
-        absTop > screenSize.height * 0.75 - safeArea.bottom;
+    final bool nearBottom = absTop > screenSize.height * 0.75 - safeArea.bottom;
     final bool flingVertical = velocity.dy.abs() > 400;
 
     double snapDy;
@@ -291,11 +293,27 @@ class _FloatingMiniPlayerState extends ConsumerState<FloatingMiniPlayer>
                                         useThumbnail: true,
                                         thumbnailWidth: 96,
                                         thumbnailHeight: 96,
+                                        placeholder: Container(
+                                          color: AppColors.surfaceDark,
+                                          child: const FlickArtworkPlaceholder(
+                                            size: 22,
+                                            opacity: 0.85,
+                                          ),
+                                        ),
+                                        errorWidget: Container(
+                                          color: AppColors.surfaceDark,
+                                          child: const FlickArtworkPlaceholder(
+                                            size: 22,
+                                            opacity: 0.85,
+                                          ),
+                                        ),
                                       )
-                                    : const Icon(
-                                        LucideIcons.music,
-                                        size: 16,
-                                        color: AppColors.textTertiary,
+                                    : Container(
+                                        color: AppColors.surfaceDark,
+                                        child: const FlickArtworkPlaceholder(
+                                          size: 20,
+                                          opacity: 0.88,
+                                        ),
                                       ),
                               ),
                             ),

--- a/lib/widgets/common/glass_bottom_sheet.dart
+++ b/lib/widgets/common/glass_bottom_sheet.dart
@@ -141,6 +141,7 @@ class GlassBottomSheet extends StatelessWidget {
     bool enableDrag = true,
   }) {
     return showModalBottomSheet<T>(
+      useRootNavigator: true,
       context: context,
       isScrollControlled: isScrollControlled,
       isDismissible: isDismissible,


### PR DESCRIPTION
# Summary

- Add `FlickArtworkPlaceholder` widget and replace all music note icon placeholders across the app
- Add song metadata editor bottom sheet with `syncSongMetadata` for live updates across queue, playlist, and current song
- Route full player and queue screens via root navigator to cover persistent bottom bar
- Add `useRootNavigator` to all `showModalBottomSheet` calls and enable it for glass bottom sheets

# Changes

## FlickArtworkPlaceholder

- Add `FlickArtworkPlaceholder` widget (43 lines) with Flick logo branding
- Replace music note icon placeholders across 20+ screens: player, queue, playlists, albums, artists, folders, favorites, search, menu, smart mix, listening recap, recently played/added, share cards, mini player, embedded mini player, and more
- Update widget default art drawable to use Flick logo

## Song Metadata Editor

- Add metadata editor bottom sheet (654 lines) replacing full-screen editor
- Add `syncSongMetadata` to `PlayerService` (141 lines) — updates in-memory playlist, queue, and current song on metadata edit
- Deprecate full-screen metadata editor screen

## Root Navigator Routing

- Add root navigator global key
- Route full player and queue via root navigator (covers persistent bottom bar)
- Add `pushOnRoot` helper for routes that must hide the bottom bar
- Enable root navigator for glass bottom sheets
- Add `useRootNavigator` to all `showModalBottomSheet` calls (30 files)

## Other

- Remove `FloatingMiniPlayer` from album, artist, playlist, and smart mix detail screens
- Format app info settings screen
- Add widget flick logo drawable for home screen widgets

## Files Changed

- `lib/widgets/common/flick_artwork_placeholder.dart`
- `lib/features/songs/widgets/metadata_editor_bottom_sheet.dart`
- `lib/services/player_service.dart`
- `lib/core/navigation/root_navigator.dart`
- `lib/core/utils/navigation_helper.dart`
- `lib/widgets/common/glass_bottom_sheet.dart`
- `lib/app/app.dart`
- `android/app/src/main/res/drawable/widget_flick_logo.xml`, `widget_default_art.xml`
- 20+ screens across `features/player`, `features/playlists`, `features/albums`, `features/artists`, `features/folders`, `features/favorites`, `features/search`, `features/menu`, `features/songs`, `features/settings`, `features/queue`, `features/recap`, `features/milestone`