### PR TITLE
 Harden Rust audio engine against crashes, detect lying container headers, and fix album artist grouping

### DIFF
--- a/lib/data/repositories/song_repository.dart
+++ b/lib/data/repositories/song_repository.dart
@@ -405,7 +405,7 @@ class SongRepository {
 
     for (final song in songs) {
       final albumName = _albumNameForSong(song);
-      final albumArtist = _albumArtistForSong(song);
+      final albumArtist = albumArtistForSong(song);
       final key = _albumGroupKey(albumName);
 
       groupedSongs.putIfAbsent(key, () => []).add(song);
@@ -572,9 +572,18 @@ class SongRepository {
     return albumName;
   }
 
-  String _albumArtistForSong(Song song) {
+  static bool _isVariousArtistsTag(String value) =>
+      value.toLowerCase() == 'various artists';
+
+  static String albumArtistForSong(Song song) {
     final albumArtist = song.albumArtist?.trim();
     if (albumArtist != null && albumArtist.isNotEmpty) {
+      // A literal "Various Artists" albumartist tag is a placeholder, not a
+      // name; prefer the per-track artist so real names surface.
+      if (_isVariousArtistsTag(albumArtist)) {
+        final artist = song.artist.trim();
+        if (artist.isNotEmpty && !_isVariousArtistsTag(artist)) return artist;
+      }
       return albumArtist;
     }
 
@@ -584,12 +593,19 @@ class SongRepository {
   }
 
   // ponytail: >1 distinct albumArtist ⇒ untagged compilation (scanner bakes
-  // per-track artist in when the tag's missing). Ceiling: a regular album
-  // with a few mistagged tracks mislabels as "Various Artists"; upgrade to
-  // grouping by MediaStore ALBUM_ID if that bites.
+  // per-track artist in when the tag's missing). Show the actual names
+  // comma-joined; only an explicit "Various Artists" tag collapses to itself.
+  // Ceiling: a regular album with a few mistagged tracks shows a noisy
+  // artist list; upgrade to grouping by MediaStore ALBUM_ID if that bites.
   static String resolveGroupArtist(Set<String> artists) {
-    final distinct = artists.where((a) => a.trim().isNotEmpty).toSet();
-    if (distinct.length > 1) return 'Various Artists';
+    final distinct = artists
+        .map((a) => a.trim())
+        .where((a) => a.isNotEmpty)
+        .toSet();
+    if (distinct.length > 1) {
+      if (distinct.contains('Various Artists')) return 'Various Artists';
+      return (distinct.toList()..sort()).join(', ');
+    }
     if (distinct.length == 1) return distinct.first;
     return 'Unknown Artist';
   }

--- a/lib/features/albums/screens/album_detail_screen.dart
+++ b/lib/features/albums/screens/album_detail_screen.dart
@@ -523,17 +523,20 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen>
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        widget.albumName,
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleSmall
-                            ?.copyWith(
-                              color: context.adaptiveTextPrimary,
-                              fontWeight: FontWeight.w600,
-                            ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          widget.albumName,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(
+                                color: context.adaptiveTextPrimary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                          maxLines: 1,
+                        ),
                       ),
                       Text(
                         '${widget.albumArtist} • ${widget.songs.length} songs',

--- a/lib/features/artists/screens/artist_detail_screen.dart
+++ b/lib/features/artists/screens/artist_detail_screen.dart
@@ -585,17 +585,20 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen>
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        widget.artistName,
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleSmall
-                            ?.copyWith(
-                              color: context.adaptiveTextPrimary,
-                              fontWeight: FontWeight.w600,
-                            ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          widget.artistName,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(
+                                color: context.adaptiveTextPrimary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                          maxLines: 1,
+                        ),
                       ),
                       Text(
                         '${_albumGroups.length} albums • ${widget.songs.length} songs',

--- a/lib/features/menu/screens/menu_screen.dart
+++ b/lib/features/menu/screens/menu_screen.dart
@@ -461,63 +461,67 @@ class _MenuScreenState extends ConsumerState<MenuScreen>
     await GlassBottomSheet.show<void>(
       context: context,
       title: 'Choose Audio Engine',
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'The audio engine determines how your music is played back. Each option balances reliability, quality, and compatibility differently.',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: context.adaptiveTextTertiary,
-              height: 1.45,
+      // Pop via the sheet's own context; the caller's context would pop the
+      // nested tab navigator and wipe every tab.
+      content: Builder(
+        builder: (sheetContext) => Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'The audio engine determines how your music is played back. Each option balances reliability, quality, and compatibility differently.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.adaptiveTextTertiary,
+                height: 1.45,
+              ),
             ),
-          ),
-          const SizedBox(height: AppConstants.spacingMd),
-          _buildEngineOption(
-            context,
-            title: 'Standard',
-            subtitle:
-                'Default Android player — plays everything reliably. The safest choice for most listeners.',
-            icon: LucideIcons.smartphone,
-            selected: current == AudioEnginePreference.exoPlayer,
-            onTap: () => _selectEngine(
+            const SizedBox(height: AppConstants.spacingMd),
+            _buildEngineOption(
               context,
-              service,
-              AudioEnginePreference.exoPlayer,
-              current,
+              title: 'Standard',
+              subtitle:
+                  'Default Android player — plays everything reliably. The safest choice for most listeners.',
+              icon: LucideIcons.smartphone,
+              selected: current == AudioEnginePreference.exoPlayer,
+              onTap: () => _selectEngine(
+                sheetContext,
+                service,
+                AudioEnginePreference.exoPlayer,
+                current,
+              ),
             ),
-          ),
-          const SizedBox(height: AppConstants.spacingSm),
-          _buildEngineOption(
-            context,
-            title: 'High Quality',
-            subtitle:
-                'Our Rust-powered engine. Cleaner sound and smoother playback — recommended for daily listening.',
-            icon: LucideIcons.audioLines,
-            selected: current == AudioEnginePreference.rustOboe,
-            onTap: () => _selectEngine(
+            const SizedBox(height: AppConstants.spacingSm),
+            _buildEngineOption(
               context,
-              service,
-              AudioEnginePreference.rustOboe,
-              current,
+              title: 'High Quality',
+              subtitle:
+                  'Our Rust-powered engine. Cleaner sound and smoother playback — recommended for daily listening.',
+              icon: LucideIcons.audioLines,
+              selected: current == AudioEnginePreference.rustOboe,
+              onTap: () => _selectEngine(
+                sheetContext,
+                service,
+                AudioEnginePreference.rustOboe,
+                current,
+              ),
             ),
-          ),
-          const SizedBox(height: AppConstants.spacingSm),
-          _buildEngineOption(
-            context,
-            title: 'Bit-perfect (USB DAC)',
-            subtitle:
-                'Studio-grade output for external DACs and headphone amps. Bypasses Android\'s audio processing for pure sound.',
-            icon: LucideIcons.usb,
-            selected: current == AudioEnginePreference.isochronousUsb,
-            onTap: () => _selectEngine(
+            const SizedBox(height: AppConstants.spacingSm),
+            _buildEngineOption(
               context,
-              service,
-              AudioEnginePreference.isochronousUsb,
-              current,
+              title: 'Bit-perfect (USB DAC)',
+              subtitle:
+                  "Studio-grade output for external DACs and headphone amps. Bypasses Android's audio processing for pure sound.",
+              icon: LucideIcons.usb,
+              selected: current == AudioEnginePreference.isochronousUsb,
+              onTap: () => _selectEngine(
+                sheetContext,
+                service,
+                AudioEnginePreference.isochronousUsb,
+                current,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/menu/screens/smart_mix_detail_screen.dart
+++ b/lib/features/menu/screens/smart_mix_detail_screen.dart
@@ -392,17 +392,20 @@ class _SmartMixDetailScreenState extends ConsumerState<SmartMixDetailScreen>
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        widget.title,
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleSmall
-                            ?.copyWith(
-                              color: context.adaptiveTextPrimary,
-                              fontWeight: FontWeight.w600,
-                            ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          widget.title,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(
+                                color: context.adaptiveTextPrimary,
+                                fontWeight: FontWeight.w600,
+                              ),
+                          maxLines: 1,
+                        ),
                       ),
                       Text(
                         '${widget.songs.length} songs${widget.songs.isNotEmpty ? ' • $_formattedTotalDuration' : ''}',

--- a/lib/features/playlists/screens/playlist_detail_screen.dart
+++ b/lib/features/playlists/screens/playlist_detail_screen.dart
@@ -637,14 +637,17 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen>
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        playlist.name,
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: context.adaptiveTextPrimary,
-                          fontWeight: FontWeight.w600,
+                      FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          playlist.name,
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: context.adaptiveTextPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          maxLines: 1,
                         ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
                       ),
                       Text(
                         '${_songs.length} songs${_songs.isNotEmpty ? ' • $_formattedTotalDuration' : ''}',

--- a/lib/features/settings/screens/duplicate_cleaner_screen.dart
+++ b/lib/features/settings/screens/duplicate_cleaner_screen.dart
@@ -572,7 +572,7 @@ class _SummaryCardState extends ConsumerState<_SummaryCard> {
                   setState(() => _collapsed = !_collapsed);
                 },
                 child: AnimatedRotation(
-                  turns: _collapsed ? -0.25 : 0,
+                  turns: _collapsed ? 0.0 : 0.5,
                   duration: AppConstants.animationNormal,
                   child: Container(
                     width: 28,

--- a/lib/features/settings/screens/duplicate_cleaner_screen.dart
+++ b/lib/features/settings/screens/duplicate_cleaner_screen.dart
@@ -480,14 +480,23 @@ class _Header extends StatelessWidget {
 // Summary card
 // ---------------------------------------------------------------------------
 
-class _SummaryCard extends ConsumerWidget {
+class _SummaryCard extends ConsumerStatefulWidget {
   const _SummaryCard({required this.scanState, required this.result});
 
   final DuplicateScanState scanState;
   final DuplicateScanResult result;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_SummaryCard> createState() => _SummaryCardState();
+}
+
+class _SummaryCardState extends ConsumerState<_SummaryCard> {
+  bool _collapsed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final scanState = widget.scanState;
+    final result = widget.result;
     final toRemove = scanState.selectedRemoveCount;
 
     return Container(
@@ -542,7 +551,9 @@ class _SummaryCard extends ConsumerWidget {
                     ),
                     const SizedBox(height: 3),
                     Text(
-                      'Only library entries are removed — your audio files stay on disk.',
+                      _collapsed
+                          ? '${result.totalGroups} groups • $toRemove to remove'
+                          : 'Only library entries are removed — your audio files stay on disk.',
                       style: TextStyle(
                         fontFamily: 'ProductSans',
                         fontSize: 12,
@@ -554,74 +565,119 @@ class _SummaryCard extends ConsumerWidget {
                   ],
                 ),
               ),
-            ],
-          ),
-          const SizedBox(height: AppConstants.spacingMd),
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppConstants.spacingMd,
-              vertical: AppConstants.spacingSm,
-            ),
-            decoration: BoxDecoration(
-              color: AppColors.backgroundLight.withValues(alpha: 0.9),
-              borderRadius: BorderRadius.circular(AppConstants.radiusMd),
-              border: Border.all(color: AppColors.glassBorderStrong),
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _SummaryStat(
-                  label: 'Groups',
-                  value: result.totalGroups.toString(),
-                  icon: LucideIcons.layers,
-                ),
-                Container(
-                  width: 1,
-                  height: 36,
-                  color: AppColors.glassBorder,
-                ),
-                _SummaryStat(
-                  label: 'To remove',
-                  value: toRemove.toString(),
-                  icon: LucideIcons.trash2,
-                  highlight: true,
-                ),
-                Container(
-                  width: 1,
-                  height: 36,
-                  color: AppColors.glassBorder,
-                ),
-                _SummaryStat(
-                  label: 'Will keep',
-                  value: scanState.selectedKeepCount.toString(),
-                  icon: LucideIcons.shieldCheck,
-                ),
-              ],
-            ),
-          ),
-          if (scanState.hasCustomSelection) ...[
-            const SizedBox(height: AppConstants.spacingSm),
-            Row(
-              children: [
-                const Icon(
-                  LucideIcons.info,
-                  size: 13,
-                  color: AppColors.textSecondary,
-                ),
-                const SizedBox(width: 6),
-                const Expanded(
-                  child: Text(
-                    'You customized which versions to keep. Nice — you’re in control.',
-                    style: TextStyle(
-                      fontFamily: 'ProductSans',
-                      fontSize: 11.5,
-                      color: AppColors.textSecondary,
+              const SizedBox(width: AppConstants.spacingSm),
+              GestureDetector(
+                onTap: () {
+                  AppHaptics.tap();
+                  setState(() => _collapsed = !_collapsed);
+                },
+                child: AnimatedRotation(
+                  turns: _collapsed ? -0.25 : 0,
+                  duration: AppConstants.animationNormal,
+                  child: Container(
+                    width: 28,
+                    height: 28,
+                    decoration: BoxDecoration(
+                      color: AppColors.glassBackgroundStrong,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: AppColors.glassBorder),
+                    ),
+                    child: Icon(
+                      LucideIcons.chevronDown,
+                      color: context.adaptiveTextSecondary,
+                      size: 16,
                     ),
                   ),
                 ),
-              ],
+              ),
+            ],
+          ),
+          AnimatedSize(
+            duration: AppConstants.animationNormal,
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: AnimatedOpacity(
+              duration: AppConstants.animationNormal,
+              opacity: _collapsed ? 0.0 : 1.0,
+              child: _collapsed
+                  ? const SizedBox.shrink()
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: AppConstants.spacingMd),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppConstants.spacingMd,
+                            vertical: AppConstants.spacingSm,
+                          ),
+                          decoration: BoxDecoration(
+                            color: AppColors.backgroundLight
+                                .withValues(alpha: 0.9),
+                            borderRadius:
+                                BorderRadius.circular(AppConstants.radiusMd),
+                            border: Border.all(
+                                color: AppColors.glassBorderStrong),
+                          ),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceAround,
+                            children: [
+                              _SummaryStat(
+                                label: 'Groups',
+                                value: result.totalGroups.toString(),
+                                icon: LucideIcons.layers,
+                              ),
+                              Container(
+                                width: 1,
+                                height: 36,
+                                color: AppColors.glassBorder,
+                              ),
+                              _SummaryStat(
+                                label: 'To remove',
+                                value: toRemove.toString(),
+                                icon: LucideIcons.trash2,
+                                highlight: true,
+                              ),
+                              Container(
+                                width: 1,
+                                height: 36,
+                                color: AppColors.glassBorder,
+                              ),
+                              _SummaryStat(
+                                label: 'Will keep',
+                                value: scanState.selectedKeepCount
+                                    .toString(),
+                                icon: LucideIcons.shieldCheck,
+                              ),
+                            ],
+                          ),
+                        ),
+                        if (scanState.hasCustomSelection) ...[
+                          const SizedBox(height: AppConstants.spacingSm),
+                          Row(
+                            children: [
+                              const Icon(
+                                LucideIcons.info,
+                                size: 13,
+                                color: AppColors.textSecondary,
+                              ),
+                              const SizedBox(width: 6),
+                              const Expanded(
+                                child: Text(
+                                  "You customized which versions to keep. Nice — you're in control.",
+                                  style: TextStyle(
+                                    fontFamily: 'ProductSans',
+                                    fontSize: 11.5,
+                                    color: AppColors.textSecondary,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    ),
             ),
-          ],
+          ),
         ],
       ),
     );

--- a/lib/providers/songs_provider.dart
+++ b/lib/providers/songs_provider.dart
@@ -298,11 +298,7 @@ class SongsState {
       final albumName = song.album?.trim().isNotEmpty == true
           ? song.album!.trim()
           : 'Unknown Album';
-      final albumArtist = song.albumArtist?.trim().isNotEmpty == true
-          ? song.albumArtist!.trim()
-          : (song.artist.trim().isNotEmpty
-                ? song.artist.trim()
-                : 'Unknown Artist');
+      final albumArtist = SongRepository.albumArtistForSong(song);
       final key = albumName;
 
       groupedSongs.putIfAbsent(key, () => []).add(song);

--- a/lib/services/player_service.dart
+++ b/lib/services/player_service.dart
@@ -338,6 +338,7 @@ class PlayerService {
   bool _priorityAnchorActive = false;
   bool _priorityAnchorEnabled = true;
   bool _midStreamUsbFallbackActive = false;
+  bool _deadRustEngineRecoveryActive = false;
   late final AudioSessionManager _sessionManager;
   late final AudioEngineManager _playbackManager;
   RustAudioEngine? _rustEngine;
@@ -2756,6 +2757,23 @@ class PlayerService {
         }());
         return;
       }
+      if (message.toLowerCase().contains('audio engine thread crashed')) {
+        final song = currentSongNotifier.value;
+        final position = _lastPlaybackState?.position ?? Duration.zero;
+        unawaited(() async {
+          final revived = await _handleDeadRustEngineFailure(
+            StateError(message),
+            song: song,
+            initialPosition: position,
+          );
+          if (!revived) {
+            await _refreshAudioOutputDiagnostics(
+              reason: 'Rust engine thread crash',
+            );
+          }
+        }());
+        return;
+      }
       unawaited(_refreshAudioOutputDiagnostics(reason: 'Rust backend error'));
     };
   }
@@ -4287,6 +4305,14 @@ class PlayerService {
       if (recovered) {
         return;
       }
+      final rustRecovered = await _handleDeadRustEngineFailure(
+        e,
+        song: song,
+        initialPosition: Duration.zero,
+      );
+      if (rustRecovered) {
+        return;
+      }
       _debugLog(
         '[Playback] play() failed for ${song.title} '
         'on ${currentEngineType.logLabel}: $e',
@@ -4662,6 +4688,79 @@ class PlayerService {
     }
 
     return true;
+  }
+
+  /// Recovery for a Rust engine whose command thread died mid-session
+  /// (FRB "disconnected channel" errors or a thread-crash event). The
+  /// service layer already retried once against a respawned engine; if we
+  /// land here the failure is persistent, so try one more explicit respawn
+  /// and, failing that, fall back to the plain Android engine.
+  Future<bool> _handleDeadRustEngineFailure(
+    Object error, {
+    required Song? song,
+    required Duration initialPosition,
+  }) async {
+    if (!Platform.isAndroid || !_usingRustBackend) {
+      return false;
+    }
+
+    final message = error.toString();
+    final normalized = message.toLowerCase();
+    if (!normalized.contains('disconnected channel') &&
+        !normalized.contains('audio engine thread crashed')) {
+      return false;
+    }
+    if (_deadRustEngineRecoveryActive) {
+      return false;
+    }
+
+    _deadRustEngineRecoveryActive = true;
+    try {
+      _debugLog(
+        '[Engine] Rust engine unreachable ($message); attempting respawn',
+      );
+      var revived = false;
+      try {
+        await _rustAudioService.prepareEngine();
+        revived = true;
+      } catch (e) {
+        _debugLog('[Engine] Rust engine respawn failed: $e');
+      }
+
+      if (!revived) {
+        await _rustAudioService.setHighResMode(false);
+        await _sessionManager.recordFallback(
+          requestedMode: currentEngineType,
+          fallbackMode: AudioEngineType.normalAndroid,
+          reason: 'rust audio engine unrecoverable: $message',
+        );
+        await _sessionManager.switchMode(
+          AudioEngineType.normalAndroid,
+          initializeNewEngine: true,
+          reason: 'rust audio engine command channel dead',
+        );
+      }
+
+      if (song != null) {
+        await _prepareImmediatePlaybackAsset(song);
+        await _runWithSuppressedSequenceStateUpdates(() async {
+          await _playbackManager.playTrack(
+            song,
+            initialPosition: initialPosition,
+          );
+        });
+        _ensurePositionSaveTimer();
+        await _refreshAudioOutputDiagnostics(
+          reason: revived
+              ? 'rust engine respawned'
+              : 'rust engine fallback to NORMAL_ANDROID',
+          activeSong: song,
+        );
+      }
+      return true;
+    } finally {
+      _deadRustEngineRecoveryActive = false;
+    }
   }
 
   Future<void> togglePlayPause() {

--- a/lib/services/rust_audio_service.dart
+++ b/lib/services/rust_audio_service.dart
@@ -212,6 +212,24 @@ class RustAudioService {
     }
   }
 
+  /// A failed command carrying "disconnected channel" means the Rust audio
+  /// thread died — it owns the command receiver, so its death breaks every
+  /// subsequent send. Re-preparing forces the manager to recreate the engine
+  /// (the Rust-side liveness gate refuses to reuse dead handles).
+  static bool _isDeadEngineError(Object error) =>
+      error.toString().toLowerCase().contains('disconnected channel');
+
+  Future<T> _reviveAndRetry<T>(Future<T> Function() call) async {
+    try {
+      return await call();
+    } catch (e) {
+      if (!_isDeadEngineError(e)) rethrow;
+      devLog('[RustAudio] Command channel dead; respawning engine and retrying');
+      await prepareEngine();
+      return await call();
+    }
+  }
+
   /// Get the current playback state.
   RustPlaybackState get state => stateNotifier.value;
 
@@ -239,7 +257,7 @@ class RustAudioService {
 
     _syncDsdOutputMode();
     _syncDsdTransportOverrides();
-    await rust_audio.audioPlay(path: path);
+    await _reviveAndRetry(() => rust_audio.audioPlay(path: path));
     _currentPath = path;
     // Also sync from Rust engine to ensure accuracy
     _currentPath = rust_audio.audioGetCurrentPath() ?? path;
@@ -258,7 +276,9 @@ class RustAudioService {
     }
     _syncDsdOutputMode();
     _syncDsdTransportOverrides();
-    await rust_audio.audioPlayFromHttp(url: url, headers: headers);
+    await _reviveAndRetry(
+      () => rust_audio.audioPlayFromHttp(url: url, headers: headers),
+    );
     _currentPath = rust_audio.audioGetCurrentPath() ?? url;
     _startProgressUpdates(fast: true);
   }
@@ -273,7 +293,7 @@ class RustAudioService {
     _nextPath = path;
     _syncDsdOutputMode();
     _syncDsdTransportOverrides();
-    await rust_audio.audioQueueNext(path: path);
+    await _reviveAndRetry(() => rust_audio.audioQueueNext(path: path));
   }
 
   /// Queue a remote HTTP stream as the next track for gapless playback.
@@ -287,7 +307,9 @@ class RustAudioService {
     _nextPath = url;
     _syncDsdOutputMode();
     _syncDsdTransportOverrides();
-    await rust_audio.audioQueueNextFromHttp(url: url, headers: headers);
+    await _reviveAndRetry(
+      () => rust_audio.audioQueueNextFromHttp(url: url, headers: headers),
+    );
   }
 
   void _syncDsdOutputMode() {
@@ -429,7 +451,9 @@ class RustAudioService {
     if (!_initialized) return;
     final clampedSpeed = speed.clamp(0.5, 2.0);
     playbackSpeedNotifier.value = clampedSpeed;
-    await rust_audio.audioSetPlaybackSpeed(speed: clampedSpeed);
+    await _reviveAndRetry(
+      () => rust_audio.audioSetPlaybackSpeed(speed: clampedSpeed),
+    );
   }
 
   /// Set pitch shift in semitones (tempo preserved). 0 = bypass.

--- a/rust/src/api/audio_api.rs
+++ b/rust/src/api/audio_api.rs
@@ -327,6 +327,10 @@ fn resolve_requested_output_sample_rate(
 fn resolve_track_playback_output_sample_rate(
     preferred_sample_rate: Option<u32>,
 ) -> Result<Option<u32>, String> {
+    // Lying container headers (1 Hz ALAC stsd) must not become output configs.
+    let preferred_sample_rate =
+        preferred_sample_rate.filter(|rate| crate::audio::decoder::plausible_sample_rate(*rate));
+
     #[cfg(target_os = "android")]
     {
         let route_type = ENGINE_MANAGER.capability_route_type();
@@ -339,10 +343,12 @@ fn resolve_track_playback_output_sample_rate(
             && matches!(route_type.as_str(), "unknown" | "internal" | "wired")
             && current_device_profile().is_some_and(|profile| profile.is_dap())
             && !usb_direct_active;
-        if should_preserve_existing_rate {
-            if let Some(existing_rate) = read_audio_engine(|handle| handle.sample_rate()) {
-                return Ok(Some(existing_rate));
-            }
+        if let Some(existing_rate) = should_preserve_existing_rate
+            .then(|| read_audio_engine(|handle| handle.sample_rate()))
+            .flatten()
+            .filter(|rate| crate::audio::decoder::plausible_sample_rate(*rate))
+        {
+            return Ok(Some(existing_rate));
         }
     }
 

--- a/rust/src/audio/decoder.rs
+++ b/rust/src/audio/decoder.rs
@@ -147,27 +147,75 @@ fn build_probe_result(
     probed: symphonia::core::probe::ProbeResult,
     name_path: PathBuf,
 ) -> Result<ProbeResult, DecoderError> {
-    let format = probed.format;
+    let mut format = probed.format;
 
     // Find the first audio track
-    let track = format
-        .tracks()
-        .iter()
-        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
-        .ok_or(DecoderError::NoAudioTrack)?;
+    let (track_id, codec_params) = {
+        let track = format
+            .tracks()
+            .iter()
+            .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+            .ok_or(DecoderError::NoAudioTrack)?;
+        (track.id, track.codec_params.clone())
+    };
 
-    let track_id = track.id;
-    let codec_params = &track.codec_params;
+    let declared_sample_rate = codec_params.sample_rate.unwrap_or(44100);
+    let declared_channels = codec_params.channels.map(|c| c.count()).unwrap_or(2);
 
-    let sample_rate = codec_params.sample_rate.unwrap_or(44100);
-    let channels = codec_params.channels.map(|c| c.count()).unwrap_or(2);
+    let decoder_opts = DecoderOptions::default();
+    let is_opus = codec_params.codec == CODEC_TYPE_OPUS;
+    let mut decoder: Box<dyn Decoder> = if is_opus {
+        Box::new(
+            opus_decoder::OpusDecoder::try_new(&codec_params, &decoder_opts)
+                .map_err(|e| DecoderError::UnsupportedFormat(e.to_string()))?,
+        )
+    } else {
+        symphonia::default::get_codecs()
+            .make(&codec_params, &decoder_opts)
+            .map_err(|e| DecoderError::UnsupportedFormat(e.to_string()))?
+    };
 
-    // Calculate duration
+    // Container headers can lie: M4A stsd entries for ALAC have been seen
+    // advertising a 1 Hz sample rate. A bogus rate here propagates straight
+    // into the audio engine output config, so trust one decoded packet when
+    // the header looks impossible, then rewind to frame zero.
+    let header_lies = implausible_layout(declared_sample_rate, declared_channels);
+    let (sample_rate, channels) = if header_lies {
+        match peek_decoded_layout(&mut format, decoder.as_mut(), track_id) {
+            Some((rate, ch)) => {
+                dev_eprintln!(
+                    "[DECODER] header sr={} ch={} implausible; using decoded sr={} ch={}",
+                    declared_sample_rate,
+                    declared_channels,
+                    rate,
+                    ch
+                );
+                (rate, ch)
+            }
+            None => {
+                dev_eprintln!(
+                    "[DECODER] header sr={} ch={} implausible and peek failed; trusting header",
+                    declared_sample_rate,
+                    declared_channels
+                );
+                (declared_sample_rate, declared_channels)
+            }
+        }
+    } else {
+        (declared_sample_rate, declared_channels)
+    };
+
+    // Calculate duration. A lying header also carries a lying time_base
+    // (derived from the fake rate), so only use it for plausible headers.
     let duration_secs = if let Some(n_frames) = codec_params.n_frames {
-        if let Some(time_base) = codec_params.time_base {
-            time_base.calc_time(n_frames).seconds as f64
-        } else {
+        if header_lies || codec_params.time_base.is_none() {
             n_frames as f64 / sample_rate as f64
+        } else {
+            codec_params
+                .time_base
+                .unwrap()
+                .calc_time(n_frames)
+                .seconds as f64
         }
     } else {
         0.0
@@ -177,8 +225,6 @@ fn build_probe_result(
     // it selects an output rate for the active stream.
     let total_samples = (duration_secs * sample_rate as f64 * channels as f64) as u64;
 
-    let decoder_opts = DecoderOptions::default();
-    let is_opus = codec_params.codec == CODEC_TYPE_OPUS;
     dev_eprintln!(
         "[DECODER] codec={} sr={} ch={} dur={:.1}s -> {}",
         codec_params.codec,
@@ -187,16 +233,6 @@ fn build_probe_result(
         duration_secs,
         if is_opus { "OpusDecoder (custom)" } else { "symphonia default" },
     );
-    let decoder: Box<dyn Decoder> = if is_opus {
-        Box::new(
-            opus_decoder::OpusDecoder::try_new(codec_params, &decoder_opts)
-                .map_err(|e| DecoderError::UnsupportedFormat(e.to_string()))?,
-        )
-    } else {
-        symphonia::default::get_codecs()
-            .make(&codec_params, &decoder_opts)
-            .map_err(|e| DecoderError::UnsupportedFormat(e.to_string()))?
-    };
 
     let source_info = SourceInfo {
         path: name_path,
@@ -214,6 +250,63 @@ fn build_probe_result(
         decoder,
         track_id,
     })
+}
+
+/// Rates outside this window cannot be real audio — they are lying container
+/// headers (e.g. 1 Hz ALAC stsd) and must never reach an output stream config.
+/// The ceiling clears DSD-over-PCM byte rates (DSD1024 ≈ 2.82 MHz) and 1536k
+/// USB links while still rejecting nonsense.
+pub(crate) const MIN_PLAUSIBLE_SAMPLE_RATE: u32 = 8_000;
+pub(crate) const MAX_PLAUSIBLE_SAMPLE_RATE: u32 = 3_528_000;
+
+/// True when the declared layout is impossible for real audio.
+fn implausible_layout(sample_rate: u32, channels: usize) -> bool {
+    !plausible_sample_rate(sample_rate) || !(1..=8).contains(&channels)
+}
+
+/// Guard against bogus track/header rates (lying container metadata) ever
+/// being used as an output stream rate.
+pub(crate) fn plausible_sample_rate(rate: u32) -> bool {
+    (MIN_PLAUSIBLE_SAMPLE_RATE..=MAX_PLAUSIBLE_SAMPLE_RATE).contains(&rate)
+}
+
+/// Decode one packet to read the true rate/channel count, then rewind the
+/// format reader to the start so playback still decodes from frame zero.
+/// Returns `None` (with a best-effort rewind) when the peek cannot be trusted.
+fn peek_decoded_layout(
+    format: &mut Box<dyn FormatReader>,
+    decoder: &mut dyn Decoder,
+    track_id: u32,
+) -> Option<(u32, usize)> {
+    let peeked = (|| -> Option<(u32, usize)> {
+        let packet = format.next_packet().ok()?;
+        if packet.track_id() != track_id {
+            return None;
+        }
+        let decoded = decoder.decode(&packet).ok()?;
+        let spec = decoded.spec();
+        if spec.rate == 0 || spec.channels.count() == 0 {
+            return None;
+        }
+        Some((spec.rate, spec.channels.count()))
+    })();
+
+    decoder.reset();
+    if format
+        .seek(
+            SeekMode::Accurate,
+            SeekTo::Time {
+                time: Time::new(0, 0.0),
+                track_id: Some(track_id),
+            },
+        )
+        .is_err()
+    {
+        dev_eprintln!("[DECODER] rewind after layout peek failed; first packet may be skipped");
+    }
+    decoder.reset();
+
+    peeked
 }
 
 /// Lowercased, ogg-normalized extension hint derived from an HTTP URL's path
@@ -759,5 +852,31 @@ impl SeekContext {
         self.decoder.reset();
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{implausible_layout, plausible_sample_rate};
+
+    #[test]
+    fn bogus_container_rates_are_rejected() {
+        // The Galaxy A52s ALAC-in-M4A case: stsd cookie declares 1 Hz.
+        assert!(implausible_layout(1, 2));
+        assert!(implausible_layout(0, 2));
+        assert!(implausible_layout(7_999, 2));
+        assert!(implausible_layout(3_528_001, 2));
+        assert!(implausible_layout(44_100, 0));
+        assert!(implausible_layout(44_100, 9));
+    }
+
+    #[test]
+    fn real_layouts_pass_through() {
+        for rate in [8_000u32, 44_100, 48_000, 96_000, 192_000, 768_000] {
+            assert!(!implausible_layout(rate, 2), "rate {rate}");
+            assert!(plausible_sample_rate(rate));
+        }
+        // DSD-over-PCM byte rates stay plausible.
+        assert!(plausible_sample_rate(2_822_400));
     }
 }

--- a/rust/src/audio/engine.rs
+++ b/rust/src/audio/engine.rs
@@ -221,8 +221,9 @@ impl AudioCallbackData {
     ) -> Self {
         // Pre-allocate mix buffers for 1 second of audio — large enough
         // for any platform's output callback (cpal can deliver up to 8k
-        // frames; Oboe typically ~1k).
-        let buffer_size = sample_rate as usize * channels;
+        // frames; Oboe typically ~1k). The floor keeps a bogus sample rate
+        // from collapsing the scratch buffers to callback-hostile sizes.
+        let buffer_size = (sample_rate as usize * channels).max(8192 * channels.max(1));
         // Speed buffer needs to be larger to handle 2x speed (need 2x input for 1x output)
         let speed_buffer_size = buffer_size * 3;
 
@@ -397,7 +398,10 @@ impl AudioCallbackData {
     }
 
     pub fn reconfigure_sample_rate(&self, sample_rate: u32) {
-        let buffer_size = (sample_rate as usize / 10) * self.channels;
+        // Floor keeps a bogus rate from collapsing the scratch buffers below
+        // a usable callback size (see the buffer guard in the callback).
+        let buffer_size =
+            ((sample_rate as usize / 10) * self.channels).max(8192 * self.channels.max(1));
         let speed_buffer_size = buffer_size * 3;
 
         self.crossfader.lock().rebind_sample_rate(sample_rate);
@@ -416,6 +420,27 @@ impl AudioCallbackData {
         shifter.set_semitones(semitones);
         *self.pitch_shifter.lock() = shifter;
     }
+}
+
+/// Surface an audio-thread panic as an Error event so release builds can
+/// still see why commands started failing (a dead thread otherwise only
+/// shows up as "sending on a disconnected channel").
+fn report_thread_panic(
+    event_tx: &Sender<AudioEvent>,
+    result: Result<(), Box<dyn std::any::Any + Send>>,
+) {
+    let Err(panic) = result else { return };
+    let detail = if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else {
+        "unknown panic payload".to_string()
+    };
+    dev_eprintln!("[ENGINE] audio command thread panicked: {}", detail);
+    let _ = event_tx.try_send(AudioEvent::Error {
+        message: format!("Audio engine thread crashed: {}", detail),
+    });
 }
 
 /// Handle for controlling the audio engine from any thread.
@@ -461,6 +486,17 @@ impl AudioEngineHandle {
         self.command_tx
             .try_send(command)
             .map_err(|e| format!("Failed to send command: {}", e))
+    }
+
+    /// True while the audio command thread (owner of the command channel) is
+    /// still running. If it panicked or exited, every send_command fails with
+    /// "sending on a disconnected channel" forever, so the engine must be
+    /// recreated.
+    pub fn is_alive(&self) -> bool {
+        self._audio_thread
+            .lock()
+            .as_ref()
+            .is_some_and(|handle| !handle.is_finished())
     }
 
     /// Play a track.
@@ -858,44 +894,56 @@ pub fn create_audio_engine(
     let audio_thread = thread::Builder::new()
         .name("audio-engine".to_string())
         .spawn(move || {
-            // Build the stream in this thread
-            let stream = match device.build_output_stream(
-                &config,
-                move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                    audio_callback(data, &callback_data_clone, &event_tx_clone);
-                },
-                |err| {
-                    dev_eprintln!("Audio stream error: {}", err);
-                },
-                None,
-            ) {
-                Ok(s) => s,
-                Err(e) => {
-                    dev_eprintln!("Failed to build audio stream: {}", e);
+            let event_tx_panic = event_tx.clone();
+            let event_tx_build_err = event_tx.clone();
+            let thread_body = move || {
+                // Build the stream in this thread
+                let stream = match device.build_output_stream(
+                    &config,
+                    move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                        audio_callback(data, &callback_data_clone, &event_tx_clone);
+                    },
+                    |err| {
+                        dev_eprintln!("Audio stream error: {}", err);
+                    },
+                    None,
+                ) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        dev_eprintln!("Failed to build audio stream: {}", e);
+                        let _ = event_tx_build_err.try_send(AudioEvent::Error {
+                            message: format!("Failed to build audio stream: {}", e),
+                        });
+                        return;
+                    }
+                };
+
+                // Start the stream
+                if let Err(e) = stream.play() {
+                    dev_eprintln!("Failed to start audio stream: {}", e);
                     return;
                 }
+
+                // Run command processing loop
+                command_processing_loop(
+                    command_rx,
+                    finished_rx,
+                    event_tx,
+                    callback_data_for_thread,
+                    state_clone,
+                    decoders_clone,
+                    target_sample_rate,
+                    shutdown_clone,
+                    None,
+                );
+
+                // Stream will be dropped here when the loop exits
             };
 
-            // Start the stream
-            if let Err(e) = stream.play() {
-                dev_eprintln!("Failed to start audio stream: {}", e);
-                return;
-            }
-
-            // Run command processing loop
-            command_processing_loop(
-                command_rx,
-                finished_rx,
-                event_tx,
-                callback_data_for_thread,
-                state_clone,
-                decoders_clone,
-                target_sample_rate,
-                shutdown_clone,
-                None,
+            report_thread_panic(
+                &event_tx_panic,
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(thread_body)),
             );
-
-            // Stream will be dropped here when the loop exits
         });
 
     let audio_thread = audio_thread.map_err(|e| format!("Failed to spawn audio thread: {}", e))?;
@@ -1288,6 +1336,12 @@ pub fn create_audio_engine(
     let will_attempt_usb = debug_state.registered;
     #[cfg(not(feature = "uac2"))]
     let will_attempt_usb = false;
+
+    // Bogus track rates (lying M4A headers advertise 1 Hz) must never reach
+    // an output stream config: the callback buffers collapse and the audio
+    // thread dies. Treat them as "no preference" and use the platform default.
+    let preferred_sample_rate =
+        preferred_sample_rate.filter(|rate| crate::audio::decoder::plausible_sample_rate(*rate));
 
     // When a DAP device has bit-perfect disabled, force the output to
     // 48 kHz so that all DSP runs at a fixed rate and the in-app rubato
@@ -2010,6 +2064,10 @@ pub fn create_audio_engine(
     let audio_thread = thread::Builder::new()
         .name("audio-engine".to_string())
         .spawn(move || {
+            let event_tx_panic = event_tx.clone();
+            // Body stays at original indentation; wrapping it just to re-indent
+            // 130 lines would churn the diff.
+            let thread_body = std::panic::AssertUnwindSafe(move || {
             #[cfg(feature = "uac2")]
             let mut direct_usb_backend = direct_usb_backend;
             let mut dsd_native_backend = dsd_native_backend;
@@ -2144,6 +2202,11 @@ pub fn create_audio_engine(
             );
 
             supervisor.stop();
+            });
+            report_thread_panic(
+                &event_tx_panic,
+                std::panic::catch_unwind(thread_body),
+            );
         });
 
     let audio_thread = audio_thread.map_err(|e| format!("Failed to spawn audio thread: {}", e))?;

--- a/rust/src/audio/manager.rs
+++ b/rust/src/audio/manager.rs
@@ -295,6 +295,16 @@ impl EngineManager {
         {
             let mut state = self.state.lock();
             let should_reuse = state.rust_handle.as_ref().is_some_and(|handle| {
+                // A dead command thread drops the channel receiver, so every
+                // later command fails with "disconnected channel" and the
+                // engine can never recover. Never reuse a dead handle.
+                if !handle.is_alive() {
+                    crate::dev_eprintln!(
+                        "[MANAGER] rust engine command thread is dead; forcing recreation"
+                    );
+                    return false;
+                }
+
                 if handle.output_signature() == desired_signature {
                     return true;
                 }

--- a/test/data/repositories/song_repository_test.dart
+++ b/test/data/repositories/song_repository_test.dart
@@ -1,17 +1,56 @@
 import 'package:flick/data/repositories/song_repository.dart';
+import 'package:flick/models/song.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+Song _song({required String artist, String? albumArtist}) => Song(
+  id: artist,
+  title: 'T',
+  artist: artist,
+  albumArtist: albumArtist,
+  duration: Duration(seconds: 1),
+  fileType: 'FLAC',
+);
+
 void main() {
+  group('SongRepository.albumArtistForSong', () {
+    test('literal Various Artists tag falls back to per-track artist', () {
+      expect(
+        SongRepository.albumArtistForSong(
+          _song(artist: 'Kendrick Lamar', albumArtist: 'Various Artists'),
+        ),
+        'Kendrick Lamar',
+      );
+    });
+
+    test('Various Artists track artist keeps the tag', () {
+      expect(
+        SongRepository.albumArtistForSong(
+          _song(artist: 'Various Artists', albumArtist: 'various artists'),
+        ),
+        'various artists',
+      );
+    });
+
+    test('real albumArtist tag is untouched', () {
+      expect(
+        SongRepository.albumArtistForSong(
+          _song(artist: 'Kendrick Lamar', albumArtist: 'ScHoolboy Q'),
+        ),
+        'ScHoolboy Q',
+      );
+    });
+  });
+
   group('SongRepository.resolveGroupArtist', () {
     test('single artist stays as-is', () {
       expect(SongRepository.resolveGroupArtist({'Pink Floyd'}), 'Pink Floyd');
     });
 
-    test('distinct albumArtists resolve to Various Artists (untagged comp)',
+    test('distinct albumArtists resolve to comma-joined names (untagged comp)',
         () {
       expect(
         SongRepository.resolveGroupArtist({'A Tribe Called Quest', 'De La Soul'}),
-        'Various Artists',
+        'A Tribe Called Quest, De La Soul',
       );
     });
 


### PR DESCRIPTION
# Summary

- Add Rust audio engine crash recovery: panic reporting, dead channel revival, and fallback to Android engine
- Detect and correct lying audio container headers (implausible sample rates/channels) via decoded packet peek
- Fix album artist grouping for "Various Artists" tags and artists with multiple names
- Fix UI issues: detail screen title truncation, engine picker bottom sheet context, summary card rotation

# Changes

## Rust Engine Resilience

- Add `_handleDeadRustEngineFailure` to `PlayerService` — respawns engine or falls back to Android engine on thread crashes and disconnected channel errors
- Add Revive Rust audio engine on dead channel with `is_alive()` checks
- Prevent reuse of dead audio engine handle (never reuse dead handle after receiver drop)
- Add panic reporting: surface audio command thread panics as Error events
- Add buffer floor guards against bogus sample rates collapsing callback sizes
- Filter implausible preferred rates before stream configuration

## Container Header Validation

- Add plausibility checks for declared sample rate and channels in decoder
- Peek one decoded packet to recover true layout when headers lie, then rewind format reader
- Adjust duration calculation after correction
- Filter implausible sample rates (e.g. 1 Hz ALAC headers) from playback output via `plausible_sample_rate`

## Album Artist Grouping

- Handle literal "Various Artists" albumartist tags by preferring per-track artist names
- Show comma-joined distinct artists instead of collapsing to "Various Artists"
- Use `SongRepository` for album artist lookup in songs provider
- Add album artist tests covering Various Artists fallback and real tags

## UI Fixes

- Use fitted box for album, artist, smart mix, and playlist detail screen titles
- Fix engine picker bottom sheet context (capture via `Builder` to prevent tab navigator wipe)
- Fix summary card rotation logic in duplicate cleaner

## Files Changed

- `rust/src/audio/engine.rs`, `manager.rs`, `decoder.rs`
- `rust/src/api/audio_api.rs`
- `lib/services/player_service.dart`, `rust_audio_service.dart`
- `lib/data/repositories/song_repository.dart`
- `lib/providers/songs_provider.dart`
- `lib/features/menu/screens/menu_screen.dart`
- `lib/features/{albums,artists,playlists,smart_mix}/screens/*detail_screen.dart`
- `lib/features/settings/screens/duplicate_cleaner_screen.dart`
- `test/data/repositories/song_repository_test.dart`