### PR TITLE
 Add karaoke lyrics rendering, SongTileThumbnail widget, and Jellyfin secure re-auth

### DIFF
--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -4,7 +4,6 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/data/repositories/song_repository.dart';
 import 'package:flick/features/artists/screens/artist_detail_screen.dart';
@@ -12,11 +11,11 @@ import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
-import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
+import 'package:flick/widgets/common/song_tile_thumbnail.dart';
 import 'package:flick/widgets/common/detail_header.dart';
 import 'package:flick/features/player/widgets/add_to_playlist_sheet.dart';
 import 'package:flick/features/player/widgets/sleep_timer_bottom_sheet.dart';
@@ -646,30 +645,7 @@ class _SongTile extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Container(
-                width: context.scaleSize(AppConstants.containerSizeMd),
-                height: context.scaleSize(AppConstants.containerSizeMd),
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                  child: CachedImageWidget(
-                    imagePath: song.albumArt,
-                    audioSourcePath: song.filePath,
-                    fit: BoxFit.cover,
-                    placeholder: const FlickArtworkPlaceholder(
-                      size: 28,
-                      opacity: 0.9,
-                    ),
-                    errorWidget: const FlickArtworkPlaceholder(
-                      size: 28,
-                      opacity: 0.9,
-                    ),
-                  ),
-                ),
-              ),
+              SongTileThumbnail(song: song, trackNumber: song.trackNumber),
               const SizedBox(width: AppConstants.spacingMd),
               Expanded(
                 child: Column(

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -5,7 +5,6 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
-import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/data/repositories/artist_repository.dart';
 import 'package:flick/data/repositories/recently_played_repository.dart';
 import 'package:flick/data/repositories/song_repository.dart';
@@ -19,6 +18,7 @@ import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
+import 'package:flick/widgets/common/song_tile_thumbnail.dart';
 import 'package:flick/widgets/common/detail_header.dart';
 import 'package:flick/features/player/widgets/add_to_playlist_sheet.dart';
 import 'package:flick/features/player/widgets/sleep_timer_bottom_sheet.dart';
@@ -983,24 +983,7 @@ class _SongTile extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Container(
-                width: context.scaleSize(AppConstants.containerSizeMd),
-                height: context.scaleSize(AppConstants.containerSizeMd),
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                  child: CachedImageWidget(
-                    imagePath: song.albumArt,
-                    audioSourcePath: song.filePath,
-                    fit: BoxFit.cover,
-                    placeholder: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
-                    errorWidget: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
-                  ),
-                ),
-              ),
+              SongTileThumbnail(song: song, trackNumber: song.trackNumber),
               const SizedBox(width: AppConstants.spacingMd),
               Expanded(
                 child: Column(

--- a/lib/features/menu/screens/smart_mix_detail_screen.dart
+++ b/lib/features/menu/screens/smart_mix_detail_screen.dart
@@ -6,7 +6,6 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/theme/adaptive_color_provider.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/core/utils/responsive.dart';
 import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
@@ -16,9 +15,9 @@ import 'package:flick/services/player_service.dart';
 import 'package:flick/providers/navigation_provider.dart';
 import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
-import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
+import 'package:flick/widgets/common/song_tile_thumbnail.dart';
 import 'package:flick/widgets/common/detail_header.dart';
 import 'package:flick/features/player/widgets/add_to_playlist_sheet.dart';
 import 'package:flick/features/player/widgets/sleep_timer_bottom_sheet.dart';
@@ -347,6 +346,7 @@ class _SmartMixDetailScreenState extends ConsumerState<SmartMixDetailScreen>
                               final song = widget.songs[index];
                               return _SongTile(
                                 song: song,
+                                index: index,
                                 onTap: () => _playSong(song),
                               );
                             }, childCount: widget.songs.length),
@@ -536,9 +536,10 @@ class _SmartMixDetailScreenState extends ConsumerState<SmartMixDetailScreen>
 
 class _SongTile extends StatelessWidget {
   final Song song;
+  final int? index;
   final VoidCallback onTap;
 
-  const _SongTile({required this.song, required this.onTap});
+  const _SongTile({required this.song, this.index, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -553,23 +554,9 @@ class _SongTile extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Container(
-                width: context.scaleSize(AppConstants.containerSizeMd),
-                height: context.scaleSize(AppConstants.containerSizeMd),
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                  child: CachedImageWidget(
-                    imagePath: song.albumArt,
-                    audioSourcePath: song.filePath,
-                    fit: BoxFit.cover,
-                    placeholder: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
-                    errorWidget: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
-                  ),
-                ),
+              SongTileThumbnail(
+                song: song,
+                trackNumber: index != null ? index! + 1 : null,
               ),
               const SizedBox(width: AppConstants.spacingMd),
               Expanded(

--- a/lib/features/player/widgets/album_color_helpers.dart
+++ b/lib/features/player/widgets/album_color_helpers.dart
@@ -5,11 +5,15 @@ const Color _darkBase = Color(0xFF121212);
 Color albumSurface(Color albumColor, double blend) =>
     Color.lerp(_darkBase, albumColor, blend)!;
 
-Color albumAccent(Color albumColor, double blend) {
+Color albumAccent(
+  Color albumColor,
+  double blend, {
+  double lightness = 0.65,
+}) {
   final hsl = HSLColor.fromColor(albumColor);
   return hsl
       .withSaturation((hsl.saturation * 0.7).clamp(0.3, 0.8))
-      .withLightness(0.65)
+      .withLightness(lightness)
       .toColor()
       .withValues(alpha: (blend + 0.3).clamp(0.0, 1.0));
 }

--- a/lib/features/player/widgets/animated_song_scene.dart
+++ b/lib/features/player/widgets/animated_song_scene.dart
@@ -259,17 +259,29 @@ class AnimatedSongScene extends StatelessWidget {
   }
 
   Widget _buildBackground(BuildContext context) {
+    final bgBlend = albumColorMode.backgroundBlend;
+    final hasAlbumTint = albumColor != null && bgBlend > 0;
+    // Lyrics readability scrim: fades in over any background variant so white
+    // lyric text keeps contrast. Follows the album color mode — flat black
+    // when off, increasingly album-hued toward vibrant, but always lerped
+    // from black so the tint stays dark enough to read text over.
+    final scrimColor =
+        hasAlbumTint
+            ? Color.lerp(Colors.black, albumColor!, (bgBlend * 1.2).clamp(0.0, 0.35))!
+            : Colors.black;
+
     return Stack(
       children: [
         Positioned.fill(child: _buildBaseBackground(context)),
-        // Lyrics readability scrim: fades in over any background variant so
-        // white lyric text keeps contrast against bright album art.
         Positioned.fill(
           child: IgnorePointer(
             child: AnimatedOpacity(
               duration: AppConstants.animationNormal,
               opacity: lyricsMode ? 1.0 : 0.0,
-              child: ColoredBox(color: Colors.black.withValues(alpha: 0.45)),
+              child: AnimatedContainer(
+                duration: AppConstants.animationNormal,
+                color: scrimColor.withValues(alpha: 0.45),
+              ),
             ),
           ),
         ),

--- a/lib/features/player/widgets/animated_song_scene.dart
+++ b/lib/features/player/widgets/animated_song_scene.dart
@@ -259,6 +259,25 @@ class AnimatedSongScene extends StatelessWidget {
   }
 
   Widget _buildBackground(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(child: _buildBaseBackground(context)),
+        // Lyrics readability scrim: fades in over any background variant so
+        // white lyric text keeps contrast against bright album art.
+        Positioned.fill(
+          child: IgnorePointer(
+            child: AnimatedOpacity(
+              duration: AppConstants.animationNormal,
+              opacity: lyricsMode ? 1.0 : 0.0,
+              child: ColoredBox(color: Colors.black.withValues(alpha: 0.45)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBaseBackground(BuildContext context) {
     final bgBlend = albumColorMode.backgroundBlend;
     final hasAlbumTint = albumColor != null && bgBlend > 0;
 

--- a/lib/features/player/widgets/inline_lyrics_panel.dart
+++ b/lib/features/player/widgets/inline_lyrics_panel.dart
@@ -1,17 +1,20 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:fading_marquee_widget/fading_marquee_widget.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/services/player_service.dart';
 import 'package:flick/services/lyrics_service.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
-import 'package:flick/features/player/widgets/album_color_helpers.dart';
+import 'package:flick/features/player/widgets/lyrics_alignment.dart';
 import 'package:flick/features/player/widgets/lyrics_editor_bottom_sheet.dart';
 import 'package:flick/features/player/widgets/online_lyrics_search_sheet.dart';
-class InlineLyricsPanel extends StatefulWidget {
+import 'package:flick/features/player/widgets/synced_lyrics_view.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+class InlineLyricsPanel extends ConsumerStatefulWidget {
   final PlayerService playerService;
   final LyricsService lyricsService;
   final Song song;
@@ -25,28 +28,19 @@ class InlineLyricsPanel extends StatefulWidget {
   });
 
   @override
-  State<InlineLyricsPanel> createState() => _InlineLyricsPanelState();
+  ConsumerState<InlineLyricsPanel> createState() => _InlineLyricsPanelState();
 }
 
-class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
-  static const double _lineHeight = 116;
-  static const double _centerFactor = 0.35;
-
+class _InlineLyricsPanelState extends ConsumerState<InlineLyricsPanel> {
   final ScrollController _scrollController = ScrollController();
   LyricsData? _lyricsData;
   bool _isLoading = true;
   bool _hasManualLyricsSelection = false;
-  int _activeLineIndex = -1;
   bool _isMetaCollapsed = false;
-  bool _isScrollAnimating = false;
-  double? _pendingScrollTarget;
-  Duration _lastTrackedPosition = Duration.zero;
-  static const int _seekBackThresholdMs = 500;
 
   @override
   void initState() {
     super.initState();
-    widget.playerService.positionNotifier.addListener(_onPositionChanged);
     _loadLyricsForSong(widget.song);
   }
 
@@ -60,36 +54,8 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
 
   @override
   void dispose() {
-    widget.playerService.positionNotifier.removeListener(_onPositionChanged);
     _scrollController.dispose();
     super.dispose();
-  }
-
-  void _onPositionChanged() {
-    final data = _lyricsData;
-    if (data == null || !data.isSynchronized || data.lines.isEmpty) return;
-
-    final position = widget.playerService.positionNotifier.value;
-    final newIndex = widget.lyricsService.findCurrentLineIndex(data, position);
-    if (newIndex == _activeLineIndex) {
-      _lastTrackedPosition = position;
-      return;
-    }
-
-    // Forward playback only ever advances the active line. The audio engine
-    // occasionally reports a transiently lower position (post-seek/buffer dip,
-    // rounding), which would make the list scroll up then snap back. Treat a
-    // backward change as jitter unless the position dropped by a real amount.
-    final isSeekBack =
-        position.inMilliseconds <
-        _lastTrackedPosition.inMilliseconds - _seekBackThresholdMs;
-    _lastTrackedPosition = position;
-
-    if (newIndex < _activeLineIndex && !isSeekBack) return;
-
-    _activeLineIndex = newIndex;
-    _scrollToActiveLine(newIndex);
-    setState(() {});
   }
 
   Future<void> _loadLyricsForSong(Song song) async {
@@ -97,8 +63,6 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
     setState(() {
       _isLoading = true;
       _lyricsData = null;
-      _activeLineIndex = -1;
-      _lastTrackedPosition = Duration.zero;
     });
 
     final loaded = await widget.lyricsService.loadLyricsForSong(
@@ -117,69 +81,6 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
           manualSource != null && manualSource.isNotEmpty;
       _isLoading = false;
     });
-
-    _onPositionChanged();
-  }
-
-  void _scrollToActiveLine(int index) {
-    if (!_scrollController.hasClients || index < 0) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final target = (index * _lineHeight) + (_lineHeight / 2);
-    final clampedTarget = target.clamp(0.0, maxScroll);
-
-    _pendingScrollTarget = clampedTarget;
-
-    if (!_isScrollAnimating) {
-      _performScroll();
-    }
-  }
-
-  void _performScroll() {
-    if (!_scrollController.hasClients || _pendingScrollTarget == null) {
-      _isScrollAnimating = false;
-      return;
-    }
-
-    final target = _pendingScrollTarget!;
-    _pendingScrollTarget = null;
-
-    final delta = (_scrollController.offset - target).abs();
-    if (delta < _lineHeight * 0.08) {
-      _performScroll();
-      return;
-    }
-
-    _isScrollAnimating = true;
-    _scrollController
-        .animateTo(
-          target,
-          duration: AppConstants.animationNormal,
-          curve: Curves.easeOutCubic,
-        )
-        .then((_) {
-          _isScrollAnimating = false;
-          _performScroll();
-        });
-  }
-
-  Future<void> _seekToLyricLine(int index) async {
-    final lyrics = _lyricsData;
-    if (lyrics == null || !lyrics.isSynchronized || index < 0) return;
-
-    final target = lyrics.lines[index].timestamp;
-    widget.playerService.positionNotifier.value = target;
-
-    if (mounted && _activeLineIndex != index) {
-      setState(() {
-        _activeLineIndex = index;
-      });
-    }
-
-    _isScrollAnimating = false;
-    _pendingScrollTarget = null;
-    _scrollToActiveLine(index);
-    await widget.playerService.seek(target);
   }
 
   String? _lyricsSourceLabel(String? source) {
@@ -329,7 +230,36 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
     final sourceLabel = _lyricsSourceLabel(lyrics.source);
     final textColor = Colors.white.withValues(alpha: 0.82);
 
-    Widget chip(IconData icon, String label, {bool accent = false}) {
+    Widget chip(
+      IconData icon,
+      String label, {
+      bool accent = false,
+      bool marqueeLabel = false,
+    }) {
+      final labelStyle = TextStyle(
+        fontFamily: 'ProductSans',
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        color: accent ? AppColors.accent : textColor,
+      );
+      final labelWidget = marqueeLabel
+          ? SizedBox(
+              width: 132,
+              child: FadingMarqueeWidget(
+                id: label,
+                gap: 20,
+                delay: const Duration(milliseconds: 1200),
+                pause: const Duration(milliseconds: 800),
+                duration: const Duration(seconds: 6),
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  softWrap: false,
+                  style: labelStyle,
+                ),
+              ),
+            )
+          : Text(label, style: labelStyle);
       return Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         decoration: BoxDecoration(
@@ -348,15 +278,7 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
           children: [
             Icon(icon, size: 14, color: accent ? AppColors.accent : textColor),
             const SizedBox(width: 6),
-            Text(
-              label,
-              style: TextStyle(
-                fontFamily: 'ProductSans',
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
-                color: accent ? AppColors.accent : textColor,
-              ),
-            ),
+            labelWidget,
           ],
         ),
       );
@@ -382,7 +304,7 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
                 ),
                 const SizedBox(width: 8),
                 if (sourceLabel != null) ...[
-                  chip(LucideIcons.badgeInfo, sourceLabel),
+                  chip(LucideIcons.badgeInfo, sourceLabel, marqueeLabel: true),
                   const SizedBox(width: 8),
                 ],
                 AnimatedRotation(
@@ -404,50 +326,24 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
               ? CrossFadeState.showFirst
               : CrossFadeState.showSecond,
           firstChild: const SizedBox(width: double.infinity),
-          secondChild: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
-                child: Wrap(
-                  alignment: WrapAlignment.center,
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    chip(
-                      lyrics.isSynchronized
-                          ? LucideIcons.touchpad
-                          : Icons.notes_rounded,
-                      lyrics.isSynchronized
-                          ? 'Tap any line to seek'
-                          : 'Static lyrics — no timestamps',
-                    ),
-                    chip(LucideIcons.pencilLine, 'Edit & Sync Studio'),
-                    if (lyrics.lines.isNotEmpty)
-                      chip(
-                        Icons.format_align_left,
-                        '${lyrics.lines.length} lines',
-                      ),
-                  ],
-                ),
-              ),
-              _buildActionButtons(),
-            ],
-          ),
+          secondChild: _buildActionButtons(),
         ),
       ],
     );
   }
 
   Widget _buildPlainLyricsView(LyricsData lyrics) {
-    return Align(
-      alignment: Alignment.center,
-      child: SingleChildScrollView(
-        controller: _scrollController,
-        padding: const EdgeInsets.fromLTRB(12, 8, 12, 20),
+    final alignment = resolveLyricsAlignment(
+      ref.watch(appPreferencesProvider).lyricsTextAlign,
+    );
+    return SingleChildScrollView(
+      controller: _scrollController,
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 20),
+      child: SizedBox(
+        width: double.infinity,
         child: Text(
           lyrics.lines.map((line) => line.text).join('\n'),
-          textAlign: TextAlign.center,
+          textAlign: alignment.textAlign,
           style: TextStyle(
             fontFamily: 'ProductSans',
             fontSize: 18,
@@ -459,125 +355,13 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
     );
   }
 
-  double _lyricOpacityForIndex(int index) {
-    if (_activeLineIndex < 0) return 0.72;
-
-    final distance = (index - _activeLineIndex).abs();
-    switch (distance) {
-      case 0:
-        return 1;
-      case 1:
-        return 0.56;
-      case 2:
-        return 0.36;
-      case 3:
-        return 0.24;
-      default:
-        return 0.18;
-    }
-  }
-
-  TextStyle _lyricTextStyle(bool isActive, double opacity) {
-    return TextStyle(
-      fontFamily: 'ProductSans',
-      fontSize: isActive ? 22 : 17,
-      height: isActive ? 1.18 : 1.24,
-      fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
-      color: Colors.white.withValues(alpha: opacity),
-    );
-  }
-
-  StrutStyle _lyricStrutStyle(bool isActive) {
-    return StrutStyle(
-      fontFamily: 'ProductSans',
-      fontSize: isActive ? 22 : 17,
-      height: isActive ? 1.18 : 1.24,
-      forceStrutHeight: true,
-    );
-  }
-
   Widget _buildSynchronizedLyricsView(LyricsData lyrics) {
     return Expanded(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final centerPadding = constraints.maxHeight * _centerFactor;
-          return ListView.builder(
-            scrollCacheExtent: ScrollCacheExtent.pixels(_lineHeight * 8),
-            controller: _scrollController,
-            padding: EdgeInsets.fromLTRB(10, centerPadding, 10, centerPadding),
-            itemCount: lyrics.lines.length,
-            itemExtent: _lineHeight,
-            itemBuilder: (context, index) {
-              final line = lyrics.lines[index];
-              final isActive = index == _activeLineIndex;
-              final lineOpacity = _lyricOpacityForIndex(index);
-
-              return RepaintBoundary(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 6),
-                  child: Material(
-                    color: Colors.transparent,
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(22),
-                      onTap: () => unawaited(_seekToLyricLine(index)),
-                      child: Center(
-                        child: isActive
-                            ? AnimatedContainer(
-                                duration: AppConstants.animationFast,
-                                curve: Curves.easeOutCubic,
-                                alignment: Alignment.center,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 18,
-                                  vertical: 12,
-                                ),
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(22),
-                                  color: widget.albumColor != null
-                                      ? albumAccent(
-                                          widget.albumColor!,
-                                          0.3,
-                                        ).withValues(alpha: 0.16)
-                                      : Colors.white.withValues(alpha: 0.16),
-                                  border: Border.all(
-                                    color: widget.albumColor != null
-                                        ? albumAccent(
-                                            widget.albumColor!,
-                                            0.3,
-                                          ).withValues(alpha: 0.22)
-                                        : Colors.white.withValues(alpha: 0.22),
-                                  ),
-                                ),
-                                child: Text(
-                                  line.text,
-                                  maxLines: 3,
-                                  overflow: TextOverflow.fade,
-                                  textAlign: TextAlign.center,
-                                  style: _lyricTextStyle(true, lineOpacity),
-                                  strutStyle: _lyricStrutStyle(true),
-                                ),
-                              )
-                            : Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 10,
-                                ),
-                                child: Text(
-                                  line.text,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.fade,
-                                  textAlign: TextAlign.center,
-                                  style: _lyricTextStyle(false, lineOpacity),
-                                  strutStyle: _lyricStrutStyle(false),
-                                ),
-                              ),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            },
-          );
-        },
+      child: SyncedLyricsView(
+        playerService: widget.playerService,
+        lyricsService: widget.lyricsService,
+        lyrics: lyrics,
+        albumColor: widget.albumColor,
       ),
     );
   }
@@ -658,7 +442,3 @@ class _InlineLyricsPanelState extends State<InlineLyricsPanel> {
     );
   }
 }
-
-/// Extracted waveform layer widget.
-/// Owns a ValueListenableBuilder on [positionNotifier] so that 50ms position
-/// ticks **never** cause the parent [_FullPlayerScreenState] to rebuild.

--- a/lib/features/player/widgets/karaoke_lyric_line.dart
+++ b/lib/features/player/widgets/karaoke_lyric_line.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flick/services/lyrics_service.dart';
+import 'package:flick/services/player_service.dart';
+
+/// Renders a single lyric line as karaoke-style text: a soft highlight
+/// sweeps through the words in reading order based on playback position.
+/// Real enhanced-LRC word timings drive the sweep; plain synced lines fall
+/// back to a single whole-line window.
+///
+/// The widget subscribes to [PlayerService.positionNotifier] and
+/// extrapolates between engine ticks with a frame ticker, so the sweep stays
+/// smooth even when position updates arrive infrequently.
+
+/// Splits a [LyricsWord] whose text spans multiple tokens into one segment
+/// per token, distributing the word's window proportionally to token
+/// length. Each segment renders with its own gradient, so a line that wraps
+/// across rows sweeps in reading order instead of highlighting the same
+/// horizontal band on every row.
+List<LyricsWord> splitKaraokeWord(LyricsWord word) {
+  final matches = RegExp(r'\S+\s*').allMatches(word.text).toList();
+  if (matches.length <= 1) return [word];
+
+  final leading = word.text.substring(0, matches.first.start);
+  final windowMs = word.end.inMilliseconds - word.start.inMilliseconds;
+
+  final weights = [
+    for (final match in matches)
+      (match.group(0) ?? '').trim().length.clamp(1, 64),
+  ];
+  final weightSum = weights.fold<int>(0, (a, b) => a + b);
+
+  final segments = <LyricsWord>[];
+  var consumed = 0;
+  for (var i = 0; i < matches.length; i++) {
+    final text = (i == 0 ? leading : '') + (matches[i].group(0) ?? '');
+    if (windowMs <= 0 || weightSum <= 0) {
+      segments.add(LyricsWord(start: word.start, end: word.end, text: text));
+      continue;
+    }
+    final startRatio = consumed / weightSum;
+    consumed += weights[i];
+    final endRatio = consumed / weightSum;
+    segments.add(
+      LyricsWord(
+        start: word.start +
+            Duration(milliseconds: (startRatio * windowMs).round()),
+        end: word.start +
+            Duration(milliseconds: (endRatio * windowMs).round()),
+        text: text,
+      ),
+    );
+  }
+  return segments;
+}
+class KaraokeLyricLine extends StatefulWidget {
+  final PlayerService playerService;
+  final LyricsService lyricsService;
+  final LyricsData lyrics;
+  final int lineIndex;
+  final TextAlign textAlign;
+  final TextStyle style;
+  final Color sungColor;
+  final Color unsungColor;
+
+  const KaraokeLyricLine({
+    super.key,
+    required this.playerService,
+    required this.lyricsService,
+    required this.lyrics,
+    required this.lineIndex,
+    required this.textAlign,
+    required this.style,
+    required this.sungColor,
+    required this.unsungColor,
+  });
+
+  @override
+  State<KaraokeLyricLine> createState() => _KaraokeLyricLineState();
+}
+
+class _KaraokeLyricLineState extends State<KaraokeLyricLine>
+    with SingleTickerProviderStateMixin {
+  static const double _fillEpsilon = 0.0004;
+
+  late List<LyricsWord> _segments;
+  Duration _basePosition = Duration.zero;
+  Duration _tickerElapsed = Duration.zero;
+  Duration _baseTickerElapsed = Duration.zero;
+  bool _isPlaying = false;
+  Ticker? _ticker;
+  List<double> _lastFills = const [];
+  int _builtForLineIndex = -1;
+  LyricsData? _builtForLyrics;
+
+  @override
+  void initState() {
+    super.initState();
+    _basePosition = widget.playerService.positionNotifier.value;
+    _isPlaying = widget.playerService.isPlayingNotifier.value;
+    widget.playerService.positionNotifier.addListener(_onPositionTick);
+    widget.playerService.isPlayingNotifier.addListener(_onPlayingChanged);
+    _resolveWords();
+    _updateTicker();
+  }
+
+  @override
+  void didUpdateWidget(covariant KaraokeLyricLine oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.lyrics, widget.lyrics) ||
+        oldWidget.lineIndex != widget.lineIndex) {
+      _resolveWords();
+      _onPositionTick();
+      return;
+    }
+    _updateTicker();
+  }
+
+  void _resolveWords() {
+    _segments = [
+      for (final word
+          in widget.lyricsService.resolveWords(widget.lyrics, widget.lineIndex))
+        ...splitKaraokeWord(word),
+    ];
+    _builtForLineIndex = widget.lineIndex;
+    _builtForLyrics = widget.lyrics;
+    _lastFills = const [];
+  }
+
+  void _onPositionTick() {
+    _basePosition = widget.playerService.positionNotifier.value;
+    _baseTickerElapsed = _tickerElapsed;
+    _updateTicker();
+  }
+
+  void _onPlayingChanged() {
+    // Freeze extrapolation at the exact current predicted position so
+    // pausing does not jump the fill forward.
+    _basePosition = _predictedPosition();
+    _baseTickerElapsed = _tickerElapsed;
+    _isPlaying = widget.playerService.isPlayingNotifier.value;
+    _updateTicker();
+  }
+
+  void _updateTicker() {
+    final shouldRun = _isPlaying && _segments.isNotEmpty && mounted;
+    if (shouldRun && _ticker == null) {
+      _tickerElapsed = Duration.zero;
+      _baseTickerElapsed = Duration.zero;
+      _ticker = createTicker(_onFrame);
+      _ticker!.start();
+    } else if (!shouldRun && _ticker != null) {
+      _ticker!.dispose();
+      _ticker = null;
+      _rebuildIfFillsChanged();
+    }
+  }
+
+  Duration _predictedPosition() {
+    if (!_isPlaying) return _basePosition;
+    final ahead = _tickerElapsed - _baseTickerElapsed;
+    if (ahead < Duration.zero) return _basePosition;
+    return _basePosition + ahead;
+  }
+
+  void _onFrame(Duration elapsed) {
+    _tickerElapsed = elapsed;
+    _rebuildIfFillsChanged();
+  }
+
+  void _rebuildIfFillsChanged() {
+    if (_segments.isEmpty || !mounted) return;
+
+    final position = _predictedPosition();
+    final nextFills = <double>[
+      for (final segment in _segments)
+        LyricsService.fillForWord(segment, position),
+    ];
+
+    final previous = _lastFills;
+    var changed = previous.length != nextFills.length;
+    if (!changed) {
+      for (var i = 0; i < nextFills.length; i++) {
+        if ((previous[i] - nextFills[i]).abs() > _fillEpsilon) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) return;
+
+    setState(() => _lastFills = nextFills);
+  }
+
+  WrapAlignment get _wrapAlignment {
+    switch (widget.textAlign) {
+      case TextAlign.left:
+        return WrapAlignment.start;
+      case TextAlign.right:
+        return WrapAlignment.end;
+      default:
+        return WrapAlignment.center;
+    }
+  }
+
+  Widget _buildWord(LyricsWord word, double fill) {
+    final clamped = fill.clamp(0.0, 1.0);
+    final durationMs = word.end.inMilliseconds - word.start.inMilliseconds;
+    final edgeStart = clamped >= 1.0 || durationMs <= 0
+        ? clamped
+        : (clamped - 80 / durationMs).clamp(0.0, 1.0);
+
+    return ShaderMask(
+      shaderCallback: (rect) {
+        return LinearGradient(
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
+          colors: [widget.sungColor, widget.unsungColor],
+          stops: [edgeStart, clamped],
+        ).createShader(rect);
+      },
+      child: Text(word.text, style: widget.style),
+    );
+  }
+
+  @override
+  void dispose() {
+    _ticker?.dispose();
+    widget.playerService.positionNotifier.removeListener(_onPositionTick);
+    widget.playerService.isPlayingNotifier.removeListener(_onPlayingChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_builtForLineIndex != widget.lineIndex ||
+        !identical(_builtForLyrics, widget.lyrics)) {
+      _resolveWords();
+    }
+
+    if (_segments.isEmpty) {
+      return Text(
+        widget.lyrics.lines[widget.lineIndex].text,
+        textAlign: widget.textAlign,
+        style: widget.style,
+      );
+    }
+
+    final fills = _lastFills.isEmpty
+        ? List<double>.filled(_segments.length, 0.0)
+        : _lastFills;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Wrap(
+        alignment: _wrapAlignment,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          for (var i = 0; i < _segments.length; i++)
+            _buildWord(_segments[i], i < fills.length ? fills[i] : 0.0),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/lyrics_alignment.dart
+++ b/lib/features/player/widgets/lyrics_alignment.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+
+/// Screen-edge anchoring for the lyrics views: one preference value maps to
+/// both text alignment inside a line and how the line box itself sits in the
+/// panel, so "left" means the words hug the left edge of the screen.
+class LyricsAlignment {
+  final TextAlign textAlign;
+  final WrapAlignment wrapAlignment;
+
+  const LyricsAlignment._(this.textAlign, this.wrapAlignment);
+
+  static const LyricsAlignment left = LyricsAlignment._(
+    TextAlign.left,
+    WrapAlignment.start,
+  );
+  static const LyricsAlignment center = LyricsAlignment._(
+    TextAlign.center,
+    WrapAlignment.center,
+  );
+  static const LyricsAlignment right = LyricsAlignment._(
+    TextAlign.right,
+    WrapAlignment.end,
+  );
+}
+
+LyricsAlignment resolveLyricsAlignment(String pref) {
+  switch (pref) {
+    case 'left':
+      return LyricsAlignment.left;
+    case 'right':
+      return LyricsAlignment.right;
+    default:
+      return LyricsAlignment.center;
+  }
+}

--- a/lib/features/player/widgets/synced_lyrics_view.dart
+++ b/lib/features/player/widgets/synced_lyrics_view.dart
@@ -1,0 +1,481 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart'
+    show ScrollCacheExtent, ScrollDirection;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:flick/features/player/widgets/album_color_helpers.dart';
+import 'package:flick/features/player/widgets/karaoke_lyric_line.dart';
+import 'package:flick/features/player/widgets/lyrics_alignment.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+import 'package:flick/services/lyrics_service.dart';
+import 'package:flick/services/player_service.dart';
+
+/// Synced lyrics list with a fixed focus anchor: the active line pins at
+/// [_anchorFraction] of the viewport height, per-line geometry comes from a
+/// measured-height registry (TextPainter estimates until real sizes arrive),
+/// and animations are single-flight — a new target simply interrupts the
+/// previous animateTo.
+///
+/// User drags suspend auto-following; it resumes after [_followResumeMs] of
+/// idle, or immediately on a tap-to-seek or external seek.
+class SyncedLyricsView extends ConsumerStatefulWidget {
+  final PlayerService playerService;
+  final LyricsService lyricsService;
+  final LyricsData lyrics;
+  final Color? albumColor;
+
+  const SyncedLyricsView({
+    super.key,
+    required this.playerService,
+    required this.lyricsService,
+    required this.lyrics,
+    this.albumColor,
+  });
+
+  @override
+  ConsumerState<SyncedLyricsView> createState() => _SyncedLyricsViewState();
+}
+
+class _SyncedLyricsViewState extends ConsumerState<SyncedLyricsView> {
+  static const double _anchorFraction = 0.32;
+  static const int _followResumeMs = 4000;
+  static const int _seekBackThresholdMs = 1200;
+  static const int _seekForwardThresholdMs = 3000;
+  static const double _measureEpsilonPx = 0.5;
+  static const double _correctionMinDeltaPx = 6;
+
+  final ScrollController _scrollController = ScrollController();
+
+  List<double> _inactiveEstimates = const [];
+  List<double> _activeEstimates = const [];
+  List<double?> _measuredHeights = const [];
+  List<double> _lineTops = const [];
+  double? _estimatesForWidth;
+  LyricsData? _estimatesForLyrics;
+
+  int _activeLineIndex = -1;
+  Duration _lastTickPosition = Duration.zero;
+  bool _following = true;
+  Timer? _followResumeTimer;
+  bool _needsInitialJump = true;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.playerService.positionNotifier.addListener(_onPositionChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant SyncedLyricsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.playerService != widget.playerService) {
+      oldWidget.playerService.positionNotifier.removeListener(_onPositionChanged);
+      widget.playerService.positionNotifier.addListener(_onPositionChanged);
+    }
+    if (!identical(oldWidget.lyrics, widget.lyrics)) {
+      _estimatesForWidth = null;
+      _needsInitialJump = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    _followResumeTimer?.cancel();
+    widget.playerService.positionNotifier.removeListener(_onPositionChanged);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onPositionChanged() {
+    final position = widget.playerService.positionNotifier.value;
+    final deltaMs = position.inMilliseconds - _lastTickPosition.inMilliseconds;
+    _lastTickPosition = position;
+    final isSeekBack = deltaMs <= -_seekBackThresholdMs;
+    final isSeek = isSeekBack || deltaMs >= _seekForwardThresholdMs;
+
+    final newIndex = widget.lyricsService.findCurrentLineIndex(
+      widget.lyrics,
+      position,
+    );
+    if (newIndex == _activeLineIndex) {
+      if (isSeek) _resumeFollow();
+      return;
+    }
+
+    // Transient position dips from the audio engine must not scroll back.
+    if (newIndex < _activeLineIndex && !isSeekBack) return;
+
+    _setActiveIndex(newIndex);
+    if (isSeek) _resumeFollow(animateNow: false);
+    if (_following) {
+      _animateToActiveLine(immediate: isSeek);
+    }
+  }
+
+  void _syncToPosition() {
+    final position = widget.playerService.positionNotifier.value;
+    _lastTickPosition = position;
+    final newIndex = widget.lyricsService.findCurrentLineIndex(
+      widget.lyrics,
+      position,
+    );
+    if (newIndex != _activeLineIndex) {
+      _setActiveIndex(newIndex);
+    }
+    _jumpToActiveLine();
+  }
+
+  Future<void> _seekToLine(int index) async {
+    if (index < 0 || index >= widget.lyrics.lines.length) return;
+    final target = widget.lyrics.lines[index].timestamp;
+    widget.playerService.positionNotifier.value = target;
+    _lastTickPosition = target;
+    _resumeFollow(animateNow: false);
+    _setActiveIndex(index);
+    _animateToActiveLine();
+    await widget.playerService.seek(target);
+  }
+
+  // --- geometry ---------------------------------------------------------
+
+  void _ensureEstimates(double listWidth) {
+    if (_estimatesForWidth == listWidth &&
+        identical(_estimatesForLyrics, widget.lyrics)) {
+      return;
+    }
+    final lines = widget.lyrics.lines;
+    final textWidth = listWidth - 44 > 24 ? listWidth - 44 : 24.0;
+    final inactive = <double>[];
+    final active = <double>[];
+    for (final line in lines) {
+      inactive.add(
+        32 + _estimateTextHeight(line.text, 17, 1.24, 2, textWidth),
+      );
+      active.add(28 + _estimateTextHeight(line.text, 22, 1.18, 3, textWidth));
+    }
+    _inactiveEstimates = inactive;
+    _activeEstimates = active;
+    _measuredHeights = List<double?>.filled(lines.length, null);
+    _lineTops = List<double>.filled(lines.length, 0);
+    _estimatesForWidth = listWidth;
+    _estimatesForLyrics = widget.lyrics;
+    _recomputeTops();
+  }
+
+  double _estimateTextHeight(
+    String text,
+    double fontSize,
+    double heightFactor,
+    int maxLines,
+    double maxWidth,
+  ) {
+    final painter = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(
+          fontFamily: 'ProductSans',
+          fontSize: fontSize,
+          height: heightFactor,
+          fontWeight: maxLines == 3 ? FontWeight.w700 : FontWeight.w500,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+      maxLines: maxLines,
+    );
+    painter.layout(maxWidth: maxWidth);
+    final height = painter.height;
+    painter.dispose();
+    return height;
+  }
+
+  double _heightOf(int index) {
+    final measured = index < _measuredHeights.length
+        ? _measuredHeights[index]
+        : null;
+    if (measured != null) return measured;
+    return index == _activeLineIndex
+        ? _activeEstimates[index]
+        : _inactiveEstimates[index];
+  }
+
+  void _recomputeTops() {
+    final count = widget.lyrics.lines.length;
+    if (_lineTops.length != count) {
+      _lineTops = List<double>.filled(count, 0);
+    }
+    var top = 0.0;
+    for (var i = 0; i < count; i++) {
+      _lineTops[i] = top;
+      top += _heightOf(i);
+    }
+  }
+
+  void _onLineMeasured(int index, double height) {
+    if (index >= _measuredHeights.length) return;
+    final current = _heightOf(index);
+    if ((current - height).abs() <= _measureEpsilonPx) {
+      _measuredHeights[index] = height;
+      return;
+    }
+    _measuredHeights[index] = height;
+    _recomputeTops();
+    if (_following && _scrollController.hasClients) {
+      final target = _targetFor(_activeLineIndex);
+      if (target != null &&
+          (target - _scrollController.offset).abs() >
+              _correctionMinDeltaPx) {
+        _animateToActiveLine();
+      }
+    }
+  }
+
+  void _setActiveIndex(int index) {
+    if (index == _activeLineIndex) return;
+    if (_activeLineIndex >= 0 && _activeLineIndex < _measuredHeights.length) {
+      _measuredHeights[_activeLineIndex] = null;
+    }
+    _activeLineIndex = index;
+    if (index >= 0 && index < _measuredHeights.length) {
+      _measuredHeights[index] = null;
+    }
+    _recomputeTops();
+    setState(() {});
+  }
+
+  // --- scrolling --------------------------------------------------------
+
+  double? _targetFor(int index) {
+    if (!_scrollController.hasClients) return null;
+    final position = _scrollController.position;
+    final viewport = position.viewportDimension;
+    final anchorPx = viewport * _anchorFraction;
+    if (index < 0) return 0.0;
+    if (index >= _lineTops.length) return null;
+    final center =
+        viewport * _anchorFraction + _lineTops[index] + _heightOf(index) / 2;
+    return (center - anchorPx).clamp(0.0, position.maxScrollExtent);
+  }
+
+  void _animateToActiveLine({bool immediate = false}) {
+    if (!_scrollController.hasClients) return;
+    final target = _targetFor(_activeLineIndex);
+    if (target == null) return;
+    final distance = (target - _scrollController.offset).abs();
+    final durationMs = immediate
+        ? 350
+        : (250 + distance * 0.6).clamp(250, 600).round();
+    _scrollController
+        .animateTo(
+          target,
+          duration: Duration(milliseconds: durationMs),
+          curve: Curves.easeOutCubic,
+        )
+        .catchError((_) {});
+  }
+
+  void _jumpToActiveLine() {
+    if (!_scrollController.hasClients) return;
+    final target = _targetFor(_activeLineIndex);
+    if (target == null) return;
+    _scrollController.jumpTo(target);
+  }
+
+  void _suspendFollow() {
+    _followResumeTimer?.cancel();
+    _followResumeTimer = Timer(const Duration(milliseconds: _followResumeMs), () {
+      if (!mounted) return;
+      _following = true;
+      _animateToActiveLine();
+    });
+    _following = false;
+  }
+
+  void _resumeFollow({bool animateNow = true}) {
+    _followResumeTimer?.cancel();
+    _following = true;
+    if (animateNow) _animateToActiveLine();
+  }
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    final userDragging =
+        (notification is ScrollStartNotification &&
+            notification.dragDetails != null) ||
+        (notification is ScrollUpdateNotification &&
+            notification.dragDetails != null) ||
+        (notification is UserScrollNotification &&
+            notification.direction != ScrollDirection.idle);
+    if (userDragging) _suspendFollow();
+    return false;
+  }
+
+  // --- rendering --------------------------------------------------------
+
+  double _opacityForIndex(int index) {
+    if (_activeLineIndex < 0) return 0.72;
+    final distance = (index - _activeLineIndex).abs();
+    switch (distance) {
+      case 0:
+        return 1;
+      case 1:
+        return 0.56;
+      case 2:
+        return 0.36;
+      case 3:
+        return 0.24;
+      default:
+        return 0.18;
+    }
+  }
+
+  TextStyle _textStyle(bool isActive, double opacity) {
+    return TextStyle(
+      fontFamily: 'ProductSans',
+      fontSize: isActive ? 22 : 17,
+      height: isActive ? 1.18 : 1.24,
+      fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+      color: Colors.white.withValues(alpha: opacity),
+    );
+  }
+
+  StrutStyle _strutStyle(bool isActive) {
+    return StrutStyle(
+      fontFamily: 'ProductSans',
+      fontSize: isActive ? 22 : 17,
+      height: isActive ? 1.18 : 1.24,
+      forceStrutHeight: true,
+    );
+  }
+
+  Color get _sungColor {
+    final albumColor = widget.albumColor;
+    if (albumColor != null) {
+      return albumAccent(albumColor, 0.7, lightness: 0.88);
+    }
+    return Colors.white;
+  }
+
+  Widget _buildLine(BuildContext context, int index, LyricsAlignment alignment) {
+    final line = widget.lyrics.lines[index];
+    final isActive = index == _activeLineIndex;
+
+    final content = isActive
+        ? Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: KaraokeLyricLine(
+              playerService: widget.playerService,
+              lyricsService: widget.lyricsService,
+              lyrics: widget.lyrics,
+              lineIndex: index,
+              textAlign: alignment.textAlign,
+              style: _textStyle(true, 1),
+              sungColor: _sungColor,
+              unsungColor: Colors.white.withValues(alpha: 0.30),
+            ),
+          )
+        : Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Text(
+              line.text,
+              maxLines: 2,
+              overflow: TextOverflow.fade,
+              textAlign: alignment.textAlign,
+              style: _textStyle(false, _opacityForIndex(index)),
+              strutStyle: _strutStyle(false),
+            ),
+          );
+
+    return _MeasuredLine(
+      index: index,
+      onMeasured: _onLineMeasured,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(22),
+            onTap: () => unawaited(_seekToLine(index)),
+            child: content,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final alignment = resolveLyricsAlignment(
+      ref.watch(appPreferencesProvider).lyricsTextAlign,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        _ensureEstimates(constraints.maxWidth);
+        if (_needsInitialJump) {
+          _needsInitialJump = false;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) _syncToPosition();
+          });
+        }
+
+        final anchorPx = constraints.maxHeight * _anchorFraction;
+        return NotificationListener<ScrollNotification>(
+          onNotification: _onScrollNotification,
+          child: ListView.builder(
+            controller: _scrollController,
+            scrollCacheExtent: ScrollCacheExtent.pixels(900),
+            padding: EdgeInsets.only(
+              top: anchorPx,
+              bottom: constraints.maxHeight - anchorPx,
+              left: 10,
+              right: 10,
+            ),
+            itemCount: widget.lyrics.lines.length,
+            itemBuilder: (context, index) =>
+                _buildLine(context, index, alignment),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Reports its rendered height after each frame so the parent can keep its
+/// line geometry registry in sync with reality.
+class _MeasuredLine extends StatefulWidget {
+  final int index;
+  final void Function(int index, double height) onMeasured;
+  final Widget child;
+
+  const _MeasuredLine({
+    required this.index,
+    required this.onMeasured,
+    required this.child,
+  });
+
+  @override
+  State<_MeasuredLine> createState() => _MeasuredLineState();
+}
+
+class _MeasuredLineState extends State<_MeasuredLine> {
+  double? _reported;
+
+  @override
+  Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _report());
+    return widget.child;
+  }
+
+  void _report() {
+    if (!mounted) return;
+    final size = context.size;
+    if (size == null) return;
+    if (_reported != null &&
+        (_reported! - size.height).abs() <= 0.5) {
+      return;
+    }
+    _reported = size.height;
+    widget.onMeasured(widget.index, size.height);
+  }
+}

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -12,7 +12,6 @@ import 'package:flick/core/utils/navigation_helper.dart';
 import 'package:flick/models/playback_context.dart';
 import 'package:flick/models/song.dart';
 import 'package:flick/models/playlist.dart';
-import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 import 'package:flick/services/album_art_service.dart';
 import 'package:flick/services/color_extraction_service.dart';
 import 'package:flick/services/player_service.dart';
@@ -24,6 +23,7 @@ import 'package:flick/providers/app_preferences_provider.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/animated_album_art.dart';
 import 'package:flick/widgets/common/scroll_fade_wrapper.dart';
+import 'package:flick/widgets/common/song_tile_thumbnail.dart';
 import 'package:flick/widgets/common/detail_header.dart';
 import 'package:flick/features/player/widgets/sleep_timer_bottom_sheet.dart';
 import 'package:flick/providers/favorites_provider.dart';
@@ -817,29 +817,9 @@ class _SongTile extends StatelessWidget {
                     ),
                   ),
                 ),
-              Container(
-                width: context.scaleSize(AppConstants.containerSizeMd),
-                height: context.scaleSize(AppConstants.containerSizeMd),
-                decoration: BoxDecoration(
-                  color: AppColors.glassBackground,
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(AppConstants.radiusSm),
-                  child: CachedImageWidget(
-                    imagePath: song.albumArt,
-                    audioSourcePath: song.filePath,
-                    fit: BoxFit.cover,
-                    placeholder: const FlickArtworkPlaceholder(
-                      size: 28,
-                      opacity: 0.9,
-                    ),
-                    errorWidget: const FlickArtworkPlaceholder(
-                      size: 28,
-                      opacity: 0.9,
-                    ),
-                  ),
-                ),
+              SongTileThumbnail(
+                song: song,
+                trackNumber: index != null ? index! + 1 : null,
               ),
               const SizedBox(width: AppConstants.spacingMd),
               Expanded(

--- a/lib/features/settings/screens/lyrics_settings_screen.dart
+++ b/lib/features/settings/screens/lyrics_settings_screen.dart
@@ -35,6 +35,47 @@ class LyricsSettingsScreen extends ConsumerWidget {
             ],
           ),
           const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Display'),
+          SettingsCard(
+            children: [
+              SelectionSetting(
+                icon: Icons.format_align_left_rounded,
+                title: 'Left',
+                subtitle: 'Align lyric text to the left edge',
+                selected: appPrefs.lyricsTextAlign == 'left',
+                onTap: () {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setLyricsTextAlign('left');
+                },
+              ),
+              const SettingsDivider(),
+              SelectionSetting(
+                icon: Icons.format_align_center_rounded,
+                title: 'Center',
+                subtitle: 'Align lyric text to the center',
+                selected: appPrefs.lyricsTextAlign == 'center',
+                onTap: () {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setLyricsTextAlign('center');
+                },
+              ),
+              const SettingsDivider(),
+              SelectionSetting(
+                icon: Icons.format_align_right_rounded,
+                title: 'Right',
+                subtitle: 'Align lyric text to the right edge',
+                selected: appPrefs.lyricsTextAlign == 'right',
+                onTap: () {
+                  ref
+                      .read(appPreferencesProvider.notifier)
+                      .setLyricsTextAlign('right');
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
           const SizedBox(height: AppConstants.navBarHeight + 40),
         ],
       ),

--- a/lib/features/settings/screens/network_server_edit_screen.dart
+++ b/lib/features/settings/screens/network_server_edit_screen.dart
@@ -17,6 +17,7 @@ import '../../../core/utils/responsive.dart';
 import '../../../data/database.dart';
 import '../../../data/repositories/song_repository.dart';
 import '../../../services/playlist_service.dart';
+import '../../../services/sources/jellyfin_service.dart';
 import '../../../services/sources/network_source_service.dart';
 import '../../../services/sources/tidal_service.dart';
 import '../widgets/settings_widgets.dart';
@@ -65,7 +66,7 @@ const List<_ProtocolMeta> _protocols = [
     subtitle: 'Jellyfin · Emby',
     icon: LucideIcons.clapperboard,
     urlHint: 'https://jf.example.com',
-    passwordHelper: 'Sent once to sign in; an access token is stored',
+    passwordHelper: 'Kept in secure storage to re-sign in when the token expires',
   ),
   _ProtocolMeta(
     id: NetworkProtocol.webdav,
@@ -296,6 +297,13 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       });
       return;
     }
+    final password = _passwordController.text;
+    if (_selectedProtocol == NetworkProtocol.jellyfin &&
+        token != null &&
+        password.isNotEmpty) {
+      await JellyfinService.instance
+          .persistPassword(_draftEntity(token: token), password);
+    }
     await Database.instance.writeTxn(() async {
       await Database.networkServers.put(_draftEntity(token: token));
     });
@@ -323,6 +331,9 @@ class _NetworkServerEditScreenState extends State<NetworkServerEditScreen> {
       destructive: true,
     );
     if (!confirmed) return;
+    if (server.protocol == NetworkProtocol.jellyfin) {
+      await JellyfinService.instance.forgetPassword(server.id);
+    }
     await Database.instance.writeTxn(() async {
       await Database.networkServers.delete(server.id);
     });

--- a/lib/features/settings/screens/ui_customization_settings_screen.dart
+++ b/lib/features/settings/screens/ui_customization_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/models/album_color_mode.dart';
 import 'package:flick/models/progress_bar_style.dart';
+import 'package:flick/models/song_tile_thumbnail_mode.dart';
 import 'package:flick/providers/providers.dart';
 import 'package:flick/features/settings/widgets/settings_widgets.dart';
 
@@ -197,6 +198,36 @@ class UiCustomizationSettingsScreen extends ConsumerWidget {
                 },
               ),
             ],
+          ),
+          const SizedBox(height: AppConstants.spacingLg),
+          const SettingsSectionHeader('Track Thumbnails'),
+          SettingsCard(
+            children: SongTileThumbnailMode.values.map((mode) {
+              final isSelected =
+                  appPreferences.songTileThumbnailMode == mode.storageValue;
+              final icon = switch (mode) {
+                SongTileThumbnailMode.artwork => LucideIcons.image,
+                SongTileThumbnailMode.trackNumber => LucideIcons.hash,
+                SongTileThumbnailMode.trackNumberOnArt => LucideIcons.layers,
+              };
+              return Column(
+                children: [
+                  if (mode != SongTileThumbnailMode.values.first)
+                    const SettingsDivider(),
+                  SelectionSetting(
+                    icon: icon,
+                    title: mode.label,
+                    subtitle: mode.description,
+                    selected: isSelected,
+                    onTap: () {
+                      ref
+                          .read(appPreferencesProvider.notifier)
+                          .setSongTileThumbnailMode(mode.storageValue);
+                    },
+                  ),
+                ],
+              );
+            }).toList(),
           ),
           const SizedBox(height: AppConstants.spacingLg),
           const SettingsSectionHeader('Progress Bar'),

--- a/lib/features/songs/widgets/song_card.dart
+++ b/lib/features/songs/widgets/song_card.dart
@@ -5,7 +5,6 @@ import 'package:flick/core/theme/app_colors.dart';
 import 'package:flick/core/constants/app_constants.dart';
 import 'package:flick/core/utils/app_haptics.dart';
 import 'package:flick/models/song.dart';
-import 'package:flick/widgets/common/marquee_widget.dart';
 import 'package:flick/widgets/common/cached_image_widget.dart';
 import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
 
@@ -402,7 +401,10 @@ class _SongCardState extends State<SongCard> {
         if (isSelected)
           SizedBox(
             height: 24,
-            child: MarqueeWidget(
+            width: double.infinity,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: Alignment.centerLeft,
               child: Text(
                 widget.song.title,
                 style: const TextStyle(
@@ -411,6 +413,9 @@ class _SongCardState extends State<SongCard> {
                   color: Colors.white,
                   letterSpacing: 0.2,
                 ),
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.visible,
               ),
             ),
           )

--- a/lib/models/song_tile_thumbnail_mode.dart
+++ b/lib/models/song_tile_thumbnail_mode.dart
@@ -1,0 +1,48 @@
+enum SongTileThumbnailMode { artwork, trackNumber, trackNumberOnArt }
+
+extension SongTileThumbnailModeX on SongTileThumbnailMode {
+  String get storageValue {
+    switch (this) {
+      case SongTileThumbnailMode.artwork:
+        return 'artwork';
+      case SongTileThumbnailMode.trackNumber:
+        return 'trackNumber';
+      case SongTileThumbnailMode.trackNumberOnArt:
+        return 'trackNumberOnArt';
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case SongTileThumbnailMode.artwork:
+        return 'Album Art';
+      case SongTileThumbnailMode.trackNumber:
+        return 'Track Number';
+      case SongTileThumbnailMode.trackNumberOnArt:
+        return 'Number on Art';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case SongTileThumbnailMode.artwork:
+        return 'Show album artwork.';
+      case SongTileThumbnailMode.trackNumber:
+        return 'Show the track number.';
+      case SongTileThumbnailMode.trackNumberOnArt:
+        return 'Show the number over blurred art.';
+    }
+  }
+
+  static SongTileThumbnailMode fromStorageValue(String? value) {
+    switch (value) {
+      case 'trackNumber':
+        return SongTileThumbnailMode.trackNumber;
+      case 'trackNumberOnArt':
+        return SongTileThumbnailMode.trackNumberOnArt;
+      case 'artwork':
+      default:
+        return SongTileThumbnailMode.artwork;
+    }
+  }
+}

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -139,6 +139,12 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
     await ref.read(appPreferencesServiceProvider).setReplayGainMode(value);
   }
 
+  Future<void> setLyricsTextAlign(String value) async {
+    if (state.lyricsTextAlign == value) return;
+    state = state.copyWith(lyricsTextAlign: value);
+    await ref.read(appPreferencesServiceProvider).setLyricsTextAlign(value);
+  }
+
   Future<void> setReplayGainPreampDb(double value) async {
     if (state.replayGainPreampDb == value) return;
     state = state.copyWith(replayGainPreampDb: value);

--- a/lib/providers/app_preferences_provider.dart
+++ b/lib/providers/app_preferences_provider.dart
@@ -799,6 +799,14 @@ class AppPreferencesNotifier extends Notifier<AppPreferences> {
         .setDetailHeaderCenteredTitle(value);
   }
 
+  Future<void> setSongTileThumbnailMode(String value) async {
+    if (state.songTileThumbnailMode == value) return;
+    state = state.copyWith(songTileThumbnailMode: value);
+    await ref
+        .read(appPreferencesServiceProvider)
+        .setSongTileThumbnailMode(value);
+  }
+
   Future<void> resetOrbitSettings() async {
     state = state.copyWith(
       orbitRadiusRatio: 1.0,

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -106,6 +106,7 @@ class AppPreferences {
   final bool showMoreArtists;
   final bool detailHeaderArtExpanded;
   final bool detailHeaderCenteredTitle;
+  final String songTileThumbnailMode; // 'artwork', 'trackNumber', or 'trackNumberOnArt'
   final bool extendedVolumeEnabled;
   final String replayGainMode; // 'off', 'track', or 'album'
   final String lyricsTextAlign; // 'left', 'center', or 'right'
@@ -218,6 +219,7 @@ class AppPreferences {
     this.showMoreArtists = true,
     this.detailHeaderArtExpanded = true,
     this.detailHeaderCenteredTitle = false,
+    this.songTileThumbnailMode = 'artwork',
     this.extendedVolumeEnabled = false,
     this.replayGainMode = 'off',
     this.lyricsTextAlign = 'center',
@@ -331,6 +333,7 @@ class AppPreferences {
     bool? showMoreArtists,
     bool? detailHeaderArtExpanded,
     bool? detailHeaderCenteredTitle,
+    String? songTileThumbnailMode,
     bool? extendedVolumeEnabled,
     String? replayGainMode,
     String? lyricsTextAlign,
@@ -490,6 +493,8 @@ class AppPreferences {
           detailHeaderArtExpanded ?? this.detailHeaderArtExpanded,
       detailHeaderCenteredTitle:
           detailHeaderCenteredTitle ?? this.detailHeaderCenteredTitle,
+      songTileThumbnailMode:
+          songTileThumbnailMode ?? this.songTileThumbnailMode,
       extendedVolumeEnabled:
           extendedVolumeEnabled ?? this.extendedVolumeEnabled,
       replayGainMode: replayGainMode ?? this.replayGainMode,
@@ -614,6 +619,7 @@ class AppPreferencesService {
   static const _showMoreArtistsKey = 'album_show_more_artists';
   static const _detailHeaderArtExpandedKey = 'detail_header_art_expanded';
   static const _detailHeaderCenteredTitleKey = 'detail_header_centered_title';
+  static const _songTileThumbnailModeKey = 'song_tile_thumbnail_mode';
   static const _extendedVolumeEnabledKey = 'audio_extended_volume_enabled';
   static const _replayGainModeKey = 'audio_replaygain_mode';
   static const _lyricsTextAlignKey = 'lyrics_text_align';
@@ -779,6 +785,8 @@ class AppPreferencesService {
           prefs.getBool(_detailHeaderArtExpandedKey) ?? true,
       detailHeaderCenteredTitle:
           prefs.getBool(_detailHeaderCenteredTitleKey) ?? false,
+      songTileThumbnailMode:
+          prefs.getString(_songTileThumbnailModeKey) ?? 'artwork',
       extendedVolumeEnabled:
           prefs.getBool(_extendedVolumeEnabledKey) ?? false,
       replayGainMode: prefs.getString(_replayGainModeKey) ?? 'off',
@@ -1816,6 +1824,16 @@ class AppPreferencesService {
   Future<void> setDetailHeaderCenteredTitle(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_detailHeaderCenteredTitleKey, value);
+  }
+
+  Future<String> getSongTileThumbnailMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_songTileThumbnailModeKey) ?? 'artwork';
+  }
+
+  Future<void> setSongTileThumbnailMode(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_songTileThumbnailModeKey, value);
   }
 
   Future<void> clearOrbitSettings() async {

--- a/lib/services/app_preferences_service.dart
+++ b/lib/services/app_preferences_service.dart
@@ -108,6 +108,7 @@ class AppPreferences {
   final bool detailHeaderCenteredTitle;
   final bool extendedVolumeEnabled;
   final String replayGainMode; // 'off', 'track', or 'album'
+  final String lyricsTextAlign; // 'left', 'center', or 'right'
   final double replayGainPreampDb;
   final bool replayGainPreventClipping;
 
@@ -219,6 +220,7 @@ class AppPreferences {
     this.detailHeaderCenteredTitle = false,
     this.extendedVolumeEnabled = false,
     this.replayGainMode = 'off',
+    this.lyricsTextAlign = 'center',
     this.replayGainPreampDb = 0.0,
     this.replayGainPreventClipping = true,
   });
@@ -331,6 +333,7 @@ class AppPreferences {
     bool? detailHeaderCenteredTitle,
     bool? extendedVolumeEnabled,
     String? replayGainMode,
+    String? lyricsTextAlign,
     double? replayGainPreampDb,
     bool? replayGainPreventClipping,
   }) {
@@ -490,6 +493,7 @@ class AppPreferences {
       extendedVolumeEnabled:
           extendedVolumeEnabled ?? this.extendedVolumeEnabled,
       replayGainMode: replayGainMode ?? this.replayGainMode,
+      lyricsTextAlign: lyricsTextAlign ?? this.lyricsTextAlign,
       replayGainPreampDb: replayGainPreampDb ?? this.replayGainPreampDb,
       replayGainPreventClipping:
           replayGainPreventClipping ?? this.replayGainPreventClipping,
@@ -612,6 +616,7 @@ class AppPreferencesService {
   static const _detailHeaderCenteredTitleKey = 'detail_header_centered_title';
   static const _extendedVolumeEnabledKey = 'audio_extended_volume_enabled';
   static const _replayGainModeKey = 'audio_replaygain_mode';
+  static const _lyricsTextAlignKey = 'lyrics_text_align';
   static const _replayGainPreampKey = 'audio_replaygain_preamp_db';
   static const _replayGainPreventClippingKey =
       'audio_replaygain_prevent_clipping';
@@ -777,6 +782,7 @@ class AppPreferencesService {
       extendedVolumeEnabled:
           prefs.getBool(_extendedVolumeEnabledKey) ?? false,
       replayGainMode: prefs.getString(_replayGainModeKey) ?? 'off',
+      lyricsTextAlign: prefs.getString(_lyricsTextAlignKey) ?? 'center',
       replayGainPreampDb: prefs.getDouble(_replayGainPreampKey) ?? 0.0,
       replayGainPreventClipping:
           prefs.getBool(_replayGainPreventClippingKey) ?? true,
@@ -951,6 +957,16 @@ class AppPreferencesService {
   Future<void> setReplayGainMode(String value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_replayGainModeKey, value);
+  }
+
+  Future<String> getLyricsTextAlign() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_lyricsTextAlignKey) ?? 'center';
+  }
+
+  Future<void> setLyricsTextAlign(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_lyricsTextAlignKey, value);
   }
 
   Future<double> getReplayGainPreampDb() async {

--- a/lib/services/lyrics_service.dart
+++ b/lib/services/lyrics_service.dart
@@ -8,12 +8,33 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:flick/models/song.dart';
 
+/// A single word (or whitespace-joined token) within a lyric line, with an
+/// optional timing window for karaoke-style highlighting.
+class LyricsWord {
+  final Duration start;
+  final Duration end;
+  final String text;
+
+  const LyricsWord({
+    required this.start,
+    required this.end,
+    required this.text,
+  });
+}
+
 /// A single lyric line, optionally timestamped for synchronized display.
+/// [words] carries per-word timings when the source was enhanced LRC;
+/// otherwise it is null and word timings are interpolated at render time.
 class LyricsLine {
   final Duration timestamp;
   final String text;
+  final List<LyricsWord>? words;
 
-  const LyricsLine({required this.timestamp, required this.text});
+  const LyricsLine({
+    required this.timestamp,
+    required this.text,
+    this.words,
+  });
 }
 
 /// Parsed lyrics payload.
@@ -49,6 +70,9 @@ class LyricsService {
   );
   static const String _manualLyricsOverridesKey = 'lyrics_manual_overrides_v1';
   static const String _managedLyricsDirectoryName = 'lyrics';
+  static final RegExp _wordTimestampPattern = RegExp(
+    r'<(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)>',
+  );
 
   final Map<String, LyricsData?> _cache = {};
 
@@ -248,6 +272,108 @@ class LyricsService {
     return result;
   }
 
+  /// Fill progress (0..1) of a word at [position]. Values below the window
+  /// are unsung, above fully sung.
+  static double fillForWord(LyricsWord word, Duration position) {
+    final startMs = word.start.inMilliseconds;
+    final endMs = word.end.inMilliseconds;
+    if (endMs <= startMs) return position >= word.end ? 1.0 : 0.0;
+    final ratio =
+        (position.inMilliseconds - startMs).toDouble() / (endMs - startMs);
+    return ratio.clamp(0.0, 1.0);
+  }
+
+  /// Per-word timing windows for the given line. Enhanced-LRC lines chain
+  /// their real timestamps. Plain synced lines carry no word data, so they
+  /// get a single whole-line window instead of guessed per-word timing —
+  /// the karaoke sweep then tracks real data only.
+  List<LyricsWord> resolveWords(LyricsData lyrics, int lineIndex) {
+    final line = lyrics.lines[lineIndex];
+    final lineEnd = _lineEndTime(lyrics, lineIndex);
+
+    final existing = line.words;
+    if (existing != null && existing.isNotEmpty) {
+      return [
+        for (var i = 0; i < existing.length; i++)
+          LyricsWord(
+            start: existing[i].start,
+            end: i + 1 < existing.length
+                ? existing[i + 1].start > existing[i].start
+                      ? existing[i + 1].start
+                      : existing[i].start
+                : _tailTrimmedEnd(existing[i].start, lineEnd),
+            text: existing[i].text,
+          ),
+      ];
+    }
+
+    if (line.text.trim().isEmpty) return const [];
+
+    var end = _tailTrimmedEnd(line.timestamp, lineEnd);
+    final maxWindow = const Duration(seconds: 6);
+    if (end - line.timestamp > maxWindow) {
+      end = line.timestamp + maxWindow;
+    }
+    return [LyricsWord(start: line.timestamp, end: end, text: line.text)];
+  }
+
+  Duration _lineEndTime(LyricsData lyrics, int index) {
+    final ts = lyrics.lines[index].timestamp;
+    if (index + 1 < lyrics.lines.length) {
+      final next = lyrics.lines[index + 1].timestamp;
+      if (next > ts) return next;
+    }
+    return ts + const Duration(seconds: 5);
+  }
+
+  /// Fraction of a line's lifetime the karaoke sweep spans. The remaining
+  /// tail rests fully filled, so the scroll to the next line never starts
+  /// while words are still filling.
+  static const double _sweepWindowFactor = 0.85;
+
+  Duration _tailTrimmedEnd(Duration start, Duration lineEnd) {
+    final remainingMs = (lineEnd - start).inMilliseconds;
+    if (remainingMs <= 0) return start + const Duration(seconds: 4);
+    return start +
+        Duration(milliseconds: (remainingMs * _sweepWindowFactor).round());
+  }
+
+  List<LyricsWord>? _extractWords(String body, int offsetMs) {
+    final times = <Duration>[];
+    final starts = <int>[];
+    final ends = <int>[];
+
+    for (final match in _wordTimestampPattern.allMatches(body)) {
+      final parsed = _parseTimestamp(match.group(1) ?? '');
+      if (parsed == null) continue;
+      final adjustedMs = parsed.inMilliseconds + offsetMs;
+      times.add(
+        Duration(milliseconds: adjustedMs < 0 ? 0 : adjustedMs),
+      );
+      starts.add(match.start);
+      ends.add(match.end);
+    }
+    if (times.isEmpty) return null;
+
+    final words = <LyricsWord>[];
+    for (var i = 0; i < times.length; i++) {
+      final segStart = i == 0 ? 0 : ends[i];
+      final segEnd = i + 1 < times.length ? starts[i + 1] : body.length;
+      final segment = body
+          .substring(segStart, segEnd)
+          .replaceAll(_wordTimestampPattern, '');
+      if (segment.isEmpty && i > 0) continue;
+      words.add(
+        LyricsWord(
+          start: times[i],
+          end: times[i],
+          text: segment,
+        ),
+      );
+    }
+    return words.isEmpty ? null : words;
+  }
+
   LyricsData parseLyricsText(String raw, {String? source}) {
     return _parseLyrics(raw, source: source);
   }
@@ -256,18 +382,19 @@ class LyricsService {
     return _parseTimestamp(timestamp);
   }
 
-  String formatTimestamp(Duration duration) {
+  String _formatClock(Duration duration) {
     final totalMinutes = duration.inMinutes;
     final seconds = duration.inSeconds.remainder(60);
     final centiseconds = (duration.inMilliseconds.remainder(1000) ~/ 10);
-    return '[${totalMinutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}.${centiseconds.toString().padLeft(2, '0')}]';
+    return '${totalMinutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}.${centiseconds.toString().padLeft(2, '0')}';
+  }
+
+  String formatTimestamp(Duration duration) {
+    return '[${_formatClock(duration)}]';
   }
 
   String formatLengthTag(Duration duration) {
-    final totalMinutes = duration.inMinutes;
-    final seconds = duration.inSeconds.remainder(60);
-    final centiseconds = (duration.inMilliseconds.remainder(1000) ~/ 10);
-    return '[length:${totalMinutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}.${centiseconds.toString().padLeft(2, '0')}]';
+    return '[length:${_formatClock(duration)}]';
   }
 
   String buildLrcContent({
@@ -293,7 +420,15 @@ class LyricsService {
     }
 
     for (final line in lines) {
-      buffer.writeln('${formatTimestamp(line.timestamp)}${line.text}');
+      final words = line.words;
+      if (words != null && words.isNotEmpty) {
+        final enhanced = words
+            .map((w) => '<${_formatClock(w.start)}>${w.text}')
+            .join();
+        buffer.writeln('${formatTimestamp(line.timestamp)}$enhanced');
+      } else {
+        buffer.writeln('${formatTimestamp(line.timestamp)}${line.text}');
+      }
     }
     return buffer.toString().trimRight();
   }
@@ -443,7 +578,6 @@ class LyricsService {
     final rows = normalized.split('\n');
 
     final timestampPattern = RegExp(r'\[(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)\]');
-    final wordTimestampPattern = RegExp(r'<(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)>');
     final offsetPattern = RegExp(
       r'^\s*\[offset:([+-]?\d+)\]\s*$',
       caseSensitive: false,
@@ -467,9 +601,10 @@ class LyricsService {
       final matches = timestampPattern.allMatches(line).toList();
       if (matches.isNotEmpty) {
         hasTimestamps = true;
-        final lyricText = line
-            .replaceAll(timestampPattern, '')
-            .replaceAll(wordTimestampPattern, '')
+        final body = line.replaceAll(timestampPattern, '');
+        final words = _extractWords(body, offsetMs);
+        final lyricText = body
+            .replaceAll(_wordTimestampPattern, '')
             .trim();
         for (final match in matches) {
           final parsedTime = _parseTimestamp(match.group(1) ?? '');
@@ -480,7 +615,9 @@ class LyricsService {
             milliseconds: adjustedMs < 0 ? 0 : adjustedMs,
           );
           if (lyricText.isEmpty) continue;
-          parsedLines.add(LyricsLine(timestamp: clamped, text: lyricText));
+          parsedLines.add(
+            LyricsLine(timestamp: clamped, text: lyricText, words: words),
+          );
         }
         continue;
       }

--- a/lib/services/sources/jellyfin_password_store.dart
+++ b/lib/services/sources/jellyfin_password_store.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Platform-keystore copy of a Jellyfin password, keyed by server id.
+///
+/// Jellyfin access tokens can die server-side (restart with a fresh
+/// encryption key, password change, revoked session). The password lives
+/// here — never in the Isar row — so a 401 during sync/stream silently
+/// re-authenticates instead of forcing a manual re-entry.
+class JellyfinPasswordStore {
+  JellyfinPasswordStore({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  static String _key(int serverId) => 'jellyfin_password_$serverId';
+
+  Future<String?> read(int serverId) => _storage.read(key: _key(serverId));
+
+  Future<void> write(int serverId, String password) =>
+      _storage.write(key: _key(serverId), value: password);
+
+  Future<void> delete(int serverId) => _storage.delete(key: _key(serverId));
+}

--- a/lib/services/sources/jellyfin_service.dart
+++ b/lib/services/sources/jellyfin_service.dart
@@ -6,11 +6,11 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import '../../core/utils/app_log.dart';
-import '../../data/entities/network_server_entity.dart';
-import '../../data/entities/song_entity.dart';
+import '../../data/database.dart';
 import '../../data/repositories/song_repository.dart';
 import '../library_scanner_service.dart' show ScanProgress;
 import '../network_cache_service.dart';
+import 'jellyfin_password_store.dart';
 import 'network_source_service.dart';
 
 /// Jellyfin / Emby REST client (JSON).
@@ -18,12 +18,22 @@ import 'network_source_service.dart';
 /// Auth: `POST /Users/AuthenticateByName` exchanges a plaintext password for
 /// an access token. The stored [NetworkServerEntity.token] is a JSON blob
 /// `{"userId":..., "token":...}` because every library call is scoped to the
-/// authenticated user id. The plaintext password is never persisted.
+/// authenticated user id. The plaintext password lives only in the platform
+/// keystore ([JellyfinPasswordStore]) so a dead token can be silently
+/// exchanged for a fresh one on the next 401.
 class JellyfinService implements NetworkSourceService {
-  JellyfinService._({http.Client? client, SongRepository? songRepository, NetworkCacheService? networkCache})
-      : _client = client ?? http.Client(),
+  JellyfinService._({
+    http.Client? client,
+    SongRepository? songRepository,
+    NetworkCacheService? networkCache,
+    JellyfinPasswordStore? passwordStore,
+    Future<void> Function(NetworkServerEntity server, String token)?
+        persistToken,
+  })  : _client = client ?? http.Client(),
         _songRepository = songRepository,
-        _networkCache = networkCache;
+        _networkCache = networkCache,
+        _passwordStore = passwordStore,
+        _persistToken = persistToken ?? _persistTokenToDatabase;
 
   static JellyfinService instance = JellyfinService._();
 
@@ -32,11 +42,16 @@ class JellyfinService implements NetworkSourceService {
     http.Client? client,
     SongRepository? songRepository,
     NetworkCacheService? networkCache,
+    JellyfinPasswordStore? passwordStore,
+    Future<void> Function(NetworkServerEntity server, String token)?
+        persistToken,
   }) =>
       JellyfinService._(
         client: client,
         songRepository: songRepository,
         networkCache: networkCache,
+        passwordStore: passwordStore,
+        persistToken: persistToken,
       );
 
   static const String _clientName = 'flick';
@@ -51,9 +66,14 @@ class JellyfinService implements NetworkSourceService {
   final http.Client _client;
   SongRepository? _songRepository;
   NetworkCacheService? _networkCache;
+  JellyfinPasswordStore? _passwordStore;
+  final Future<void> Function(NetworkServerEntity server, String token)
+      _persistToken;
 
   SongRepository get _repo => _songRepository ??= SongRepository();
   NetworkCacheService get _cache => _networkCache ??= NetworkCacheService();
+  JellyfinPasswordStore get _passwords =>
+      _passwordStore ??= JellyfinPasswordStore();
 
   @override
   String get protocol => NetworkProtocol.jellyfin;
@@ -82,6 +102,46 @@ class JellyfinService implements NetworkSourceService {
       if (uid == null || tok == null) return null;
       return _JellyfinCredentials(uid, tok);
     } catch (_) {
+      return null;
+    }
+  }
+
+  static Future<void> _persistTokenToDatabase(
+    NetworkServerEntity server,
+    String token,
+  ) async {
+    await Database.instance.writeTxn(() async {
+      final stored = await Database.networkServers.get(server.id);
+      if (stored != null) {
+        stored.token = token;
+        await Database.networkServers.put(stored);
+      }
+    });
+  }
+
+  /// Remember the password in the platform keystore for silent re-auth.
+  Future<void> persistPassword(NetworkServerEntity server, String password) =>
+      _passwords.write(server.id, password);
+
+  Future<void> forgetPassword(int serverId) => _passwords.delete(serverId);
+
+  /// Exchange the stored password for a fresh access token after a 401.
+  /// Persists the new token and updates [server] in place. Returns the new
+  /// access token, or null when no password is stored or the exchange fails.
+  Future<String?> _reauth(NetworkServerEntity server) async {
+    final password = await _passwords.read(server.id);
+    if (password == null || password.isEmpty) return null;
+    try {
+      final fresh = await resolveToken(server, password);
+      if (fresh == null) return null;
+      await _persistToken(server, fresh);
+      server.token = fresh;
+      final creds = _creds(fresh);
+      if (creds == null) return null;
+      AppLog.instance.add('Jellyfin re-authenticated ${server.label}');
+      return creds.token;
+    } catch (e) {
+      AppLog.instance.add('Jellyfin re-auth failed for ${server.label}: $e');
       return null;
     }
   }
@@ -150,18 +210,28 @@ class JellyfinService implements NetworkSourceService {
     String? accessToken,
     Duration timeout = const Duration(seconds: 20),
   }) async {
-    var uri = Uri.parse('${_base(server)}$path');
-    if (query != null) uri = uri.replace(queryParameters: query);
-    final response = await _client
-        .get(uri, headers: {
-          'Authorization': _authHeader(accessToken),
-          'Accept': 'application/json',
-        })
-        .timeout(timeout);
-    if (response.statusCode != 200) {
+    var token = accessToken;
+    for (var attempt = 0; ; attempt++) {
+      var uri = Uri.parse('${_base(server)}$path');
+      if (query != null) uri = uri.replace(queryParameters: query);
+      final response = await _client
+          .get(uri, headers: {
+            'Authorization': _authHeader(token),
+            'Accept': 'application/json',
+          })
+          .timeout(timeout);
+      if (response.statusCode == 200) {
+        return jsonDecode(response.body) as Map<String, dynamic>;
+      }
+      if (response.statusCode == 401 && attempt == 0) {
+        final fresh = await _reauth(server);
+        if (fresh != null) {
+          token = fresh;
+          continue;
+        }
+      }
       throw JellyfinNetworkException('HTTP ${response.statusCode} for $path');
     }
-    return jsonDecode(response.body) as Map<String, dynamic>;
   }
 
   Future<List<Map<String, dynamic>>> _allAudio(
@@ -190,17 +260,25 @@ class JellyfinService implements NetworkSourceService {
     String marker,
   ) async {
     final creds = _creds(server.token);
-    var uri = Uri.parse('${_base(server)}/Items/$marker/Images/Primary');
-    uri = uri.replace(queryParameters: {
-      if (creds != null) 'api_key': creds.token,
-    });
-    final response =
-        await _client.get(uri).timeout(const Duration(seconds: 30));
-    if (response.statusCode != 200) {
+    var token = creds?.token;
+    for (var attempt = 0; ; attempt++) {
+      var uri = Uri.parse('${_base(server)}/Items/$marker/Images/Primary');
+      uri = uri.replace(queryParameters: {
+        'api_key': ?token,
+      });
+      final response =
+          await _client.get(uri).timeout(const Duration(seconds: 30));
+      if (response.statusCode == 200) return response.bodyBytes;
+      if (response.statusCode == 401 && attempt == 0) {
+        final fresh = await _reauth(server);
+        if (fresh != null) {
+          token = fresh;
+          continue;
+        }
+      }
       throw JellyfinNetworkException(
           'HTTP ${response.statusCode} for cover $marker');
     }
-    return response.bodyBytes;
   }
 
   @override
@@ -218,14 +296,21 @@ class JellyfinService implements NetworkSourceService {
     if (creds == null) {
       throw StateError('Jellyfin server "${server.label}" has no stored token');
     }
-    final uri = Uri.parse('${_base(server)}/Audio/$songId/stream')
-        .replace(queryParameters: {
-      'static': 'true',
-      'api_key': creds.token,
-    });
-    final request = http.Request('GET', uri);
-    final response =
-        await _client.send(request).timeout(const Duration(minutes: 5));
+    var token = creds.token;
+    http.StreamedResponse response;
+    for (var attempt = 0; ; attempt++) {
+      final uri = Uri.parse('${_base(server)}/Audio/$songId/stream')
+          .replace(queryParameters: {
+        'static': 'true',
+        'api_key': token,
+      });
+      final request = http.Request('GET', uri);
+      response = await _client.send(request).timeout(const Duration(minutes: 5));
+      if (response.statusCode != 401 || attempt > 0) break;
+      final fresh = await _reauth(server);
+      if (fresh == null) break;
+      token = fresh;
+    }
     if (response.statusCode != 200) {
       throw JellyfinNetworkException(
           'HTTP ${response.statusCode} for stream $songId');

--- a/lib/widgets/common/song_tile_thumbnail.dart
+++ b/lib/widgets/common/song_tile_thumbnail.dart
@@ -1,0 +1,106 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flick/core/constants/app_constants.dart';
+import 'package:flick/core/theme/adaptive_color_provider.dart';
+import 'package:flick/core/theme/app_colors.dart';
+import 'package:flick/core/utils/responsive.dart';
+import 'package:flick/models/song.dart';
+import 'package:flick/models/song_tile_thumbnail_mode.dart';
+import 'package:flick/providers/app_preferences_provider.dart';
+import 'package:flick/widgets/common/cached_image_widget.dart';
+import 'package:flick/widgets/common/flick_artwork_placeholder.dart';
+
+/// Song row thumbnail for detail screens, driven by the
+/// songTileThumbnailMode preference: album art, track number, or track
+/// number over dimmed/blurred art.
+class SongTileThumbnail extends ConsumerWidget {
+  const SongTileThumbnail({super.key, required this.song, this.trackNumber});
+
+  final Song song;
+  final int? trackNumber;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = SongTileThumbnailModeX.fromStorageValue(
+      ref.watch(appPreferencesProvider).songTileThumbnailMode,
+    );
+
+    return Container(
+      width: context.scaleSize(AppConstants.containerSizeMd),
+      height: context.scaleSize(AppConstants.containerSizeMd),
+      decoration: BoxDecoration(
+        color: AppColors.glassBackground,
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppConstants.radiusSm),
+        child: _buildContent(context, mode),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, SongTileThumbnailMode mode) {
+    switch (mode) {
+      case SongTileThumbnailMode.artwork:
+        return _artwork;
+      case SongTileThumbnailMode.trackNumber:
+        if (trackNumber == null) {
+          return const Center(
+            child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+          );
+        }
+        return Center(
+          child: Text(
+            '$trackNumber',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: context.adaptiveTextPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        );
+      case SongTileThumbnailMode.trackNumberOnArt:
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ImageFiltered(
+              imageFilter: ImageFilter.blur(
+                sigmaX: 3.0,
+                sigmaY: 3.0,
+                tileMode: TileMode.clamp,
+              ),
+              child: _artwork,
+            ),
+            ColoredBox(color: Colors.black.withValues(alpha: 0.35)),
+            if (trackNumber != null)
+              Center(
+                child: Text(
+                  '$trackNumber',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              )
+            else
+              const Center(
+                child: FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+              ),
+          ],
+        );
+    }
+  }
+
+  Widget get _artwork => CachedImageWidget(
+    imagePath: song.albumArt,
+    audioSourcePath: song.filePath,
+    fit: BoxFit.cover,
+    placeholder: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+    errorWidget: const FlickArtworkPlaceholder(size: 28, opacity: 0.9),
+  );
+}

--- a/test/features/player/karaoke_word_split_test.dart
+++ b/test/features/player/karaoke_word_split_test.dart
@@ -1,0 +1,75 @@
+import 'package:flick/features/player/widgets/karaoke_lyric_line.dart';
+import 'package:flick/services/lyrics_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('splitKaraokeWord', () {
+    test('whole-line word splits into sequential token windows', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 10),
+        end: Duration(seconds: 14),
+        text: 'Hello wide world',
+      );
+      final segments = splitKaraokeWord(word);
+
+      expect(segments, hasLength(3));
+      expect(segments.first.text, 'Hello ');
+      expect(segments.last.text, 'world');
+      expect(segments.first.start, const Duration(seconds: 10));
+      expect(segments.last.end, const Duration(seconds: 14));
+      for (var i = 0; i + 1 < segments.length; i++) {
+        expect(segments[i].end, segments[i + 1].start);
+        expect(segments[i].start, lessThanOrEqualTo(segments[i + 1].start));
+      }
+    });
+
+    test('keeps leading whitespace attached to the first segment', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 0),
+        end: Duration(seconds: 2),
+        text: '  alpha beta',
+      );
+      final segments = splitKaraokeWord(word);
+
+      expect(segments, hasLength(2));
+      expect(segments.first.text, '  alpha ');
+    });
+
+    test('single-token word is returned unchanged', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 1),
+        end: Duration(seconds: 2),
+        text: 'hello ',
+      );
+
+      expect(splitKaraokeWord(word), const [word]);
+    });
+
+    test('zero-width window shares parent timing across segments', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 5),
+        end: Duration(seconds: 5),
+        text: 'a b c',
+      );
+      final segments = splitKaraokeWord(word);
+
+      expect(segments, hasLength(3));
+      for (final segment in segments) {
+        expect(segment.start, const Duration(seconds: 5));
+        expect(segment.end, const Duration(seconds: 5));
+      }
+    });
+
+    test('whitespace-only word stays a single segment', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 1),
+        end: Duration(seconds: 2),
+        text: ' ',
+      );
+      final segments = splitKaraokeWord(word);
+
+      expect(segments, hasLength(1));
+      expect(segments.single.text, ' ');
+    });
+  });
+}

--- a/test/features/player/lyrics_alignment_test.dart
+++ b/test/features/player/lyrics_alignment_test.dart
@@ -1,0 +1,24 @@
+import 'package:flick/features/player/widgets/lyrics_alignment.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('maps preference strings to edge-anchored alignments', () {
+    expect(resolveLyricsAlignment('left').textAlign, TextAlign.left);
+    expect(resolveLyricsAlignment('left').wrapAlignment, WrapAlignment.start);
+
+    expect(resolveLyricsAlignment('right').textAlign, TextAlign.right);
+    expect(resolveLyricsAlignment('right').wrapAlignment, WrapAlignment.end);
+
+    expect(resolveLyricsAlignment('center').textAlign, TextAlign.center);
+    expect(
+      resolveLyricsAlignment('center').wrapAlignment,
+      WrapAlignment.center,
+    );
+  });
+
+  test('unknown values fall back to center', () {
+    expect(resolveLyricsAlignment('nonsense').textAlign, TextAlign.center);
+    expect(resolveLyricsAlignment('').wrapAlignment, WrapAlignment.center);
+  });
+}

--- a/test/services/jellyfin_service_test.dart
+++ b/test/services/jellyfin_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flick/data/entities/network_server_entity.dart';
+import 'package:flick/services/sources/jellyfin_password_store.dart';
 import 'package:flick/services/sources/jellyfin_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -15,6 +16,25 @@ NetworkServerEntity _server({String? token}) {
     ..username = 'demo'
     ..token = token;
   return entity;
+}
+
+class _FakePasswordStore extends JellyfinPasswordStore {
+  _FakePasswordStore(this.passwords);
+
+  final Map<int, String> passwords;
+
+  @override
+  Future<String?> read(int serverId) async => passwords[serverId];
+
+  @override
+  Future<void> write(int serverId, String password) async {
+    passwords[serverId] = password;
+  }
+
+  @override
+  Future<void> delete(int serverId) async {
+    passwords.remove(serverId);
+  }
 }
 
 void main() {
@@ -78,6 +98,113 @@ void main() {
       final client = MockClient((request) async => http.Response('{}', 200));
       final service = JellyfinService.create(client: client);
       expect(await service.ping(_server(token: null)), isFalse);
+    });
+  });
+
+  group('re-auth on 401', () {
+    test('ping exchanges stored password for a fresh token and retries',
+        () async {
+      final calls = <String>[];
+      final persisted = <String>[];
+      final client = MockClient((request) async {
+        if (request.url.path == '/Users/AuthenticateByName') {
+          calls.add('auth:${request.body}');
+          return http.Response(
+            jsonEncode({
+              'User': {'Id': 'user-1'},
+              'AccessToken': 'tok-fresh',
+            }),
+            200,
+          );
+        }
+        final token = request.headers['Authorization'] ?? '';
+        if (token.contains('tok-dead')) {
+          calls.add('info:dead');
+          return http.Response('', 401);
+        }
+        calls.add('info:fresh');
+        return http.Response('{}', 200);
+      });
+      final server = _server(
+        token: jsonEncode({'userId': 'user-1', 'token': 'tok-dead'}),
+      );
+      final store = _FakePasswordStore({3: 'hunter2'});
+      final service = JellyfinService.create(
+        client: client,
+        passwordStore: store,
+        persistToken: (s, token) async => persisted.add(token),
+      );
+
+      final ok = await service.ping(server);
+
+      expect(ok, isTrue);
+      expect(calls, ['info:dead', 'auth:{"Username":"demo","Pw":"hunter2"}', 'info:fresh']);
+      expect(persisted, hasLength(1));
+      final decoded = jsonDecode(persisted.single) as Map<String, dynamic>;
+      expect(decoded['token'], 'tok-fresh');
+      // In-memory entity carries the fresh token so the sync keeps going.
+      expect(server.token, persisted.single);
+    });
+
+    test('ping stays false on 401 when no password is stored', () async {
+      var infoCalls = 0;
+      final client = MockClient((request) async {
+        if (request.url.path == '/Users/AuthenticateByName') {
+          fail('must not attempt re-auth without a stored password');
+        }
+        infoCalls++;
+        return http.Response('', 401);
+      });
+      final service = JellyfinService.create(
+        client: client,
+        passwordStore: _FakePasswordStore({}),
+      );
+
+      final ok = await service.ping(_server(
+        token: jsonEncode({'userId': 'user-1', 'token': 'tok-dead'}),
+      ));
+
+      expect(ok, isFalse);
+      expect(infoCalls, 1);
+    });
+
+    test('ping stays false when the password exchange is rejected', () async {
+      var infoCalls = 0;
+      var authCalls = 0;
+      final client = MockClient((request) async {
+        if (request.url.path == '/Users/AuthenticateByName') {
+          authCalls++;
+          return http.Response('', 401);
+        }
+        infoCalls++;
+        return http.Response('', 401);
+      });
+      final service = JellyfinService.create(
+        client: client,
+        passwordStore: _FakePasswordStore({3: 'wrong-pass'}),
+      );
+
+      final ok = await service.ping(_server(
+        token: jsonEncode({'userId': 'user-1', 'token': 'tok-dead'}),
+      ));
+
+      expect(ok, isFalse);
+      // One dead-token call, one rejected exchange, no retry after failure.
+      expect(infoCalls, 1);
+      expect(authCalls, 1);
+    });
+  });
+
+  group('password store', () {
+    test('persistPassword writes and forgetPassword deletes', () async {
+      final store = _FakePasswordStore({});
+      final service = JellyfinService.create(passwordStore: store);
+
+      await service.persistPassword(_server(), 'hunter2');
+      expect(store.passwords[3], 'hunter2');
+
+      await service.forgetPassword(3);
+      expect(store.passwords, isEmpty);
     });
   });
 }

