### PR TITLE
Add glass blur back buttons, fix nested navigation, and auto-sync fresh Tidal servers

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -112,8 +112,6 @@ class _MainShellState extends ConsumerState<MainShell>
   Timer? _idleTimer;
   bool _isBottomBarCollapsed = false;
 
-  final GlobalKey<NavigatorState> _nestedNavigatorKey =
-      GlobalKey<NavigatorState>();
   static const double _kNestedBarClearance = 150.0;
 
   @override
@@ -686,7 +684,12 @@ class _MainShellState extends ConsumerState<MainShell>
 
   void _handleBackPress(bool didPop, dynamic result) {
     if (didPop) return;
-    if (_nestedNavigatorKey.currentState?.canPop() == true) {
+
+    // Back events only reach the root navigator; detail screens pushed on
+    // the nested tab navigator must be popped here manually.
+    final nested = nestedNavigatorKey.currentState;
+    if (nested != null && nested.canPop()) {
+      nested.pop();
       return;
     }
 
@@ -761,7 +764,7 @@ class _MainShellState extends ConsumerState<MainShell>
                       return MediaQuery(
                         data: inflated,
                         child: Navigator(
-                          key: _nestedNavigatorKey,
+                          key: nestedNavigatorKey,
                           initialRoute: '/',
                           onGenerateRoute: (settings) {
                             if (settings.name == '/') {
@@ -963,7 +966,7 @@ class _MainShellState extends ConsumerState<MainShell>
         config: navBarConfig,
         collapsed: collapsed,
         onTap: (index) {
-          final nested = _nestedNavigatorKey.currentState;
+          final nested = nestedNavigatorKey.currentState;
           if (nested != null && nested.canPop()) {
             nested.popUntil((route) => route.isFirst);
           }

--- a/lib/core/navigation/root_navigator.dart
+++ b/lib/core/navigation/root_navigator.dart
@@ -4,3 +4,8 @@ import 'package:flutter/material.dart';
 /// above the persistent bottom bar (i.e. the bar is hidden). The nested
 /// navigator inside [MainShell] keeps routes below the bar.
 final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
+
+/// Global key for the nested navigator inside [MainShell]. Pushing via this
+/// key keeps the persistent bottom bar visible.
+final GlobalKey<NavigatorState> nestedNavigatorKey =
+    GlobalKey<NavigatorState>();

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -637,12 +639,27 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen>
         Positioned(
           top: MediaQuery.of(context).padding.top + 20,
           left: 16,
-          child: IconButton(
-            icon: Icon(
-              LucideIcons.chevronLeft,
-              color: context.adaptiveTextPrimary,
+          child: ClipOval(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: AppConstants.glassBlurSigma,
+                sigmaY: AppConstants.glassBlurSigma,
+              ),
+              child: Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.glassBackgroundStrong,
+                  border: Border.all(color: AppColors.glassBorder),
+                ),
+                child: IconButton(
+                  icon: Icon(
+                    LucideIcons.chevronLeft,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
             ),
-            onPressed: () => Navigator.of(context).pop(),
           ),
         ),
         Positioned(

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
@@ -706,12 +708,27 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen>
         Positioned(
           top: MediaQuery.of(context).padding.top + 20,
           left: 16,
-          child: IconButton(
-            icon: Icon(
-              LucideIcons.chevronLeft,
-              color: context.adaptiveTextPrimary,
+          child: ClipOval(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: AppConstants.glassBlurSigma,
+                sigmaY: AppConstants.glassBlurSigma,
+              ),
+              child: Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.glassBackgroundStrong,
+                  border: Border.all(color: AppColors.glassBorder),
+                ),
+                child: IconButton(
+                  icon: Icon(
+                    LucideIcons.chevronLeft,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
             ),
-            onPressed: () => Navigator.of(context).pop(),
           ),
         ),
         Positioned(

--- a/lib/features/player/widgets/player_navigation.dart
+++ b/lib/features/player/widgets/player_navigation.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/navigation/root_navigator.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/albums/screens/album_detail_screen.dart';
@@ -56,17 +58,22 @@ class PlayerNavigation {
       return;
     }
 
-    await Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => ArtistDetailScreen(
-          artistName: artistName,
-          songs: artistSongs,
-          artistArt: _firstArt(artistSongs),
-          artistArtSourcePath: _firstSourcePath(artistSongs),
-          playerService: playerService,
-        ),
+    final route = MaterialPageRoute<void>(
+      builder: (_) => ArtistDetailScreen(
+        artistName: artistName,
+        songs: artistSongs,
+        artistArt: _firstArt(artistSongs),
+        artistArtSourcePath: _firstSourcePath(artistSongs),
+        playerService: playerService,
       ),
     );
+
+    if (_isFullPlayerContext(context)) {
+      await _popFullPlayerAndPushNested(context, route);
+      return;
+    }
+
+    await Navigator.of(context).push(route);
   }
 
   Future<void> openAlbumFromSong(BuildContext context, Song song) async {
@@ -80,21 +87,53 @@ class PlayerNavigation {
       return;
     }
 
-    await Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => AlbumDetailScreen(
-          albumName: albumGroup.albumName,
-          albumArtist: albumGroup.albumArtist,
-          songs: albumGroup.songs,
-          albumArt: _firstArt(albumGroup.songs),
-          albumArtSourcePath: _firstSourcePath(albumGroup.songs),
-          playerService: playerService,
-        ),
+    final route = MaterialPageRoute<void>(
+      builder: (_) => AlbumDetailScreen(
+        albumName: albumGroup.albumName,
+        albumArtist: albumGroup.albumArtist,
+        songs: albumGroup.songs,
+        albumArt: _firstArt(albumGroup.songs),
+        albumArtSourcePath: _firstSourcePath(albumGroup.songs),
+        playerService: playerService,
       ),
     );
+
+    if (_isFullPlayerContext(context)) {
+      await _popFullPlayerAndPushNested(context, route);
+      return;
+    }
+
+    await Navigator.of(context).push(route);
   }
 
+  bool _isFullPlayerContext(BuildContext context) {
+    if (NavigationHelper.isFullPlayerOpen) return true;
+    final route = ModalRoute.of(context);
+    return route?.settings.name == '/full_player';
   }
+
+  Future<void> _popFullPlayerAndPushNested(
+    BuildContext context,
+    Route<void> route,
+  ) async {
+    if (context.mounted) Navigator.of(context).pop();
+    final delay = AppConstants.animationNormal;
+    if (delay != Duration.zero) {
+      await Future.delayed(delay);
+    } else {
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+    final nested = nestedNavigatorKey.currentState;
+    if (nested != null) {
+      await nested.push(route);
+      return;
+    }
+    final root = rootNavigatorKey.currentState;
+    if (root != null) {
+      await root.push(route);
+    }
+  }
+}
 
 String? _firstArt(List<Song> songs) {
   for (final item in songs) {

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -720,12 +721,27 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen>
         Positioned(
           top: MediaQuery.of(context).padding.top + 20,
           left: 16,
-          child: IconButton(
-            icon: Icon(
-              LucideIcons.chevronLeft,
-              color: context.adaptiveTextPrimary,
+          child: ClipOval(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: AppConstants.glassBlurSigma,
+                sigmaY: AppConstants.glassBlurSigma,
+              ),
+              child: Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.glassBackgroundStrong,
+                  border: Border.all(color: AppColors.glassBorder),
+                ),
+                child: IconButton(
+                  icon: Icon(
+                    LucideIcons.chevronLeft,
+                    color: context.adaptiveTextPrimary,
+                  ),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
             ),
-            onPressed: () => Navigator.of(context).pop(),
           ),
         ),
         Positioned(

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -186,7 +186,9 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     return NetworkServerEntity()
       ..id = old?.id ?? Isar.autoIncrement
       ..lastSyncedAt = old?.lastSyncedAt
-      ..label = _labelController.text.trim()
+      ..label = _labelController.text.trim().isEmpty
+          ? (_isTidal ? 'Tidal' : '')
+          : _labelController.text.trim()
       ..protocol = _selectedProtocol
       ..baseUrl = _isTidal
           ? TidalService.tidalBaseUrl
@@ -217,28 +219,9 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       });
       return;
     }
-    // Tidal with no session token yet: drive the device-code login (opens the
-    // browser, polls until authorized), then validate.
-    if (_isTidal && (token == null || token.isEmpty)) {
-      try {
-        token = await TidalService.instance.signIn(
-          onVerificationLink: (uri) {
-            if (!mounted) return;
-            setState(() => _testVerificationUri = uri);
-          },
-        );
-        _resolvedToken = token;
-        if (!mounted) return;
-        setState(() => _testVerificationUri = null);
-      } catch (e) {
-        if (!mounted) return;
-        setState(() {
-          _testing = false;
-          _testPassed = false;
-          _testError = _humanError(e);
-        });
-        return;
-      }
+    if (_isTidal) {
+      await _testTidal(token);
+      return;
     }
     final entity = _draftEntity(token: token);
     try {
@@ -258,8 +241,47 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
     }
   }
 
-  Future<void> _save() async {
-    if (!_isValid) return;
+  /// Tidal's test button means "sign in and connect": ping any stored session,
+  /// and when it's missing OR dead (expired/revoked refresh token — the old
+  /// flow could never recover from that), run the device-code login. A fresh
+  /// sign-in is persisted immediately; previously the token only lived in
+  /// [_resolvedToken] and was silently dropped unless the user also tapped
+  /// Add Server, so the account never stayed signed in.
+  Future<void> _testTidal(String? storedToken) async {
+    try {
+      var ok = storedToken != null &&
+          storedToken.isNotEmpty &&
+          await TidalService.instance.ping(_draftEntity(token: storedToken));
+      if (!ok) {
+        final token = await TidalService.instance.signIn(
+          onVerificationLink: (uri) {
+            if (!mounted) return;
+            setState(() => _testVerificationUri = uri);
+          },
+        );
+        _resolvedToken = token;
+        if (!mounted) return;
+        setState(() => _testVerificationUri = null);
+        ok = await TidalService.instance.ping(_draftEntity(token: token));
+      }
+      if (!mounted) return;
+      setState(() {
+        _testing = false;
+        _testPassed = ok;
+      });
+      if (ok && _resolvedToken != null) await _save(force: true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _testing = false;
+        _testPassed = false;
+        _testError = _humanError(e);
+      });
+    }
+  }
+
+  Future<void> _save({bool force = false}) async {
+    if (!_isValid && !force) return;
     setState(() => _saving = true);
     String? token;
     try {

--- a/lib/features/settings/screens/network_sources_screen.dart
+++ b/lib/features/settings/screens/network_sources_screen.dart
@@ -59,7 +59,21 @@ class _NetworkSourcesScreenState extends State<NetworkSourcesScreen> {
     );
     if (changed == true) {
       await _loadServers();
+      await _autoSyncFreshTidal();
     }
+  }
+
+  /// A just-connected Tidal server has favorites waiting — kick the first
+  /// sync automatically so signing in visibly leads to a library (bug report:
+  /// "signed in but nothing happens"). Only fires for servers that have
+  /// never synced.
+  Future<void> _autoSyncFreshTidal() async {
+    if (_syncingId != null) return;
+    final fresh = _servers.where(
+      (s) => s.protocol == NetworkProtocol.tidal && s.lastSyncedAt == null,
+    );
+    if (fresh.isEmpty) return;
+    await _syncServer(fresh.first);
   }
 
   // ponytail: string sniffing across the per-protocol exception types; a


### PR DESCRIPTION
# Summary

- Add glass blur back buttons to album, artist, and playlist detail screens
- Fix nested navigation by sharing `nestedNavigatorKey` and popping full player before pushing detail routes
- Auto-trigger first sync for newly-connected Tidal servers that have never synced

# Changes

## Glass Blur Back Buttons

- Add glass blur effect back button to album detail screen
- Add glass blur effect back button to artist detail screen
- Add glass blur effect back button to playlist detail screen

## Nested Navigation Fix

- Add `nestedNavigatorKey` to root navigator
- Replace private `_nestedNavigatorKey` with shared `nestedNavigatorKey` in `MainShell` tab navigator
- Pop full player before pushing detail routes to fix back button behavior when nested detail screens are popped manually

## Tidal Auto-Sync

- Auto-trigger first sync for newly-connected Tidal servers that have never synced (fixes "signed in but nothing happens")

## Files Changed

- `lib/core/navigation/root_navigator.dart`
- `lib/app/app.dart`
- `lib/features/player/widgets/player_navigation.dart`
- `lib/features/albums/screens/album_detail_screen.dart`
- `lib/features/artists/screens/artist_detail_screen.dart`
- `lib/features/playlists/screens/playlist_detail_screen.dart`
- `lib/features/settings/screens/network_sources_screen.dart`