--- a/test/services/lyrics_word_timing_test.dart
+++ b/test/services/lyrics_word_timing_test.dart
@@ -1,0 +1,153 @@
+import 'package:flick/services/app_preferences_service.dart';
+import 'package:flick/services/lyrics_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('enhanced LRC word parsing', () {
+    final service = LyricsService();
+
+    test('extracts word timings and keeps plain text intact', () {
+      final lyrics = service.parseLyricsText(
+        '[00:10.00]<00:10.00>Hello <00:10.50>wide <00:11.00>world\n',
+      );
+
+      expect(lyrics.isSynchronized, isTrue);
+      expect(lyrics.lines, hasLength(1));
+      final line = lyrics.lines.single;
+      expect(line.text, 'Hello wide world');
+      expect(line.words, isNotNull);
+      expect(line.words!, hasLength(3));
+      expect(line.words![0].start, const Duration(seconds: 10));
+      expect(line.words![1].start, const Duration(milliseconds: 10500));
+      expect(line.words![2].start, const Duration(seconds: 11));
+    });
+
+    test('plain synced LRC leaves words null', () {
+      final lyrics = service.parseLyricsText('[01:02.03]Just a line\n');
+
+      expect(lyrics.lines.single.words, isNull);
+      expect(lyrics.lines.single.text, 'Just a line');
+    });
+
+    test('applies offset tag to word timestamps', () {
+      final lyrics = service.parseLyricsText(
+        '[offset:1000]\n[00:10.00]<00:10.00>Alpha <00:12.00>Beta',
+      );
+
+      final words = lyrics.lines.single.words!;
+      expect(words.first.start, const Duration(seconds: 11));
+    });
+  });
+
+  group('resolveWords', () {
+    final service = LyricsService();
+
+    LyricsData synced(String raw) => service.parseLyricsText(raw);
+
+    test('chains real word ends to next word start', () {
+      final lyrics = synced(
+        '[00:10.00]<00:10.00>One <00:11.00>two <00:13.00>three',
+      );
+      final words = service.resolveWords(lyrics, 0);
+
+      expect(words[0].end, const Duration(seconds: 11));
+      expect(words[1].end, const Duration(seconds: 13));
+      // Last word rests trimmed: 13s + 85% of the remaining 2s tail.
+      expect(words[2].end, const Duration(milliseconds: 14700));
+    });
+
+    test('plain synced lines get one whole-line window', () {
+      final lyrics = synced('[00:10.00]Short big\n[00:14.00]Next');
+      final words = service.resolveWords(lyrics, 0);
+
+      expect(words, hasLength(1));
+      expect(words.single.start, const Duration(seconds: 10));
+      // 85% of the 4s window, so the sweep rests before the next line.
+      expect(words.single.end, const Duration(milliseconds: 13400));
+      expect(words.single.text, 'Short big');
+    });
+
+    test('sweep finishes before the next line starts', () {
+      final lyrics = synced('[00:10.00]A few words here\n[00:14.00]Next');
+      final words = service.resolveWords(lyrics, 0);
+
+      expect(words.last.end, lessThan(const Duration(seconds: 14)));
+    });
+
+    test('caps whole-line windows on long instrumental gaps', () {
+      final lyrics = synced('[00:10.00]Solo line\n[01:00.00]Later');
+      final words = service.resolveWords(lyrics, 0);
+
+      expect(words.single.end, const Duration(seconds: 16));
+    });
+
+    test('fillForWord clamps outside its window', () {
+      const word = LyricsWord(
+        start: Duration(seconds: 10),
+        end: Duration(seconds: 12),
+        text: 'hi',
+      );
+
+      expect(LyricsService.fillForWord(word, const Duration(seconds: 9)), 0.0);
+      expect(
+        LyricsService.fillForWord(word, const Duration(seconds: 11)),
+        closeTo(0.5, 0.001),
+      );
+      expect(
+        LyricsService.fillForWord(word, const Duration(minutes: 1)),
+        1.0,
+      );
+    });
+  });
+
+  group('buildLrcContent round-trip', () {
+    test('re-emits enhanced word tags for word-timed lines', () {
+      final service = LyricsService();
+      final content = service.buildLrcContent(
+        lines: [
+          const LyricsLine(
+            timestamp: Duration(seconds: 10),
+            text: 'Hello world',
+            words: [
+              LyricsWord(
+                start: Duration(seconds: 10),
+                end: Duration(seconds: 10, milliseconds: 500),
+                text: 'Hello ',
+              ),
+              LyricsWord(
+                start: Duration(seconds: 10, milliseconds: 500),
+                end: Duration(seconds: 11),
+                text: 'world',
+              ),
+            ],
+          ),
+        ],
+      );
+
+      expect(content, contains('<00:10.00>Hello <00:10.50>world'));
+
+      final reparsed = service.parseLyricsText(content);
+      expect(reparsed.lines.single.words, isNotNull);
+      expect(reparsed.lines.single.words!, hasLength(2));
+      expect(reparsed.lines.single.text, 'Hello world');
+    });
+  });
+
+  group('lyricsTextAlign preference', () {
+    test('defaults to center and persists changes', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      final service = AppPreferencesService();
+
+      expect(await service.getLyricsTextAlign(), 'center');
+
+      await service.setLyricsTextAlign('left');
+      expect(await service.getLyricsTextAlign(), 'left');
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('lyrics_text_align'), 'left');
+    });
+  });
+}


### PR DESCRIPTION
# Summary

- Add word-level karaoke lyrics with synchronized scrolling, gradient highlights, and frame-ticker extrapolation
- Add shared `SongTileThumbnail` widget with configurable thumbnail modes (cover, gradient, etc.)
- Add Jellyfin silent re-auth via platform keystore for 401 responses
- Update lyrics scrim to follow album color mode and add readability overlay

# Changes

## Karaoke Lyrics

- Add word-level karaoke timing to `LyricsService` (150 insertions)
- Add `SyncedLyricsView` widget (481 lines) with fixed anchor scroll, measured line heights, auto-follow suspension on drag
- Add `KaraokeLyricLine` widget (265 lines) with word-timed gradient highlights, frame-ticker extrapolation, wrapped-line token splitting
- Add lyrics alignment model and resolver
- Extract `SyncedLyricsView` from `InlineLyricsPanel` (-275 lines)
- Add lyrics readability scrim with animated black overlay during lyrics mode

## Lyrics Settings

- Add lyric text alignment preference and settings screen
- Update lyrics scrim to follow album color mode via `AnimatedContainer`

## Song Tile Thumbnail

- Add `SongTileThumbnail` widget (106 lines) with track index support
- Add `SongTileThumbnailMode` enum (cover, gradient, etc.)
- Add thumbnail mode preference, setter, and settings section
- Replace inline thumbnails in album, artist, playlist, and smart mix detail screens

## Jellyfin Secure Re-auth

- Add `JellyfinPasswordStore` using `FlutterSecureStorage` (keeps passwords out of Isar)
- Add silent re-auth on 401: exchange keystore password for fresh access token, retry requests
- Persist Jellyfin passwords on save and forget on deletion in edit screen

## Fixes & Tests

- Fix song card text truncation (`FittedBox` + `maxLines` instead of `MarqueeWidget`)
- Add lyrics word timing, alignment, and karaoke word split tests
- Add Jellyfin 401 re-auth and password tests

## Files Changed

- `lib/services/lyrics_service.dart`
- `lib/features/player/widgets/synced_lyrics_view.dart`, `karaoke_lyric_line.dart`, `inline_lyrics_panel.dart`, `lyrics_alignment.dart`, `animated_song_scene.dart`
- `lib/widgets/common/song_tile_thumbnail.dart`
- `lib/models/song_tile_thumbnail_mode.dart`
- `lib/services/sources/jellyfin_password_store.dart`, `jellyfin_service.dart`
- `lib/features/settings/screens/lyrics_settings_screen.dart`, `ui_customization_settings_screen.dart`, `network_server_edit_screen.dart`
- `lib/providers/app_preferences_provider.dart`, `lib/services/app_preferences_service.dart`
- `lib/features/songs/widgets/song_card.dart`
- `test/services/lyrics_word_timing_test.dart`, `lyrics_alignment_test.dart`, `karaoke_word_split_test.dart`, `jellyfin_service_test.dart`